### PR TITLE
adds instructions for reconfiguring nunjucks and doing simple component imports

### DIFF
--- a/site/views/get-started/index.njk
+++ b/site/views/get-started/index.njk
@@ -55,9 +55,20 @@
   <p>A Nunjucks macro is a simple template that generates more complex HTML.</p>
   <p>Nunjucks macros save you time by managing repetitive or error-prone tasks, like linking form labels to their controls.</p>
   <p>Nunjucks macros also make it easier to keep your application up to date. You can run a command to update component code instead of having to manually update your HTML.</p>
-  <p>To use Nunjucks macros in your application, you’ll need to setup Nunjucks views to point to the location of Our Future Health design system toolkit components, which is <code>PATH/TO/node_modules/ofh-design-system-toolkit/packages/components/</code>.</p>
-  <p>To include a specific component macro in your page template, you need to import the macro.</p>
-  <p>For example, to use the button macro, use the import statement <code>% from 'PATH/TO/node_modules/ofh-design-system-toolkit/packages/components/button/macro.njk' import button %}</code>.</p>
+  <p>To use Nunjucks macros in your application, you’ll need to configure Nunjucks to check the path of Our Future Health design system toolkit components when locating imports. Our Future Health team members have instructions for this [here](https://ourfuturehealth.atlassian.net/wiki/spaces/DS/pages/277250064/Migrating+to+Design+System+V2#Allowing-component-imports).</p>
+  <p>Once you've done this, you can include a specific component macro in your page template, by copy/pasting the Nunjucks template code from that component's documentation verbatim.</p>
+  <p>For example, to use the primary button macro, you can copy the Nunjucks code example in the [documentation for that component](https://designsystem.ourfuturehealth.org.uk/design-system/components/buttons/#primary-button) straight into your code:</p>
+  <p>
+    <pre>
+{% from 'packages/components/button/macro.njk' import button %}
+
+{{ button({
+  "text": "Save and continue"
+}) }}
+    </pre>
+  </p>
+
+  <p>Note that you can do this without reconfiguring your Nunjucks paths - you'd just have to use an import statement that looks more like: <code>{% from 'PATH/TO/node_modules/ofh-design-system-toolkit/packages/components/button/macro.njk' import button %}</code>.</p>
 
   <div class="ofh-inset-text ofh-u-margin-top-5">
     <p>If you’re using Nunjucks macros in production, be aware that using  <code>html</code> arguments or ones ending with <code>html</code> can be a security risk. The <a href="https://mozilla.github.io/nunjucks/templating.html">Nunjucks templating documentation</a> has guidance on how to mitigate the risks.</p>


### PR DESCRIPTION
I think it's a win to have our internal instructions linked from the "getting started" page, but that serves OFH directly (as it links to our private Confluence) and less anybody using the open sourced repo. Personally, my lean is serving OFH is more important - but this is out of my hands now as I'm leaving.

Hopefully this is helpful - I'll leave this with you @jits