### PR TITLE
updated typography page

### DIFF
--- a/site/styles/app/_code-highlight.scss
+++ b/site/styles/app/_code-highlight.scss
@@ -2,8 +2,8 @@
 li code,
 p code,
 td code {
-  background-color: $color_ofh-white;
-  color: #d14; // sass-lint:disable-line no-color-hex no-color-literals
+  background-color: $color_ofh-grey-6;
+  color: #D40202; // sass-lint:disable-line no-color-hex no-color-literals
   padding: 2px ofh-spacing(2);
   word-break: break-word;
 }

--- a/site/styles/design-example/_code-snippet.scss
+++ b/site/styles/design-example/_code-snippet.scss
@@ -12,17 +12,16 @@ $button-shadow-size: 4px;
   .app-link {
 
     &--copy {
-      border-bottom-color: $ofh-button-color;
-      box-shadow: 0 2px 0 $ofh-button-color;
+      border-radius: $ofh-border-radius;
       margin-bottom: 16px;
-      padding: 2px 8px;
+      padding: 4px 8px;
       position: absolute;
       right: 16px;
       text-transform: none;
       top: 16px;
 
       &:hover {
-        background-color: $color_ofh-grey-5;
+        background-color: $ofh-link-hover-color;
       }
 
       &:focus {

--- a/site/styles/design-example/govuk/_button.scss
+++ b/site/styles/design-example/govuk/_button.scss
@@ -4,10 +4,9 @@
 .app-link--copy:hover {
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-  background-color: $color_ofh-white;
-  border: 1px solid $color_ofh-brand-green;
-  color: $color_ofh-brand-green;
-  font-family: 'nta', Arial, sans-serif;
+  background-color: $ofh-button-color-default;
+  color: $ofh-text-white-color;
+  font-family: 'Source Sans Pro', Arial, sans-serif;
   font-size: 14px;
   font-weight: 400;
   min-width: 58px;

--- a/site/views/design-system/styles/typography/captions/index.njk
+++ b/site/views/design-system/styles/typography/captions/index.njk
@@ -1,0 +1,10 @@
+<span class="ofh-caption-xl">Caption xl</span>
+<h1>Heading 1</h1>
+<span class="ofh-caption-l">Caption l</span>
+<h1>Heading 1</h1>
+<span class="ofh-caption-m">Caption m</span>
+<h1>Heading 1</h1>
+<hr>
+<h1>Heading 1 <span class="ofh-caption-xl ofh-caption--bottom">Caption xl bottom</span></h1>
+<h1>Heading 1 <span class="ofh-caption-l ofh-caption--bottom">Caption l bottom</span></h1>
+<h1>Heading 1 <span class="ofh-caption-m ofh-caption--bottom">Caption m bottom</span></h1>

--- a/site/views/design-system/styles/typography/headings/index.njk
+++ b/site/views/design-system/styles/typography/headings/index.njk
@@ -1,5 +1,11 @@
-<h1 class="ofh-heading-xl">ofh-heading-xl</h1>
-<h2 class="ofh-heading-l">ofh-heading-l</h2>
-<h3 class="ofh-heading-m">ofh-heading-m</h3>
-<h4 class="ofh-heading-s">ofh-heading-s</h4>
-<h5 class="ofh-heading-xs">ofh-heading-xs</h5>
+<h1>Heading 1</h1>
+<h2>Heading 2</h2>
+<h3>Heading 3</h3>
+<h4>Heading 4</h4>
+<h5>Heading 5</h5>
+<hr>
+<h1 class="ofh-heading-m">Heading 1 with ofh-heading-m class</h1>
+<h2 class="ofh-heading-s">Heading 2 with ofh-heading-s class</h2>
+<h3 class="ofh-heading-xs">Heading 3 with ofh-heading-xs class</h3>
+<h4 class="ofh-heading-xl">Heading 4 with ofh-heading-xl class</h4>
+<h5 class="ofh-heading-l">Heading 5 with ofh-heading-l class</h5>

--- a/site/views/design-system/styles/typography/index.njk
+++ b/site/views/design-system/styles/typography/index.njk
@@ -45,6 +45,7 @@
         <li class="app-side-nav__item"><a class="app-side-nav__link" href="#font">Font</a></li>
         <li class="app-side-nav__item"><a class="app-side-nav__link" href="#typescale">Typescale</a></li>
         <li class="app-side-nav__item"><a class="app-side-nav__link" href="#headings">Headings</a></li>
+        <li class="app-side-nav__item"><a class="app-side-nav__link" href="#captions">Captions</a></li>
         <li class="app-side-nav__item"><a class="app-side-nav__link" href="#paragraphs">Paragraphs</a></li>
         <li class="app-side-nav__item"><a class="app-side-nav__link" href="#font-override-classes">Font override classes</a></li>
         <li class="app-side-nav__item"><a class="app-side-nav__link" href="#links">Links</a></li>
@@ -77,11 +78,26 @@
   <p>Write all headings in sentence case.</p>
   <p>Style headings consistently to create a clear content structure throughout your service and a clear content hierarchy on a page.</p>
   <p>Heading levels have meaning, especially for screen reader users and search engines. Using correct heading levels improves SEO and helps people using assistive technology to navigate through a page.</p>
+  <h3>Heading overrides</h2>
+  <p>We have 5 different classes that can be used to change the default font-size and spacing of headings. These classes can be used with any heading. Always ensure heading structure is semantically correct.</p>
+
 
   {{ designExample({
     group: "styles",
     item: "typography",
     type: "headings",
+    htmlOnly: true
+  }) }}
+
+  <h2 id="captions">Captions</h2>
+  <p>Sometimes you may need to make it clear that a page is part of a larger section or group. To do this, you can use a heading with a caption</p>
+  <p>We have 3 different sizes of caption, by default captions will display above headings. You can use an additional class to display the caption below headings.</p>
+  <p>Consider whether the caption should be part of the page heading. This will determine whether the span is nested in the heading or not.</p>
+
+  {{ designExample({
+    group: "styles",
+    item: "typography",
+    type: "captions",
     htmlOnly: true
   }) }}
 
@@ -125,8 +141,8 @@
   <p>You might need to set the font size or font weight of an element outside the predefined heading and paragraph classes. To do this you can use the font override classes in your HTML or reference the typography mixins in your own components.</p>
 
   <h3 id="font-size">Font size</h3>
-  <p>Our full typography scale goes from 14px to 64px on desktop and tablet. You can add these font size override classes to any other typographic class or element, and they will change the font size.</p>
-
+  <p>Our full typography scale goes from 14px to 64px. You can add these font size override classes to any other typographic class or element, and they will change the font size.</p>
+  <p>Only use these font size overrides with <code>p</code> tags.
   {{ designExample({
     group: "styles",
     item: "typography",

--- a/site/views/examples/components/typography.njk
+++ b/site/views/examples/components/typography.njk
@@ -10,7 +10,7 @@
 {% from 'packages/components/details/macro.njk' import details %}
 {% from 'packages/components/tables/macro.njk' import table %}
 {% from 'packages/components/warning-callout/macro.njk' import warningCallout %}
-{% extends 'standalone-example-layout.njk' %}
+{% extends 'app-layout.njk' %}
 
 {% block body %}
 


### PR DESCRIPTION
- Added captions section to the typography page
- Added default headings and separated out from heading override classes
- Updated styling of the 'copy code' button so that is more consistent with our new buttons
- Updated color and background-color used for code highlight to increase contrast.
- Updated layout used for the 'typography overview' page so it uses header and footer, but no longer think there is much value in this page and we've updated the core typography page. 
