### PR TITLE
Updated arrow icon colour

### DIFF
--- a/packages/core/styles/_icons.scss
+++ b/packages/core/styles/_icons.scss
@@ -36,11 +36,11 @@
 }
 
 .ofh-icon__arrow-right {
-  fill: $color_ofh-brand-yellow;
+  fill: $color_ofh-brand-dark-blue;
 }
 
 .ofh-icon__arrow-left {
-  fill: $color_ofh-brand-yellow;
+  fill: $color_ofh-brand-dark-blue;
 }
 
 .ofh-icon__chevron-down {


### PR DESCRIPTION
## Description

Updated arrow icon colour to increase colour contrast

Before:
<img width="167" alt="Screenshot 2023-10-17 at 14 06 33" src="https://github.com/ourfuturehealth/design-system-toolkit/assets/62945270/95901315-baf0-47aa-9646-93eeac4886fd">

After:
<img width="180" alt="Screenshot 2023-10-17 at 14 06 17" src="https://github.com/ourfuturehealth/design-system-toolkit/assets/62945270/db725fc2-c7b2-4f6f-9959-0cb3449ec6ae">
