### PR TITLE
[RP-4090] - Remove box shadow of menu toggle focus state

### DIFF
--- a/packages/components/header/_header.scss
+++ b/packages/components/header/_header.scss
@@ -439,8 +439,6 @@
 
   &:focus {
     @include ofh-focused-button;
-
-    box-shadow: 0 0 0 2px $ofh-focus-color, 0 $ofh-focus-width 0 2px $ofh-focus-text-color;
   }
 
 }


### PR DESCRIPTION
## Description

The focus state of the header menu toggle button still has an additional box shadow that needs to removed after the focus updates from release v3.2.0-alpha.1.

This PR removes the box shadow.

Before:

<img width="137" alt="Screenshot 2025-02-25 at 16 08 25" src="https://github.com/user-attachments/assets/f743616a-9114-49e3-b2cf-a7ce9d1a90cf" />

After:

<img width="177" alt="Screenshot 2025-02-25 at 16 07 45" src="https://github.com/user-attachments/assets/8f397e44-c228-4c0c-8295-30edb378aeed" />
