### PR TITLE
Fix extra blank space in Foundation styles showcase cards

### DIFF
--- a/packages/site/styles/app/_foundation-showcase.scss
+++ b/packages/site/styles/app/_foundation-showcase.scss
@@ -121,11 +121,12 @@
 }
 
 .app-foundation-showcase__cards > li {
-  height: 100%;
+  display: flex;
 }
 
 .app-foundation-showcase__landing-card {
-  height: 100%;
+  flex: 1 1 auto;
+  margin-bottom: 0;
 }
 
 .app-foundation-showcase__example-heading {


### PR DESCRIPTION
## Description

- fixes the extra blank space at the bottom of the Foundation styles showcase cards
- keeps cards aligned to the tallest card in each row
- scopes the change to the Foundation styles showcase page only

## What changed

- replaced the `height: 100%` card stretching on the showcase grid with a flex wrapper on each grid item
- removed the card's default bottom margin in this showcase context so the row height is driven by card content instead of stretched card boxes

## Verification

- `pnpm --filter=site run build`
- `pnpm --filter=site run lint:css`

Before:
<img width="1600" height="1200" alt="foundation-showcase-before" src="https://github.com/user-attachments/assets/e424f392-843a-46cd-850f-b87c8fbc7ebc" />


After:
<img width="1600" height="1200" alt="foundation-showcase-after" src="https://github.com/user-attachments/assets/8c1e8bec-30a0-453e-8a7c-fd945109029e" />

