### PR TITLE
Updated tag background colours

### DIFF
--- a/packages/components/tag/_tag.scss
+++ b/packages/components/tag/_tag.scss
@@ -36,21 +36,21 @@
 }
 
 .ofh-tag--green {
-  background-color: tint($color_ofh-brand-green, 80%);
+  background-color: $color_ofh-brand-light-green-5;
   color: $color_ofh-brand-green-1;
 }
 
 .ofh-tag--blue {
-  background-color: tint($color_ofh-brand-blue, 80%);
+  background-color: $color_ofh-brand-blue-5;
   color: $color_ofh-brand-blue-1;
 }
 
 .ofh-tag--red {
-  background-color: tint($color_ofh-brand-red, 80%);
+  background-color: $color_ofh-brand-red-5;
   color: $color_ofh-brand-red-1;
 }
 
 .ofh-tag--yellow {
-  background-color: tint($color_ofh-brand-yellow, 70%);
+  background-color: $color_ofh-brand-yellow-5;
   color: $color_ofh-brand-orange-1;
 }

--- a/site/views/design-system/components/tag/index.njk
+++ b/site/views/design-system/components/tag/index.njk
@@ -3,7 +3,7 @@
 {% set subSection = "Components" %}
 {% set pageDescription = "Use the tag component when it's possible for something to have more than 1 status and it's useful for the user to know about that status. For example, you can use a tag to show whether an item in a task list has been \"completed\"." %}
 {% set theme = "Content presentation" %}
-{% set dateUpdated = "October 2020" %}
+{% set dateUpdated = "April 2024" %}
 {% set backlog_issue_id = "174" %}
 {% set hideDescription = "true" %}
 


### PR DESCRIPTION
Used the new group of colours and applied to tags. This replaces the use of percentages.

I'm guessing the background colors on the docs site Tag page will update accordingly without me doing anything. 

