### PR TITLE
Updated green tag background to correct color

### DIFF
--- a/packages/components/tag/_tag.scss
+++ b/packages/components/tag/_tag.scss
@@ -36,7 +36,7 @@
 }
 
 .ofh-tag--green {
-  background-color: $color_ofh-brand-light-green-5;
+  background-color: $color_ofh-brand-green-5;
   color: $color_ofh-brand-green-1;
 }
 


### PR DESCRIPTION
I made a mistake. 

Have updated so the green tag background is using brand-green-5 instead of brand-light-green-5. 
