### PR TITLE
fix(release): harden toolkit/react release asset staging

### DIFF
--- a/.github/workflows/release-contract.yml
+++ b/.github/workflows/release-contract.yml
@@ -10,9 +10,11 @@ on:
       - 'docs/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
+      - 'packages/toolkit/gulpfile.js'
       - 'packages/toolkit/package.json'
       - 'packages/react-components/package.json'
       - 'packages/react-components/README.md'
+      - 'packages/react-components/scripts/**'
       - 'scripts/release/**'
 
 jobs:
@@ -38,5 +40,5 @@ jobs:
       - name: Validate docs and release templates
         run: pnpm docs:release-contract
 
-      - name: Smoke test current release artifacts
+      - name: Prepare and smoke test current release artifacts
         run: pnpm smoke:release-artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,51 +47,29 @@ jobs:
           TAG=${GITHUB_REF#refs/tags/}
           if [[ $TAG == react-v* ]]; then
             echo "PACKAGE=react-components" >> $GITHUB_OUTPUT
-            echo "PACKAGE_SCOPE=@ourfuturehealth/react-components" >> $GITHUB_OUTPUT
             echo "PACKAGE_DIR=packages/react-components" >> $GITHUB_OUTPUT
-            echo "VERSION=${TAG#react-v}" >> $GITHUB_OUTPUT
           elif [[ $TAG == toolkit-v* ]]; then
             echo "PACKAGE=toolkit" >> $GITHUB_OUTPUT
-            echo "PACKAGE_SCOPE=@ourfuturehealth/toolkit" >> $GITHUB_OUTPUT
             echo "PACKAGE_DIR=packages/toolkit" >> $GITHUB_OUTPUT
-            echo "VERSION=${TAG#toolkit-v}" >> $GITHUB_OUTPUT
           else
             # Assume v* tags are toolkit (backward compatibility)
             echo "PACKAGE=toolkit" >> $GITHUB_OUTPUT
-            echo "PACKAGE_SCOPE=@ourfuturehealth/toolkit" >> $GITHUB_OUTPUT
             echo "PACKAGE_DIR=packages/toolkit" >> $GITHUB_OUTPUT
-            echo "VERSION=${TAG#v}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build release artifacts
+      - name: Prepare release assets
+        id: release_assets
         run: |
-          if [ "${{ steps.package_info.outputs.PACKAGE }}" == "toolkit" ]; then
-            pnpm --filter=@ourfuturehealth/toolkit run zip
-          else
-            pnpm --filter=@ourfuturehealth/react-components run build
-          fi
-
-      - name: Pack release tarball
-        id: tarball
-        run: |
-          TARBALL_NAME=$(npm pack "./${{ steps.package_info.outputs.PACKAGE_DIR }}" --ignore-scripts | tail -n 1)
-          echo "ASSET_NAME=${TARBALL_NAME}" >> $GITHUB_OUTPUT
-          echo "ASSET_PATH=${GITHUB_WORKSPACE}/${TARBALL_NAME}" >> $GITHUB_OUTPUT
-
-      - name: Resolve toolkit asset details
-        if: steps.package_info.outputs.PACKAGE == 'toolkit'
-        id: toolkit_asset
-        run: |
-          ASSET_PATH=$(ls -1 ./packages/toolkit/dist/ofh-design-system-toolkit-*.zip | head -n 1)
-          ASSET_NAME=$(basename "$ASSET_PATH")
-          echo "ASSET_PATH=$ASSET_PATH" >> $GITHUB_OUTPUT
-          echo "ASSET_NAME=$ASSET_NAME" >> $GITHUB_OUTPUT
+          ./scripts/release/prepare-release-artifacts.sh \
+            "${{ steps.package_info.outputs.PACKAGE }}" \
+            --stage-dir "${RUNNER_TEMP}/release-assets-${{ github.run_id }}-${{ github.run_attempt }}-${{ steps.package_info.outputs.PACKAGE }}" \
+            --github-output "${GITHUB_OUTPUT}"
 
       - name: Smoke test release tarball
         run: |
           ./scripts/release/smoke-package-tarball.sh \
             --package-dir "${{ github.workspace }}/${{ steps.package_info.outputs.PACKAGE_DIR }}" \
-            --tarball "${{ steps.tarball.outputs.ASSET_PATH }}" \
+            --tarball "${{ steps.release_assets.outputs.TARBALL_PATH }}" \
             --managers 'yarn,npm,pnpm'
 
       - name: Render release notes
@@ -102,15 +80,15 @@ jobs:
             ./scripts/release/render-release-notes.sh \
               --package "${{ steps.package_info.outputs.PACKAGE }}" \
               --tag "${GITHUB_REF_NAME}" \
-              --version "${{ steps.package_info.outputs.VERSION }}" \
-              --tarball "${{ steps.tarball.outputs.ASSET_NAME }}" \
-              --zip "${{ steps.toolkit_asset.outputs.ASSET_NAME }}" > "${NOTES_PATH}"
+              --version "${{ steps.release_assets.outputs.VERSION }}" \
+              --tarball "${{ steps.release_assets.outputs.TARBALL_NAME }}" \
+              --zip "${{ steps.release_assets.outputs.ZIP_NAME }}" > "${NOTES_PATH}"
           else
             ./scripts/release/render-release-notes.sh \
               --package "${{ steps.package_info.outputs.PACKAGE }}" \
               --tag "${GITHUB_REF_NAME}" \
-              --version "${{ steps.package_info.outputs.VERSION }}" \
-              --tarball "${{ steps.tarball.outputs.ASSET_NAME }}" > "${NOTES_PATH}"
+              --version "${{ steps.release_assets.outputs.VERSION }}" \
+              --tarball "${{ steps.release_assets.outputs.TARBALL_NAME }}" > "${NOTES_PATH}"
           fi
           echo "NOTES_PATH=${NOTES_PATH}" >> $GITHUB_OUTPUT
 
@@ -136,7 +114,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${GITHUB_REF_NAME}" "${{ steps.toolkit_asset.outputs.ASSET_PATH }}" \
+          gh release upload "${GITHUB_REF_NAME}" "${{ steps.release_assets.outputs.ZIP_PATH }}" \
             --clobber \
             --repo "${GITHUB_REPOSITORY}"
 
@@ -144,6 +122,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${GITHUB_REF_NAME}" "${{ steps.tarball.outputs.ASSET_PATH }}" \
+          gh release upload "${GITHUB_REF_NAME}" "${{ steps.release_assets.outputs.TARBALL_PATH }}" \
             --clobber \
             --repo "${GITHUB_REPOSITORY}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Validate release contract docs
         run: pnpm docs:release-contract
 
-      - name: Determine package and version
+      - name: Determine package from tag
         id: package_info
         run: |
           TAG=${GITHUB_REF#refs/tags/}
@@ -64,6 +64,24 @@ jobs:
             "${{ steps.package_info.outputs.PACKAGE }}" \
             --stage-dir "${RUNNER_TEMP}/release-assets-${{ github.run_id }}-${{ github.run_attempt }}-${{ steps.package_info.outputs.PACKAGE }}" \
             --github-output "${GITHUB_OUTPUT}"
+
+      - name: Validate tag version matches package version
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if [[ "${TAG}" == react-v* ]]; then
+            EXPECTED_VERSION="${TAG#react-v}"
+          elif [[ "${TAG}" == toolkit-v* ]]; then
+            EXPECTED_VERSION="${TAG#toolkit-v}"
+          else
+            EXPECTED_VERSION="${TAG#v}"
+          fi
+
+          ACTUAL_VERSION="${{ steps.release_assets.outputs.VERSION }}"
+
+          if [[ "${EXPECTED_VERSION}" != "${ACTUAL_VERSION}" ]]; then
+            echo "Tag version '${EXPECTED_VERSION}' does not match package version '${ACTUAL_VERSION}' for tag '${TAG}'." >&2
+            exit 1
+          fi
 
       - name: Smoke test release tarball
         run: |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -74,12 +74,11 @@ When a release tag is pushed, [.github/workflows/release.yml](../.github/workflo
 1. installs dependencies with pnpm
 2. runs linting and tests
 3. validates the release-contract docs
-4. builds the package being released
-5. packs the package with `npm pack --ignore-scripts`
-6. smoke-tests the tarball with Yarn 1, npm, and pnpm
-7. renders release notes with the tarball install URL
-8. creates or updates the GitHub release
-9. uploads release assets
+4. prepares the package release assets in a dedicated staging directory outside the package tree
+5. smoke-tests the tarball with Yarn 1, npm, and pnpm
+6. renders release notes with the tarball install URL
+7. creates or updates the GitHub release
+8. uploads release assets
 
 Toolkit releases upload:
 
@@ -145,6 +144,7 @@ pnpm smoke:release-artifacts
 ```
 
 This validates the public docs and then tests the current branch tarballs with Yarn 1, npm, and pnpm.
+It uses the same staged-asset preparation path as the tag-driven release workflow, so PR validation exercises the same artifact handoff that production releases rely on.
 
 For local iteration you can scope this wrapper to one package and one or more package managers:
 
@@ -152,6 +152,17 @@ For local iteration you can scope this wrapper to one package and one or more pa
 ./scripts/release/smoke-current-release-artifacts.sh toolkit --managers yarn
 ./scripts/release/smoke-current-release-artifacts.sh react-components --managers npm,pnpm
 ```
+
+### Prepare release assets directly
+
+If you need to inspect the exact staged assets before tagging:
+
+```bash
+./scripts/release/prepare-release-artifacts.sh toolkit
+./scripts/release/prepare-release-artifacts.sh react-components
+```
+
+The script prints the package, version, and staged asset paths. Toolkit releases must stage both the versioned `.zip` and the package tarball before the workflow can create or update the GitHub release.
 
 ### Test unreleased changes locally in another consumer
 
@@ -183,6 +194,18 @@ Common causes:
 - package build failures
 - smoke test failures for the tarball install contract
 - stale docs or release templates that still mention the old git-subdirectory syntax
+
+### Why release assets are staged outside the package tree
+
+The release workflow deliberately copies built assets into a dedicated staging directory before it runs `npm pack`.
+
+This is intentional. CI previously showed the toolkit `createZip` step completing successfully, then failed later when the workflow tried to rediscover the versioned zip from `packages/toolkit/dist/`. Local reproduction did not show the same disappearance, and the local/CI npm versions differed, so the release flow now treats the package working tree as unstable across later packaging steps.
+
+The staged asset copy is the source of truth for:
+
+- tarball smoke testing
+- toolkit compiled-file uploads
+- release note asset references
 
 ### Consumer installation failed
 

--- a/scripts/release/prepare-release-artifacts.sh
+++ b/scripts/release/prepare-release-artifacts.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF' >&2
+Usage: prepare-release-artifacts.sh <toolkit|react-components> [--stage-dir <dir>] [--metadata-file <path>] [--github-output <path>]
+EOF
+}
+
+current_step='initializing release asset preparation'
+temp_files=()
+
+print_step() {
+  printf ' -> %s\n' "$1"
+}
+
+print_success() {
+  printf ' ✓ %s\n' "$1"
+}
+
+print_failure() {
+  printf '\n✗ %s\n' "$1" >&2
+}
+
+on_error() {
+  printf 'Release asset preparation failed while %s.\n' "${current_step}" >&2
+}
+
+cleanup() {
+  if [[ ${#temp_files[@]} -gt 0 ]]; then
+    rm -f "${temp_files[@]}"
+  fi
+}
+
+trap on_error ERR
+trap cleanup EXIT
+
+run_quiet_step() {
+  local description=$1
+  shift
+
+  local log_file
+  log_file=$(mktemp)
+  temp_files+=("${log_file}")
+
+  if "$@" >"${log_file}" 2>&1; then
+    return 0
+  fi
+
+  print_failure "${description}"
+  cat "${log_file}" >&2
+  return 1
+}
+
+run_quiet_capture_stdout() {
+  local description=$1
+  local stdout_file=$2
+  shift 2
+
+  local log_file
+  log_file=$(mktemp)
+  temp_files+=("${log_file}" "${stdout_file}")
+
+  if "$@" >"${stdout_file}" 2>"${log_file}"; then
+    return 0
+  fi
+
+  print_failure "${description}"
+  cat "${log_file}" >&2
+  if [[ -s "${stdout_file}" ]]; then
+    cat "${stdout_file}" >&2
+  fi
+  return 1
+}
+
+write_output() {
+  local key=$1
+  local value=$2
+
+  if [[ -n "${metadata_file}" ]]; then
+    printf '%s=%q\n' "${key}" "${value}" >> "${metadata_file}"
+  fi
+
+  if [[ -n "${github_output}" ]]; then
+    printf '%s=%s\n' "${key}" "${value}" >> "${github_output}"
+  fi
+}
+
+list_directory() {
+  local dir=$1
+
+  if [[ -d "${dir}" ]]; then
+    printf 'Directory contents for %s:\n' "${dir}" >&2
+    ls -la "${dir}" >&2
+    return
+  fi
+
+  printf 'Directory does not exist: %s\n' "${dir}" >&2
+}
+
+package=''
+stage_dir=''
+metadata_file=''
+github_output=${GITHUB_OUTPUT:-}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    toolkit|react-components)
+      if [[ -n "${package}" ]]; then
+        usage
+        exit 1
+      fi
+      package="$1"
+      shift
+      ;;
+    --stage-dir)
+      stage_dir="$2"
+      shift 2
+      ;;
+    --metadata-file)
+      metadata_file="$2"
+      shift 2
+      ;;
+    --github-output)
+      github_output="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${package}" ]]; then
+  usage
+  exit 1
+fi
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+cd "${repo_root}"
+
+if [[ -z "${stage_dir}" ]]; then
+  stage_dir=$(mktemp -d "${TMPDIR:-/tmp}/ofh-release-assets.${package}.XXXXXX")
+fi
+
+mkdir -p "${stage_dir}"
+if find "${stage_dir}" -mindepth 1 -print -quit | grep -q .; then
+  echo "Stage directory must be empty: ${stage_dir}" >&2
+  exit 1
+fi
+
+stage_dir=$(cd "${stage_dir}" && pwd)
+
+if [[ -n "${metadata_file}" ]]; then
+  : > "${metadata_file}"
+fi
+
+case "${package}" in
+  toolkit)
+    package_dir='packages/toolkit'
+    package_scope='@ourfuturehealth/toolkit'
+    build_command=(pnpm --filter=@ourfuturehealth/toolkit run zip)
+    ;;
+  react-components)
+    package_dir='packages/react-components'
+    package_scope='@ourfuturehealth/react-components'
+    build_command=(pnpm --filter=@ourfuturehealth/react-components run build)
+    ;;
+esac
+
+package_manifest="${repo_root}/${package_dir}/package.json"
+current_step="reading ${package} package manifest"
+print_step "Reading ${package} package metadata"
+version=$(node -p "require(process.argv[1]).version" "${package_manifest}")
+print_success "Loaded ${package_scope}@${version}"
+
+current_step="building ${package} release artifacts"
+print_step "Building ${package} release artifacts"
+run_quiet_step \
+  "Building ${package} release artifacts failed" \
+  "${build_command[@]}"
+print_success "Built ${package} release artifacts"
+
+zip_name=''
+zip_path=''
+
+# Stage assets outside the package tree before running npm pack.
+# CI showed the toolkit zip existed immediately after build but later vanished
+# when the workflow tried to rediscover it from dist/, so downstream steps
+# should only read from the staged copy.
+if [[ "${package}" == 'toolkit' ]]; then
+  current_step='staging toolkit compiled zip'
+  zip_name="ofh-design-system-toolkit-${version}.zip"
+  expected_zip_path="${repo_root}/${package_dir}/dist/${zip_name}"
+  print_step "Staging toolkit compiled zip ${zip_name}"
+
+  if [[ ! -f "${expected_zip_path}" ]]; then
+    print_failure "Missing expected toolkit zip ${expected_zip_path}"
+    list_directory "${repo_root}/${package_dir}/dist"
+    exit 1
+  fi
+
+  cp "${expected_zip_path}" "${stage_dir}/${zip_name}"
+  zip_path="${stage_dir}/${zip_name}"
+
+  if [[ ! -f "${zip_path}" ]]; then
+    print_failure "Failed to stage toolkit zip ${zip_path}"
+    list_directory "${stage_dir}"
+    exit 1
+  fi
+
+  print_success "Staged toolkit zip ${zip_name}"
+fi
+
+current_step="packing ${package} tarball"
+print_step "Packing ${package} tarball into ${stage_dir}"
+pack_output=$(mktemp)
+run_quiet_capture_stdout \
+  "Packing ${package} tarball failed" \
+  "${pack_output}" \
+  npm pack "./${package_dir}" --ignore-scripts --json --pack-destination "${stage_dir}"
+
+tarball_name=$(node - <<'NODE' "${pack_output}"
+const fs = require('fs');
+const outputPath = process.argv[2];
+const raw = fs.readFileSync(outputPath, 'utf8');
+const parsed = JSON.parse(raw);
+
+if (!Array.isArray(parsed) || parsed.length === 0 || typeof parsed[0].filename !== 'string') {
+  console.error('npm pack did not return a tarball filename in JSON output');
+  process.exit(1);
+}
+
+process.stdout.write(parsed[0].filename);
+NODE
+)
+
+tarball_path="${stage_dir}/${tarball_name}"
+if [[ ! -f "${tarball_path}" ]]; then
+  print_failure "Missing staged tarball ${tarball_path}"
+  list_directory "${stage_dir}"
+  exit 1
+fi
+
+print_success "Staged tarball ${tarball_name}"
+
+write_output 'PACKAGE' "${package}"
+write_output 'PACKAGE_DIR' "${repo_root}/${package_dir}"
+write_output 'VERSION' "${version}"
+write_output 'STAGE_DIR' "${stage_dir}"
+write_output 'TARBALL_NAME' "${tarball_name}"
+write_output 'TARBALL_PATH' "${tarball_path}"
+
+if [[ "${package}" == 'toolkit' ]]; then
+  write_output 'ZIP_NAME' "${zip_name}"
+  write_output 'ZIP_PATH' "${zip_path}"
+fi
+
+printf '\nPrepared release assets:\n'
+printf '  package: %s\n' "${package}"
+printf '  version: %s\n' "${version}"
+printf '  stage dir: %s\n' "${stage_dir}"
+printf '  tarball: %s\n' "${tarball_path}"
+if [[ "${package}" == 'toolkit' ]]; then
+  printf '  zip: %s\n' "${zip_path}"
+fi

--- a/scripts/release/prepare-release-artifacts.sh
+++ b/scripts/release/prepare-release-artifacts.sh
@@ -77,13 +77,19 @@ run_quiet_capture_stdout() {
 write_output() {
   local key=$1
   local value=$2
+  local delimiter
 
   if [[ -n "${metadata_file}" ]]; then
     printf '%s=%q\n' "${key}" "${value}" >> "${metadata_file}"
   fi
 
   if [[ -n "${github_output}" ]]; then
-    printf '%s=%s\n' "${key}" "${value}" >> "${github_output}"
+    delimiter="OFH_RELEASE_OUTPUT_${key}"
+    {
+      printf '%s<<%s\n' "${key}" "${delimiter}"
+      printf '%s\n' "${value}"
+      printf '%s\n' "${delimiter}"
+    } >> "${github_output}"
   fi
 }
 
@@ -230,14 +236,30 @@ tarball_name=$(node - <<'NODE' "${pack_output}"
 const fs = require('fs');
 const outputPath = process.argv[2];
 const raw = fs.readFileSync(outputPath, 'utf8');
-const parsed = JSON.parse(raw);
+const candidateStarts = [];
 
-if (!Array.isArray(parsed) || parsed.length === 0 || typeof parsed[0].filename !== 'string') {
-  console.error('npm pack did not return a tarball filename in JSON output');
-  process.exit(1);
+for (let index = 0; index < raw.length; index += 1) {
+  const char = raw[index];
+  if (char === '[' || char === '{') {
+    candidateStarts.push(index);
+  }
 }
 
-process.stdout.write(parsed[0].filename);
+for (const start of candidateStarts) {
+  try {
+    const parsed = JSON.parse(raw.slice(start).trim());
+
+    if (Array.isArray(parsed) && parsed.length > 0 && typeof parsed[0].filename === 'string') {
+      process.stdout.write(parsed[0].filename);
+      process.exit(0);
+    }
+  } catch (error) {
+    // Keep scanning in case npm mixed lifecycle logs into stdout before the JSON payload.
+  }
+}
+
+console.error('npm pack did not return a tarball filename in JSON output');
+process.exit(1);
 NODE
 )
 

--- a/scripts/release/render-release-notes.sh
+++ b/scripts/release/render-release-notes.sh
@@ -98,8 +98,12 @@ NODE
 
 case "$package" in
   toolkit)
+    if [[ -z "${zip_asset}" ]]; then
+      echo 'Toolkit release notes require a compiled zip asset via --zip.' >&2
+      exit 1
+    fi
     current_step='emitting toolkit release notes'
-    log_step "Emitting toolkit release notes with tarball ${tarball}"
+    log_step "Emitting toolkit release notes with tarball ${tarball} and zip ${zip_asset}"
     cat <<EOF
 Release of **toolkit** version ${version}
 

--- a/scripts/release/smoke-current-release-artifacts.sh
+++ b/scripts/release/smoke-current-release-artifacts.sh
@@ -18,23 +18,6 @@ print_success() {
   printf ' ✓ %s\n' "$1"
 }
 
-run_quiet_step() {
-  local description=$1
-  shift
-
-  local log_file
-  log_file=$(mktemp)
-  cleanup_files+=("${log_file}")
-
-  if "$@" >"${log_file}" 2>&1; then
-    return 0
-  fi
-
-  printf '\n✗ %s\n' "${description}" >&2
-  cat "${log_file}" >&2
-  return 1
-}
-
 on_error() {
   printf 'Smoke testing current release artifacts failed while %s.\n' "${current_step}" >&2
 }
@@ -69,10 +52,15 @@ while [[ $# -gt 0 ]]; do
 done
 
 cleanup_files=()
+cleanup_dirs=()
 
 cleanup() {
   if [[ ${#cleanup_files[@]} -gt 0 ]]; then
     rm -f "${cleanup_files[@]}"
+  fi
+
+  if [[ ${#cleanup_dirs[@]} -gt 0 ]]; then
+    rm -rf "${cleanup_dirs[@]}"
   fi
 }
 
@@ -84,50 +72,49 @@ print_summary() {
   printf '    package managers: %s\n' "${managers}"
 }
 
+load_prepared_artifacts() {
+  local package_name=$1
+  local metadata_file
+  local stage_dir
+
+  metadata_file=$(mktemp)
+  stage_dir=$(mktemp -d)
+  cleanup_files+=("${metadata_file}")
+  cleanup_dirs+=("${stage_dir}")
+
+  current_step="preparing ${package_name} release artifacts"
+  print_step "Preparing ${package_name} release artifacts"
+  "${repo_root}/scripts/release/prepare-release-artifacts.sh" \
+    "${package_name}" \
+    --stage-dir "${stage_dir}" \
+    --metadata-file "${metadata_file}"
+  # shellcheck disable=SC1090
+  source "${metadata_file}"
+  print_success "Prepared ${package_name} release artifacts"
+}
+
 if [[ "${package_scope}" == 'toolkit' || "${package_scope}" == 'all' ]]; then
   print_summary 'toolkit'
-  current_step='building toolkit release artifacts'
-  print_step 'Building toolkit compiled artifacts with pnpm'
-  run_quiet_step \
-    'Building toolkit compiled artifacts failed' \
-    pnpm --filter=@ourfuturehealth/toolkit run zip
-  print_success 'Built toolkit compiled artifacts'
-
-  current_step='packing toolkit tarball'
-  print_step 'Packing toolkit tarball with npm pack'
-  toolkit_tarball=$(npm pack ./packages/toolkit --ignore-scripts | tail -n 1)
-  print_success "Created toolkit tarball ${toolkit_tarball}"
-  cleanup_files+=("${toolkit_tarball}")
+  load_prepared_artifacts 'toolkit'
 
   current_step='smoke testing toolkit tarball'
   print_step "Running toolkit tarball smoke test against ${managers}"
   "${repo_root}/scripts/release/smoke-package-tarball.sh" \
-    --package-dir "${repo_root}/packages/toolkit" \
-    --tarball "${repo_root}/${toolkit_tarball}" \
+    --package-dir "${PACKAGE_DIR}" \
+    --tarball "${TARBALL_PATH}" \
     --managers "${managers}"
   print_success 'Toolkit tarball smoke test passed'
 fi
 
 if [[ "${package_scope}" == 'react-components' || "${package_scope}" == 'all' ]]; then
   print_summary 'react-components'
-  current_step='building react-components release artifacts'
-  print_step 'Building react-components library with pnpm'
-  run_quiet_step \
-    'Building react-components release artifacts failed' \
-    pnpm --filter=@ourfuturehealth/react-components run build
-  print_success 'Built react-components library'
-
-  current_step='packing react-components tarball'
-  print_step 'Packing react-components tarball with npm pack'
-  react_tarball=$(npm pack ./packages/react-components --ignore-scripts | tail -n 1)
-  print_success "Created react-components tarball ${react_tarball}"
-  cleanup_files+=("${react_tarball}")
+  load_prepared_artifacts 'react-components'
 
   current_step='smoke testing react-components tarball'
   print_step "Running react-components tarball smoke test against ${managers}"
   "${repo_root}/scripts/release/smoke-package-tarball.sh" \
-    --package-dir "${repo_root}/packages/react-components" \
-    --tarball "${repo_root}/${react_tarball}" \
+    --package-dir "${PACKAGE_DIR}" \
+    --tarball "${TARBALL_PATH}" \
     --managers "${managers}"
   print_success 'React-components tarball smoke test passed'
 fi

--- a/scripts/release/smoke-current-release-artifacts.sh
+++ b/scripts/release/smoke-current-release-artifacts.sh
@@ -90,6 +90,17 @@ load_prepared_artifacts() {
     --metadata-file "${metadata_file}"
   # shellcheck disable=SC1090
   source "${metadata_file}"
+
+  if [[ -z "${PACKAGE_DIR:-}" ]]; then
+    printf 'Missing required metadata variable: PACKAGE_DIR\n' >&2
+    exit 1
+  fi
+
+  if [[ -z "${TARBALL_PATH:-}" ]]; then
+    printf 'Missing required metadata variable: TARBALL_PATH\n' >&2
+    exit 1
+  fi
+
   print_success "Prepared ${package_name} release artifacts"
 }
 


### PR DESCRIPTION
## Description

This PR hardens the release flow for `toolkit` and `react-components` so a tag push is no longer the first place we discover missing release assets.

It is based on the failures we saw on:
- `toolkit-v4.8.0`
- `toolkit-v4.9.0`

In both cases, the toolkit release entry was created, but the compiled zip and tarball were not uploaded correctly. The React releases for the same merged commits succeeded, which made the issue look inconsistent until we traced it back to the toolkit-only zip handling.

## What Was Broken

The old workflow did this for toolkit releases:
1. build the toolkit zip
2. pack the package tarball
3. rediscover the zip later from `packages/toolkit/dist/`
4. render release notes and upload assets

In CI, step 1 succeeded, but step 3 sometimes returned nothing.

That produced this bad chain of behavior:
- toolkit asset lookup resolved to an empty string
- release notes rendered with `--zip ""`
- the GitHub release was created anyway
- zip upload then failed with an empty path
- tarball upload was skipped after that

That is why `toolkit-v4.8.0` and `toolkit-v4.9.0` both ended up needing manual repair.

## Root Cause

The workflow was relying on the package working tree still containing the expected toolkit zip after later packaging steps had already run.

The important point is that we do not need a perfect reproduction of why CI lost sight of the zip. We already have enough evidence to harden the flow safely:
- CI logs showed toolkit `createZip` completed successfully
- later in the same job, the zip could not be found again from `packages/toolkit/dist/`
- local reproduction did not show the same disappearance
- local and CI npm versions differed

So the real fix is to stop treating the package working tree as the durable source of release assets after build time.

## What This PR Changes

### 1. Adds a shared release-asset preparation script

New script:
- `scripts/release/prepare-release-artifacts.sh`

It now becomes the single source of truth for release assets.

It:
- accepts `toolkit` or `react-components`
- reads the package version from `package.json`
- builds the package
- stages release assets into a dedicated directory outside the package tree
- emits exact names and absolute paths for downstream workflow steps

For toolkit it stages both:
- `ofh-design-system-toolkit-<version>.zip`
- `ourfuturehealth-toolkit-<version>.tgz`

For React it stages:
- `ourfuturehealth-react-components-<version>.tgz`

### 2. Updates the tag-driven release workflow to use staged assets

Updated workflow:
- `.github/workflows/release.yml`

The old split steps for:
- building release artifacts
- packing the tarball
- rediscovering toolkit zip details

are replaced by a single `Prepare release assets` step.

From that point on, the workflow uses staged outputs for:
- tarball smoke testing
- toolkit release note rendering
- toolkit zip upload
- package tarball upload

This means the workflow no longer depends on `packages/toolkit/dist/` still being in the right state later in the job.

### 3. Makes toolkit release notes fail if zip metadata is missing

Updated script:
- `scripts/release/render-release-notes.sh`

Toolkit release notes now require a compiled zip name. They can no longer silently render a broken "Compiled Files" section with an empty value.

### 4. Reuses the same preparation path in PR validation

Updated:
- `scripts/release/smoke-current-release-artifacts.sh`
- `.github/workflows/release-contract.yml`

`pnpm smoke:release-artifacts` now uses the same staged-asset preparation path as the release workflow.

That matters because we want PR validation to exercise the same artifact handoff that production releases rely on.

The release-contract workflow trigger coverage was also widened so release infrastructure changes are more likely to be validated before merge.

### 5. Documents the release-asset staging model

Updated:
- `docs/release-process.md`

This now explains both:
- how release assets are prepared
- why the workflow deliberately stages them outside the package tree

## Validation

Ran locally:
- direct toolkit asset preparation via `prepare-release-artifacts.sh`
- direct react asset preparation via `prepare-release-artifacts.sh`
- toolkit release-note rendering failure case without `--zip`
- `pnpm docs:release-contract`
- `pnpm smoke:release-artifacts`

## Notes

This PR prevents the release bug from recurring.
It does not try to backfill historical releases, since the broken `toolkit-v4.8.0` and `toolkit-v4.9.0` entries were already repaired manually.
