### PR TITLE
[DSI-1] Rename the output assets from the build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ tests/backstop/html_report/*
 dist/
 
 ## Duplicated the above for .npmignore
-dist/nhsuk.css
-dist/nhsuk.js
-dist/nhsuk-*.min.css
-dist/nhsuk-*.min.js
+dist/ofh-design-system-toolkit.css
+dist/ofh-design-system-toolkit.js
+dist/ofh-design-system-toolkit-*.min.css
+dist/ofh-design-system-toolkit-*.min.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Whilst in the alpha phase, we don't yet adhere to [Semantic Versioning](https://
 
 ## [Unreleased]
 
+### Changed
+
+- Output asset files renamed to `ofh-design-system-toolkit.*`.
+
 ## [v2.0.0-alpha.0] - 2022-07-20
 
 Initial alpha (but not released as an NPM package, yet).

--- a/app/_templates/layout.njk
+++ b/app/_templates/layout.njk
@@ -11,9 +11,9 @@
 
     <title>{{ title }} - OFH design system toolkit</title>
 
-    <link href="{{ baseUrl }}assets/nhsuk.css" rel="stylesheet">
+    <link href="{{ baseUrl }}assets/ofh-design-system-toolkit.css" rel="stylesheet">
 
-    <script src="{{ baseUrl }}assets/nhsuk.js" defer></script>
+    <script src="{{ baseUrl }}assets/ofh-design-system-toolkit.js" defer></script>
 
     <link rel="shortcut icon" href="{{ baseUrl }}assets/favicons/favicon.ico" type="image/x-icon">
     <link rel="apple-touch-icon" href="{{ baseUrl }}assets/favicons/apple-touch-icon-180x180.png">

--- a/docs/installation/installing-compiled.md
+++ b/docs/installation/installing-compiled.md
@@ -26,10 +26,10 @@ If you require any of this functionality, you should [install using npm](/docs/i
 
     ```html
     <!-- Styles -->
-    <link rel="stylesheet" href="css/nhsuk-[latest version].min.css">
+    <link rel="stylesheet" href="css/ofh-design-system-toolkit-[latest version].min.css">
 
     <!-- Scripts -->
-    <script src="js/nhsuk-[latest version].min.js" defer></script>
+    <script src="js/ofh-design-system-toolkit-[latest version].min.js" defer></script>
 
     <!-- Favicons -->
     <link rel="shortcut icon" href="assets/favicons/favicon.ico" type="image/x-icon">

--- a/docs/installation/installing-with-npm.md
+++ b/docs/installation/installing-with-npm.md
@@ -73,12 +73,12 @@ Include the `node_modules/ofh-design-system-toolkit/dist/nhsuk.min.js` script in
 You might wish to copy the file into your project or reference it straight from node_modules.
 
 ```html
-    <script src="path-to-assets/nhsuk.min.js" defer></script>
+    <script src="path-to-assets/ofh-design-system-toolkit.min.js" defer></script>
   </head>
 ```
 
 ```html
-    <script src="node_modules/ofh-design-system-toolkit/dist/nhsuk.min.js" defer></script>
+    <script src="node_modules/ofh-design-system-toolkit/dist/ofh-design-system-toolkit.min.js" defer></script>
   </head>
 ```
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,6 +30,7 @@ sass.compiler = require('sass');
 function compileCSS() {
   return gulp.src(['packages/nhsuk.scss'])
     .pipe(sass())
+    .pipe(rename('ofh-design-system-toolkit.css'))
     .pipe(gulp.dest('dist/'))
     .on('error', (err) => {
       console.log(err);
@@ -54,7 +55,7 @@ function minifyCSS() {
  * JavaScript tasks
  */
 
-/* Use Webpack to build and minify the NHS.UK components JS. */
+/* Use Webpack to build and minify the OFH components JS. */
 function webpackJS() {
   return gulp.src('./packages/nhsuk.js')
     .pipe(webpack({
@@ -72,7 +73,7 @@ function webpackJS() {
         ],
       },
       output: {
-        filename: 'nhsuk.js',
+        filename: 'ofh-design-system-toolkit.js',
       },
       target: 'web',
     }))
@@ -123,7 +124,7 @@ function assets() {
 
 /* Copy JS files into their relevant folders */
 function jsFolder() {
-  return gulp.src('dist/*.min.js', '!dist/js/nhsuk.min.js')
+  return gulp.src('dist/*.min.js', '!dist/js/ofh-design-system-toolkit.min.js')
     .pipe(clean())
     .pipe(gulp.dest('dist/js/'));
 }
@@ -137,7 +138,7 @@ function cssFolder() {
 }
 
 function createZip() {
-  return gulp.src(['dist/css/*.min.css', 'dist/js/*.min.js', 'dist/assets/**', '!dist/js/nhsuk.min.js'], { base: 'dist' })
+  return gulp.src(['dist/css/*.min.css', 'dist/js/*.min.js', 'dist/assets/**', '!dist/js/ofh-design-system-toolkit.min.js'], { base: 'dist' })
     .pipe(zip(`ofh-design-system-toolkit-${version}.zip`))
     .pipe(gulp.dest('dist'));
 }


### PR DESCRIPTION
Previously, these were output as `nhsuk.*`. Now these will be `ofh-design-system-toolkit.*`.

Note: no _source_ files have been renamed; this can be done as part of a bigger rename later (if needed).

