### PR TITLE
[DS-52] Initial "Get started" page on docs site

### DIFF
--- a/site/views/_includes/_header.njk
+++ b/site/views/_includes/_header.njk
@@ -15,6 +15,10 @@
   "showSearch": "false",
   "primaryLinks": [
     {
+      'url': '/get-started',
+      'label': 'Get started'
+    },
+    {
       'url' : '/design-system/styles',
       'label' : 'Foundation styles'
     },

--- a/site/views/get-started/_breadcrumb.njk
+++ b/site/views/get-started/_breadcrumb.njk
@@ -1,0 +1,12 @@
+{%- from 'components/breadcrumb/macro.njk' import breadcrumb %}
+{{ breadcrumb({
+  items: [
+    {
+      href: "/",
+      text: "Home"
+    }
+  ],
+  href: "/get-started",
+  text: "Get started",
+  classes: "app-breadcrumb"
+}) }}

--- a/site/views/get-started/index.njk
+++ b/site/views/get-started/index.njk
@@ -1,0 +1,72 @@
+{% set pageTitle = "Get started" %}
+{% set pageDescription = "The code you need to start building user interfaces for Our Future Health websites and services." %}
+{% set dateUpdated = "January 2023" %}
+
+{% extends "app-layout.njk" %}
+
+{% block breadcrumb %}
+  {% include "./_breadcrumb.njk" %}
+{% endblock %}
+
+{% block bodyContent %}
+
+  <h2 id="include-ofh-design-system-toolkit-in-your-project">Include the Our Future Health design system toolkit in your project</h2>
+  <p>To start using the website styles, components and patterns contained here, you’ll need to include the Our Future Health design system toolkit in your project.</p>
+  <p>There are 2 ways to do this. You can either install it using node package manager (npm) or include the compiled files in your application.</p>
+
+  <h3 id="option-1-install-using-npm">Option 1: install using npm</h3>
+  <p>We recommend <a href="https://github.com/ourfuturehealth/design-system-toolkit/blob/main/docs/installation/installing-with-npm.md">installing the Our Future Health design system toolkit using npm</a>.</p>
+  <p>Using this option, you will be able to:</p>
+  <ul>
+    <li>selectively include the CSS or JavaScript for individual components</li>
+    <li>build your own styles or components based on the palette or typography and spacing mixins</li>
+    <li>customise the build (for example, overriding colours or enabling global styles)</li>
+    <li>use the component Nunjucks templates</li>
+  </ul>
+
+  <h3 id="option-2-include-compiled-files">Option 2: include compiled files</h3>
+  <p>If your project does not use npm, or if you want to try out the Our Future Health design system toolkit in your project without installing it through npm, you can <a href="https://github.com/ourfuturehealth/design-system-toolkit/blob/main/docs/installation/installing-compiled.md">download and include compiled stylesheets, JavaScript and the asset files</a>.</p>
+  <p>Using this option, you will be able to include all the CSS and JavaScript of the Our Future Health design system toolkit in your project.</p>
+  <p>You will not be able to:</p>
+  <ul>
+    <li>selectively include the CSS or JavaScript for individual components</li>
+    <li>build your own styles or components based on the palette or typography and spacing mixins</li>
+    <li>customise the build, for example, overriding colours or enabling global styles</li>
+    <li>use the component Nunjucks templates</li>
+  </ul>
+
+  <h2 id="styling-page-elements">Styling page elements</h2>
+  <p>The docs website provides CSS classes for styling content, instead of global styles.</p>
+  <p>The class names follow the Block Element Modifier (BEM) naming convention. This can look a bit daunting at first, but it makes robust code that's easy to maintain.</p>
+  <p>Explore the <a href="/design-system/styles/">Styles</a> section of the docs website to see what classes are available.</p>
+
+  <h2 id="using-components">Using components</h2>
+  <p>The <a href="/design-system/components/">components</a> in the docs website are designed to be accessible and responsive. There are 2 ways to implement them in your application.</p>
+  <p>You can either use HTML or, if you're using Nunjucks with node.js and you installed the Our Future Health design system toolkit using npm, you can use a Nunjucks Macro.</p>
+  <p>You can get the code from the HTML or Nunjucks tabs below the examples on our component pages, like this example of a button.</p>
+
+  {{ designExample({
+    group: "components",
+    item: "buttons",
+    type: "default"
+  }) }}
+
+  <h3 id="using-nunjucks-macros">Using Nunjucks macros</h3>
+  <p>A Nunjucks macro is a simple template that generates more complex HTML.</p>
+  <p>Nunjucks macros save you time by managing repetitive or error-prone tasks, like linking form labels to their controls.</p>
+  <p>Nunjucks macros also make it easier to keep your application up to date. You can run a command to update component code instead of having to manually update your HTML.</p>
+  <p>To use Nunjucks macros in your application, you’ll need to setup Nunjucks views to point to the location of Our Future Health design system toolkit components, which is <code>PATH/TO/node_modules/ofh-design-system-toolkit/packages/components/</code>.</p>
+  <p>To include a specific component macro in your page template, you need to import the macro.</p>
+  <p>For example, to use the button macro, use the import statement <code>% from 'PATH/TO/node_modules/ofh-design-system-toolkit/packages/components/button/macro.njk' import button %}</code>.</p>
+
+  <div class="ofh-inset-text ofh-u-margin-top-5">
+    <p>If you’re using Nunjucks macros in production, be aware that using  <code>html</code> arguments or ones ending with <code>html</code> can be a security risk. The <a href="https://mozilla.github.io/nunjucks/templating.html">Nunjucks templating documentation</a> has guidance on how to mitigate the risks.</p>
+  </div>
+
+
+
+  <h2>Keeping your code up to date</h2>
+  <p>We update the Our Future Health design system toolkit from time to time. Check for recent releases in the <a href="https://github.com/ourfuturehealth/design-system-toolkit/blob/main/CHANGELOG.md">Our Future Health design system toolkit changelog</a>.</p>
+
+
+{% endblock %}

--- a/site/views/index.njk
+++ b/site/views/index.njk
@@ -27,6 +27,13 @@
         <li class="ofh-grid-column-one-third ofh-card-group__item">
           <div class="ofh-card ofh-card--clickable">
             <div class="ofh-card__content">
+              <h2 class="ofh-card__heading ofh-heading-m"><a href="/get-started">Get started</a></h2>
+            </div>
+          </div>
+        </li>
+        <li class="ofh-grid-column-one-third ofh-card-group__item">
+          <div class="ofh-card ofh-card--clickable">
+            <div class="ofh-card__content">
               <h2 class="ofh-card__heading ofh-heading-m"><a href="/design-system/styles">Foundation styles</a></h2>
             </div>
           </div>

--- a/site/views/site-map.njk
+++ b/site/views/site-map.njk
@@ -9,6 +9,9 @@
 
   <ul>
     <li><a href="/">Home</a></li>
+    <li>
+      <a href="/get-started">Get started</a>
+    </li>
     {# <li>
       <a href="/accessibility">Accessibility</a>
       <ul class="ofh-u-nested-list">

--- a/site/views/sitemap.xml
+++ b/site/views/sitemap.xml
@@ -7,6 +7,9 @@
   <url>
     <loc>https://service-manual.nhs.uk/</loc>
   </url>
+  <url>
+    <loc>https://service-manual.nhs.uk/get-started</loc>
+  </url>
   <!-- <url>
     <loc>https://service-manual.nhs.uk/accessibility</loc>
   </url> -->


### PR DESCRIPTION
This copies the same approach taken on the NHSUK Service Manual. I.e. copies the <https://service-manual.nhs.uk/design-system/production> page [1], which in turn has instructions that point to the installation docs in the GitHub repo (which is where developer docs currently live).

[1] For reference, the source code for this page, when it was copied is: <https://github.com/nhsuk/nhsuk-service-manual/blob/7653c899f769ab6b2f375561d9e03034a10e174a/app/views/design-system/production.njk>.


