### PR TITLE
Update $background-bounce-color to match footer

### DIFF
--- a/packages/core/settings/_colours.scss
+++ b/packages/core/settings/_colours.scss
@@ -131,7 +131,7 @@ $color_transparent_ofh-blue-50: rgba($color_shade_ofh-blue-50, .1);
 
 // Background
 $background-color: $color_ofh-grey-6;
-$background-bounce-color: $color_ofh-grey-5;
+$background-bounce-color: $color_ofh-grey-4;
 
 // Text
 $ofh-text-black-color: $color_ofh-black;


### PR DESCRIPTION
## Description
Align $background-bounce-color with footer so when a page has no scrolling content, the footer colour continues. 

Before:
<img width="464" alt="Screenshot 2023-10-17 at 11 59 53" src="https://github.com/ourfuturehealth/design-system-toolkit/assets/62945270/b6461b43-0dd3-4317-a3c7-eb2fe523b300">

After:
<img width="473" alt="Screenshot 2023-10-17 at 11 59 04" src="https://github.com/ourfuturehealth/design-system-toolkit/assets/62945270/b70f03fe-d6a0-440b-8777-7ac731919668">
