### PR TITLE
Header component, docs + max-width for pages updated

### DIFF
--- a/packages/components/header/_header.scss
+++ b/packages/components/header/_header.scss
@@ -35,7 +35,7 @@
 
 .ofh-header {
   @include clearfix();
-  background-color: $color_ofh-brand-yellow;
+  background-color: $color_ofh-brand-dark-blue;
 }
 
 .ofh-header__container {

--- a/site/styles/app/_container.scss
+++ b/site/styles/app/_container.scss
@@ -3,7 +3,7 @@
    ========================================================================== */
 
 // Container width variable
-$app-container-size: 1100px;
+$app-container-size: 960px; // original value = 1100px. Changed to align with our standards.
 
 .app-width-container,
 .app-breadcrumb .ofh-width-container {

--- a/site/views/design-system/components/header/index.njk
+++ b/site/views/design-system/components/header/index.njk
@@ -7,12 +7,19 @@
 {% set backlog_issue_id = "16" %}
 
 {% extends "app-layout.njk" %}
+{% from 'packages/components/warning-callout/macro.njk' import warningCallout %}
+
 
 {% block breadcrumb %}
   {% include "../_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
+
+{{ warningCallout({
+  "heading": "We do not use the headers below in our products",
+  "HTML": "<p>We are currently implementing headers on a product-by-product basis. You can see we have not updated the headers due to the inclusion of an NHS logo on all the headers below.</p><p>While we update the headers component, we recommend viewing either the appropriate figma files or the live products to see how headers have been implemented.</p>"
+}) }}
 
   {{ designExample({
     group: "components",


### PR DESCRIPTION
## Changes
* Changed the default background for the header component to dark-blue
* Added a warning callout to the header documentation page alerting users that these are not the right headers
* Reduced the max-width for the page container from 1100px to align with our 960px standard.
