### PR TITLE
[DSE-28] Align form component styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Whilst in the alpha phase, we don't yet adhere to [Semantic Versioning](https://
 
 ## [Unreleased]
 
+### Changed
+
+- Updated **label** bottom margin (on all variants) to use non-responsive units and match the **legend** component more closely.
+- Added a negative top margin to **hint** components when placed after a **label** `l` or `xl` variant.
+
 ## [v2.0.0-alpha.2] - 2022-08-10
 
 ### Fixed

--- a/packages/components/hint/_hint.scss
+++ b/packages/components/hint/_hint.scss
@@ -25,6 +25,13 @@
   margin-bottom: ofh-spacing(2);
 }
 
+// Reduces visual spacing of label when there is a hint
+
+.ofh-label--l + .ofh-hint,
+.ofh-label--xl + .ofh-hint {
+  margin-top: -(ofh-spacing(1));
+}
+
 // Reduces margin-bottom of hint when used after the default legend (no class)
 // or ofh-fieldset__legend--s for better vertical alignment.
 

--- a/packages/components/label/_label.scss
+++ b/packages/components/label/_label.scss
@@ -16,9 +16,8 @@
 
   display: block;
   font-weight: $ofh-font-bold;
+  margin-bottom: ofh-spacing(3);
   margin-top: 0;
-
-  @include ofh-responsive-margin(7, 'bottom');
 }
 
 .ofh-label--l {
@@ -26,9 +25,8 @@
 
   display: block;
   font-weight: $ofh-font-bold;
+  margin-bottom: ofh-spacing(3);
   margin-top: 0;
-
-  @include ofh-responsive-margin(4, 'bottom');
 }
 
 .ofh-label--m {
@@ -36,9 +34,8 @@
 
   display: block;
   font-weight: $ofh-font-bold;
+  margin-bottom: ofh-spacing(2);
   margin-top: 0;
-
-  @include ofh-responsive-margin(4, 'bottom');
 }
 
 .ofh-label--s {
@@ -46,9 +43,8 @@
 
   display: block;
   font-weight: $ofh-font-bold;
+  margin-bottom: ofh-spacing(1);
   margin-top: 0;
-
-  @include ofh-responsive-margin(4, 'bottom');
 }
 
 // When the label is nested inside a heading, override the heading so that it


### PR DESCRIPTION
https://ourfuturehealth.atlassian.net/browse/DSE-28

- Update label margin bottom (on all variants) to use non-responsive units and match legends more closely.
- Add a negative top margin to hints when placed after a label l or xl variant.

