### PR TITLE
Broaden the main app content width

### DIFF
--- a/site/styles/app/_app.scss
+++ b/site/styles/app/_app.scss
@@ -4,6 +4,7 @@
 @import 'code-highlight';
 @import 'colour-swatch';
 @import 'contact-panel';
+@import 'container';
 @import 'example-callout';
 @import 'featured-list';
 @import 'footer';

--- a/site/styles/app/_container.scss
+++ b/site/styles/app/_container.scss
@@ -1,0 +1,20 @@
+/* ==========================================================================
+   #CONTAINER
+   ========================================================================== */
+
+// Container width variable
+$app-container-size: 1100px;
+
+.app-width-container,
+.app-breadcrumb .ofh-width-container {
+  max-width: $app-container-size;
+
+  @media (min-width: 767px) and (max-width: 1164px) {
+    margin: 0 ofh-spacing(5);
+  }
+}
+
+.ofh-header__container,
+.ofh-header__navigation {
+  max-width: $app-container-size;
+}

--- a/site/styles/main.scss
+++ b/site/styles/main.scss
@@ -18,17 +18,6 @@
   }
 }
 
-// Main nav active state
-.app-header__navigation-item__item--current {
-  @include mq($from: large-desktop) {
-    box-shadow: inset 0 -4px 0 $color_ofh-grey-4;
-  }
-
-  .ofh-header__navigation-link {
-    font-weight: $ofh-font-bold;
-  }
-}
-
 // Removal of table cell element top and bottom margins
 // Remove bottom margin from a <p>
 .ofh-table__cell {


### PR DESCRIPTION
When we originally ported over the NHS Service Manual code into this repository we excluded some bits, like the custom header and custom container width styling, so we could lean on the defaults on the design system. This resulted in a smaller content width on our docs site than what's on the NHS Service Manual.

As Ciaran and Gary have noticed, this reduced width meant that certain design examples that rely on responsive behaviour would show smaller breakpoint versions on typical laptop screens.

This change attempts to fix this by increasing the app content width to `1100px` (as well as the header) to match the same width used on the NHS Service Manual.

