### PR TITLE
PXG-1048: Update security scan to not use private kondukto GH action

### DIFF
--- a/.github/workflows/kondukto.yml
+++ b/.github/workflows/kondukto.yml
@@ -2,18 +2,36 @@ name: Kondukto security scan
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   workflow_dispatch:
 
-jobs:
-  scan:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@v4
+env:
+  TARGET_BRANCH: main
 
-      - name: Run Kondukto Scan
-        uses: ourfuturehealth/kondukto-scan/.github/actions/kondukto-reusable-action@main
-        with:
-          token: ${{ secrets.KDT_TOKEN }}
-          languages: 'js'
+jobs:
+  run-scans:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+
+    - name: Install KDT CLI
+      run: |
+        curl -sSL https://cli.kondukto.io | sh
+
+    - name: Scan with Dependabot
+      run: kdt scan --host ${{ secrets.KONDUKTO_HOST }} --token ${{ secrets.KONDUKTO_TOKEN }} -p ${{ secrets.PROJECT_NAME }} -t dependabot -b $TARGET_BRANCH --async
+
+    - name: Scan with Semgrep
+      run: kdt scan --host ${{ secrets.KONDUKTO_HOST }} --token ${{ secrets.KONDUKTO_TOKEN }} -p ${{ secrets.PROJECT_NAME }} -t semgrep -b $TARGET_BRANCH --async
+
+    - name: Scan with OSV
+      run: kdt scan --host ${{ secrets.KONDUKTO_HOST }} --token ${{ secrets.KONDUKTO_TOKEN }} -p ${{ secrets.PROJECT_NAME }} -t osvscannersca -b $TARGET_BRANCH --async
+
+    - name: Scan with Gitleaks
+      run: kdt scan --host ${{ secrets.KONDUKTO_HOST }} --token ${{ secrets.KONDUKTO_TOKEN }} -p ${{ secrets.PROJECT_NAME }} -t gitleaks -b $TARGET_BRANCH --async
+
+    - name: Scan with Trufflehog
+      run: kdt scan --host ${{ secrets.KONDUKTO_HOST }} --token ${{ secrets.KONDUKTO_TOKEN }} -p ${{ secrets.PROJECT_NAME }} -t trufflehogsecurity -b $TARGET_BRANCH --async


### PR DESCRIPTION
## Description

Previously, the workflow failed to recognise the private GH action

<img width="491" alt="Screenshot 2024-12-11 at 08 45 03" src="https://github.com/user-attachments/assets/2153c9a9-18c2-4dda-88e8-e3335149e8b1">

Instead, we will not use the private GH action and have a separate pipeline that has a separate access token for auth against  kondukto.

This has been tested on this PR:

<img width="1270" alt="Screenshot 2024-12-10 at 17 11 17" src="https://github.com/user-attachments/assets/7a079483-4ac4-42c0-8ea7-c37e75b41bb2">

https://github.com/ourfuturehealth/design-system-toolkit/actions/runs/12261439356/job/34208447076
