### PR TITLE
PXG-000: fix doc site button

### DIFF
--- a/packages/components/button/template.njk
+++ b/packages/components/button/template.njk
@@ -11,8 +11,12 @@
 {% endif %}
 
 {# Define common attributes that we can use across all element types #}
-{% set commonAttributes %} class="ofh-button ofh-button--contained
-  {%- if params.classes %} {{ params.classes }}{% endif %}
+{% set commonAttributes %} class="ofh-button
+  {%- if params.classes %}
+    {{ params.classes }}
+  {% else %}
+    ofh-button--contained
+  {% endif %}
   {%- if params.disabled %} ofh-button--disabled{% endif %}"
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}
 {%- endset -%}


### PR DESCRIPTION
## Description

Noticed the doc site had a small issue with buttons

Below was using `ofh-button ofh-button--contained ofh-button--outlined` when it should just be `ofh-button ofh-button--outlined` 
<img width="590" alt="Screenshot 2024-05-07 at 11 34 33" src="https://github.com/ourfuturehealth/design-system-toolkit/assets/63705600/2b28b356-ac49-40bf-86af-ac45d874740f">

For the error summary or forms that use buttons, they should be defaulted to `ofh-button ofh-button--contained`
<img width="600" alt="Screenshot 2024-05-07 at 11 35 29" src="https://github.com/ourfuturehealth/design-system-toolkit/assets/63705600/e47abc79-ad5c-4cd9-a630-be6d39c10690">
