### PR TITLE
PXG-528: Fixes to ofh-main-wrapper to ensure the full viewport is used

### DIFF
--- a/packages/core/objects/_main-wrapper.scss
+++ b/packages/core/objects/_main-wrapper.scss
@@ -40,7 +40,17 @@
 @include govuk-exports('govuk/objects/main-wrapper') {
   .ofh-main-wrapper {
     @include govuk-main-wrapper;
+    min-height: calc(100vh - 325px);
+
+    @include mq($until: desktop) {
+      min-height: calc(100vh - 480px);
+    }
+
+    @include mq($until: mobile) {
+      min-height: calc(100vh - 600px);
+    }
   }
+
   .ofh-main-wrapper--l {
     @include govuk-main-wrapper--l;
   }


### PR DESCRIPTION
## Description

Relates to: https://dev.azure.com/eddrp-uk/eddrp/_git/eddrp-participant/pullrequest/7961

The `px` subtracted from the viewport is based off the height of the header/footer combined.