### PR TITLE
Fix docs container gutters across mid-width breakpoints

### DIFF
--- a/packages/site/styles/app/_container.scss
+++ b/packages/site/styles/app/_container.scss
@@ -7,12 +7,9 @@ $app-container-size: 1280px;
 
 .app-width-container,
 .app-breadcrumb .ofh-width-container {
-  margin: 0 $ofh-size-16;
-  max-width: $app-container-size;
+  @include ofh-responsive-margin(32, 'horizontal');
 
-  @include govuk-media-query($from: desktop) {
-    margin: 0 $ofh-size-32;
-  }
+  max-width: $app-container-size;
 
   @include govuk-media-query($and: '(min-width: #{($app-container-size + $ofh-size-32 * 2)})') {
     margin: 0 auto;

--- a/packages/site/styles/app/_container.scss
+++ b/packages/site/styles/app/_container.scss
@@ -7,10 +7,15 @@ $app-container-size: 1280px;
 
 .app-width-container,
 .app-breadcrumb .ofh-width-container {
+  margin: 0 $ofh-size-16;
   max-width: $app-container-size;
 
-  @media (width >= 767px) and (width <= 1164px) {
+  @include govuk-media-query($from: desktop) {
     margin: 0 $ofh-size-32;
+  }
+
+  @include govuk-media-query($and: '(min-width: #{($app-container-size + $ofh-size-32 * 2)})') {
+    margin: 0 auto;
   }
 }
 


### PR DESCRIPTION
## What was found
The docs page container lost its side gutters across mid-width viewports, so the content could sit flush against the viewport edges.

## Why it happened
The docs site increased the container max width to `1280px`, but the gutter handoff logic still matched the older container behavior. That mismatch stopped the fixed gutters too early.

## How it was fixed
Use the responsive horizontal margin helper on the docs container and keep `margin: auto` only once the `1280px` container plus gutters fully fits. This restores consistent gutters across the affected range.

How it was vs how it was fixed:
<img width="1800" height="1100" alt="comparison-1200" src="https://github.com/user-attachments/assets/8dd02a49-7662-4363-b619-6059cbc48f6b" />

