### PR TITLE
[DSE-148] Revert the secondary button colour back to the previous grey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Whilst in the alpha phase, we don't yet adhere to [Semantic Versioning](https://
   - As part of this, removed the `icon-arrow-right-circle.svg` icon as we've now deviated from it and it's not needed as a separate file.
 - Removed the serif font from `ofh-body-l` class and moved it into the existing `ofh-lede-text` class.
 - Removed the explicit line height for the `.ofh-body-l` class, thus falling back to the default responsive typography styling.
+- Reverted the secondary button colour back to the previous grey from the old colour palette (`#425563`).
 
 ## [v2.0.0-alpha.2] - 2022-08-10
 

--- a/packages/core/settings/_colours.scss
+++ b/packages/core/settings/_colours.scss
@@ -150,9 +150,9 @@ $ofh-button-active-color: #BF8C02;
 // TODO: Not sure what this should be - couldn't find in Figma.
 $ofh-button-shadow-color: $color_ofh-brand-dark-blue;
 
-$ofh-secondary-button-color: #0053B3;
-$ofh-secondary-button-hover-color: #002D61;
-$ofh-secondary-button-active-color: #001F42;
+$ofh-secondary-button-color: #425563;
+$ofh-secondary-button-hover-color: shade($ofh-secondary-button-color, 20%);
+$ofh-secondary-button-active-color: shade($ofh-secondary-button-color, 50%);
 // TODO: Not sure what this should be - couldn't find in Figma.
 $ofh-secondary-button-shadow-color: shade($ofh-secondary-button-color, 50%);
 


### PR DESCRIPTION
This grey is from the old colour palette – `#425563`.

