### PR TITLE
DSE-326 / DSE-328 :: Details and Expander FE update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,28 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ## Monorepo Package Releases (`toolkit-v*`, `react-v*`)
 
-### 2026-04-09
+### 2026-04-20
+
+#### @ourfuturehealth/toolkit 4.11.0 (`toolkit-v4.11.0`)
+
+##### Changed
+
+- Refreshed the toolkit `details` and `expander` components to match the current Figma treatment for icon states, responsive spacing, and revealed-content layout
+- Corrected the open `details` content-rule alignment so the left rule sits on the intended inset edge
+- Expanded the docs-site coverage for `details` with a rich-content example and refreshed the component-page metadata for the details family
+
+#### @ourfuturehealth/react-components 0.10.0 (`react-v0.10.0`)
+
+##### Added
+
+- First public React `Details` and `Expander` components using the shared details-family renderer
+- Storybook docs, grouped expander coverage, and unit tests for the React details family
+
+##### Changed
+
+- Aligned the React details-family icon names and teaching copy with the current toolkit and docs-site surfaces
+
+### 2026-04-17
 
 #### @ourfuturehealth/toolkit 4.10.0 (`toolkit-v4.10.0`)
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,13 +6,14 @@ This guide provides detailed migration instructions for upgrading between versio
 
 ## Breaking Changes by Version
 
-| Version                                                 | Date          | Breaking Changes           | Migration Complexity                     |
-| ------------------------------------------------------- | ------------- | -------------------------- | ---------------------------------------- |
+| Version                                                 | Date          | Breaking Changes      | Migration Complexity                  |
+| ------------------------------------------------------- | ------------- | --------------------- | ------------------------------------- |
+| [v4.11.0 / React v0.10.0](#upgrading-to-v4110--react-v0100) | April 2026    | No breaking changes | 🟢 Low - adopt the public React details family if needed |
 | [v4.10.0 / React v0.9.0](#upgrading-to-v4100--react-v090) | April 2026    | React `spritePath` removal | 🟢 Low - Remove the deprecated prop and adopt canonical names for new usage |
-| [v4.9.0 / React v0.7.0](#upgrading-to-v490--react-v070) | April 2026    | Icon naming sync           | 🟡 Medium - Search/replace icon names    |
-| [v4.8.0 / React v0.6.0](#upgrading-to-v480--react-v060) | March 2026    | No breaking changes        | 🟢 Low - only relevant if you adopted the earlier TextInput prototype |
-| [v4.7.0 / React v0.5.0](#upgrading-to-v470--react-v050) | March 2026    | Card family realignment    | 🟡 Medium - API migration recommended    |
-| [v4.6.0 / React v0.4.0](#upgrading-to-v460--react-v040) | March 2026    | Tag default + naming       | 🟡 Medium - Search/replace recommended   |
+| [v4.9.0 / React v0.7.0](#upgrading-to-v490--react-v070) | April 2026    | Icon naming sync    | 🟡 Medium - Search/replace icon names  |
+| [v4.8.0 / React v0.6.0](#upgrading-to-v480--react-v060) | March 2026    | No breaking changes | 🟢 Low - only relevant if you adopted the earlier TextInput prototype |
+| [v4.7.0 / React v0.5.0](#upgrading-to-v470--react-v050) | March 2026    | Card family realignment | 🟡 Medium - API migration recommended |
+| [v4.6.0 / React v0.4.0](#upgrading-to-v460--react-v040) | March 2026    | Tag default + naming  | 🟡 Medium - Search/replace recommended |
 | [v4.5.0](#upgrading-to-v450)                            | March 2026    | Spacing and typography API changes | 🟡 Medium - Replace legacy APIs and recheck overrides |
 | [v4.3.0 / React v0.2.0](#upgrading-to-v430--react-v020) | March 2026    | Button variant naming      | 🟡 Medium - Find/replace required        |
 | [v4.1.0](#upgrading-to-v410)                            | February 2026 | Spacing scale indices      | 🟡 Medium - Index updates required       |
@@ -20,9 +21,46 @@ This guide provides detailed migration instructions for upgrading between versio
 
 ---
 
+## Upgrading to v4.11.0 / React v0.10.0
+
+**Released:** April 2026
+**Affected packages:**
+
+- `@ourfuturehealth/toolkit` v4.11.0+
+- `@ourfuturehealth/react-components` v0.10.0+
+
+### Breaking Changes
+
+None.
+
+### Release Overview
+
+This release refreshes the toolkit `details` and `expander` components to the current Figma treatment and introduces the first public React `Details` and `Expander` components.
+
+No supported API migration is required for existing toolkit consumers.
+
+React consumers can now adopt the public details family instead of carrying local disclosure implementations.
+
+### Migration Steps
+
+1. Re-run visual QA for the toolkit details family, especially open-state spacing, icon states, and revealed content layout.
+2. If you want React parity, adopt the new public `Details` and `Expander` components.
+3. Replace local disclosure wrappers with the shared React details family where appropriate.
+
+#### React example
+
+**New in `react-v0.10.0`:**
+
+```tsx
+import {
+  Details,
+  Expander,
+} from '@ourfuturehealth/react-components';
+```
+
 ## Upgrading to v4.10.0 / React v0.9.0
 
-**Planned:** April 2026
+**Released:** April 2026
 **Affected packages:**
 
 - `@ourfuturehealth/toolkit` v4.10.0+

--- a/docs/release-versioning-strategy.md
+++ b/docs/release-versioning-strategy.md
@@ -31,8 +31,8 @@ For consumer migration instructions, use [Upgrading Guide](../UPGRADING.md).
 
 | Package                             | Canonical tag pattern | Example tag      |
 | ----------------------------------- | --------------------- | ---------------- |
-| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.10.0` |
-| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.9.0`   |
+| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.11.0` |
+| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.10.0`  |
 
 The release workflow still accepts legacy toolkit tags in the `v*` format for backward compatibility, but new toolkit releases should use `toolkit-v*`.
 
@@ -60,7 +60,7 @@ Consumers must install the package release tarball:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/toolkit": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/toolkit-v4.10.0/ourfuturehealth-toolkit-4.10.0.tgz"
+    "@ourfuturehealth/toolkit": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/toolkit-v4.11.0/ourfuturehealth-toolkit-4.11.0.tgz"
   }
 }
 ```
@@ -70,7 +70,7 @@ React consumers follow the same contract:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.9.0/ourfuturehealth-react-components-0.9.0.tgz"
+    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.10.0/ourfuturehealth-react-components-0.10.0.tgz"
   }
 }
 ```
@@ -128,8 +128,10 @@ This table is a visual aid for pre-monorepo versus post-monorepo releases.
 | 19    | `react-v0.6.0`   | N/A             | `0.6.0`       | Monorepo       | Released               |
 | 20    | `toolkit-v4.9.0` | `4.9.0`         | N/A           | Monorepo       | Released               |
 | 21    | `react-v0.7.0`   | N/A             | `0.7.0`       | Monorepo       | Released               |
-| 22    | `toolkit-v4.10.0` | `4.10.0`       | N/A           | Monorepo       | Planned in this branch |
-| 23    | `react-v0.9.0`   | N/A             | `0.9.0`       | Monorepo       | Planned in this branch |
+| 22    | `toolkit-v4.10.0` | `4.10.0`       | N/A           | Monorepo       | Released               |
+| 23    | `react-v0.9.0`    | N/A            | `0.9.0`       | Monorepo       | Released               |
+| 24    | `toolkit-v4.11.0` | `4.11.0`       | N/A           | Monorepo       | Released               |
+| 25    | `react-v0.10.0`   | N/A            | `0.10.0`      | Monorepo       | Released               |
 
 ## References
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -9,7 +9,7 @@ Install the packaged GitHub release artifact:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v{version}/ourfuturehealth-react-components-{version}.tgz",
+    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.10.0/ourfuturehealth-react-components-0.10.0.tgz",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   }
@@ -49,7 +49,9 @@ import {
   CharacterCount,
   Checkboxes,
   DateInput,
+  Details,
   ErrorSummary,
+  Expander,
   Fieldset,
   Icon,
   LinkAction,
@@ -87,6 +89,13 @@ function App() {
           },
         ]}
       />
+      <Details summary="Why we ask for this">
+        We use your answers to tailor the information you see next.
+      </Details>
+      <Expander summary="What happens next">
+        We will review your answers and let you know if we need any more
+        information.
+      </Expander>
       <Tag variant="brand">Beta</Tag>
       <Button variant="contained">Click me</Button>
       <Icon name="Search" size={24} />

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/react-components",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "type": "module",
   "description": "React component library for OFH Design System",
   "packageManager": "pnpm@10.29.2",

--- a/packages/react-components/src/components/Details/Details.stories.tsx
+++ b/packages/react-components/src/components/Details/Details.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import { Details } from './Details';
 
 const defaultDetailsCode = `import { Details } from '@ourfuturehealth/react-components';
@@ -29,6 +30,13 @@ const richContentDetailsCode = `import { Details } from '@ourfuturehealth/react-
 </Details>;
 `;
 
+const detailsUsageExample = `import { Details } from '@ourfuturehealth/react-components';
+
+<Details summary="Where can I find my NHS number?">
+  An NHS number is a 10 digit number, like 485 777 3456.
+</Details>;
+`;
+
 const meta: Meta<typeof Details> = {
   title: 'Components/Details',
   component: Details,
@@ -39,6 +47,32 @@ const meta: Meta<typeof Details> = {
         component:
           'Use Details to make a page easier to scan when only some users need supporting information. The React API is intentionally small: `summary` is the clickable label, `open` controls the initial expanded state, and `children` is the content shown inside the disclosure panel. Prefer Expander when the content is more important, aimed at a wider audience, or needs more visual prominence.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Use <code>Details</code> when the disclosure is supporting
+            information that only some users will need. Pass the clickable
+            label through <code>summary</code> and the hidden content through{' '}
+            <code>children</code>.
+          </p>
+          <p>
+            Set <code>open</code> only when the content should be expanded on
+            first render. If the content is more prominent or intended for a
+            wider audience, use <code>Expander</code> instead.
+          </p>
+          <Source code={detailsUsageExample} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes of={Details} exclude={['ref']} />
+
+          <h2>Examples</h2>
+          <Stories title="Examples" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],

--- a/packages/react-components/src/components/Details/Details.stories.tsx
+++ b/packages/react-components/src/components/Details/Details.stories.tsx
@@ -2,14 +2,14 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Details } from './Details';
 
 const meta: Meta<typeof Details> = {
-  title: 'Components/Content presentation/Details',
+  title: 'Components/Details',
   component: Details,
   parameters: {
     layout: 'padded',
     docs: {
       description: {
         component:
-          'Use Details for a small amount of supporting information that is helpful for some users but not most. The React component uses the same shared details family renderer as Expander, but keeps a separate public entry point so consumers can choose the more compact disclosure pattern when they need it.',
+          'Use Details to make a page easier to scan when only some users need the supporting information. Prefer Expander when the content is more important, aimed at a wider audience, or needs more visual prominence.',
       },
     },
   },

--- a/packages/react-components/src/components/Details/Details.stories.tsx
+++ b/packages/react-components/src/components/Details/Details.stories.tsx
@@ -1,0 +1,117 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Details } from './Details';
+
+const meta: Meta<typeof Details> = {
+  title: 'Components/Content presentation/Details',
+  component: Details,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Use Details for a small amount of supporting information that is helpful for some users but not most. The React component uses the same shared details family renderer as Expander, but keeps a separate public entry point so consumers can choose the more compact disclosure pattern when they need it.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    summary: 'Where can I find my NHS number?',
+    open: false,
+  },
+  argTypes: {
+    summary: {
+      control: 'text',
+      description: 'Summary text shown in the clickable header.',
+    },
+    open: {
+      control: 'boolean',
+      description: 'Sets the native `<details open>` state.',
+    },
+    children: {
+      control: false,
+      description: 'Content shown when the details element is expanded.',
+    },
+    className: {
+      control: false,
+      description:
+        'Additional classes added to the root `<details>` element for layout or integration hooks.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+    ref: {
+      control: false,
+      description: 'React ref for the underlying `<details>` element.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <Details {...args}>
+      <p>
+        An NHS number is a 10 digit number, like 485 777 3456.
+      </p>
+      <p>
+        You can find your NHS number on any document sent to you by the NHS.
+      </p>
+    </Details>
+  ),
+};
+
+export const Open: Story = {
+  args: {
+    open: true,
+    summary: 'Where can I find my NHS number?',
+  },
+  render: (args) => (
+    <Details {...args}>
+      <p>
+        An NHS number is a 10 digit number, like 485 777 3456.
+      </p>
+      <p>
+        You can find your NHS number on any document sent to you by the NHS.
+      </p>
+    </Details>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Open state example for the details variant. Use this when you want the disclosure pre-expanded on first render.',
+      },
+    },
+  },
+};
+
+export const WithRichContent: Story = {
+  render: () => (
+    <Details summary="What can I use my NHS number for?">
+      <p>
+        The number helps different NHS services match your records correctly.
+      </p>
+      <ul>
+        <li>book appointments</li>
+        <li>view test results</li>
+        <li>share records between services</li>
+      </ul>
+    </Details>
+  ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'Example content with paragraphs and a list. The component keeps the summary compact while still supporting richer disclosure content below it.',
+      },
+    },
+  },
+};

--- a/packages/react-components/src/components/Details/Details.stories.tsx
+++ b/packages/react-components/src/components/Details/Details.stories.tsx
@@ -1,6 +1,34 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Details } from './Details';
 
+const defaultDetailsCode = `import { Details } from '@ourfuturehealth/react-components';
+
+<Details summary="Where can I find my NHS number?">
+  An NHS number is a 10 digit number, like 485 777 3456.
+</Details>;
+`;
+
+const openDetailsCode = `import { Details } from '@ourfuturehealth/react-components';
+
+<Details summary="Where can I find my NHS number?" open>
+  An NHS number is a 10 digit number, like 485 777 3456.
+</Details>;
+`;
+
+const richContentDetailsCode = `import { Details } from '@ourfuturehealth/react-components';
+
+<Details summary="What can I use my NHS number for?">
+  <p>
+    The number helps different NHS services match your records correctly.
+  </p>
+  <ul>
+    <li>book appointments</li>
+    <li>view test results</li>
+    <li>share records between services</li>
+  </ul>
+</Details>;
+`;
+
 const meta: Meta<typeof Details> = {
   title: 'Components/Details',
   component: Details,
@@ -9,7 +37,7 @@ const meta: Meta<typeof Details> = {
     docs: {
       description: {
         component:
-          'Use Details to make a page easier to scan when only some users need the supporting information. Prefer Expander when the content is more important, aimed at a wider audience, or needs more visual prominence.',
+          'Use Details to make a page easier to scan when only some users need supporting information. The React API is intentionally small: `summary` is the clickable label, `open` controls the initial expanded state, and `children` is the content shown inside the disclosure panel. Prefer Expander when the content is more important, aimed at a wider audience, or needs more visual prominence.',
       },
     },
   },
@@ -17,31 +45,36 @@ const meta: Meta<typeof Details> = {
   args: {
     summary: 'Where can I find my NHS number?',
     open: false,
+    children: 'An NHS number is a 10 digit number, like 485 777 3456.',
   },
   argTypes: {
     summary: {
       control: 'text',
-      description: 'Summary text shown in the clickable header.',
+      description:
+        'Clickable label shown in the closed state. Keep it short and descriptive so users know what the disclosure contains.',
     },
     open: {
       control: 'boolean',
-      description: 'Sets the native `<details open>` state.',
+      description:
+        'Opens the disclosure on first render. Use this when the supporting content is important enough to show immediately.',
     },
     children: {
-      control: false,
-      description: 'Content shown when the details element is expanded.',
+      control: 'text',
+      description:
+        'Content shown inside the disclosure panel after the summary. This can be plain text or richer React content.',
     },
     className: {
       control: false,
       description:
-        'Additional classes added to the root `<details>` element for layout or integration hooks.',
+        'Additional classes added to the root `<details>` element. Use this for layout or integration hooks, not to change the built-in Details behaviour.',
       table: {
         category: 'Advanced',
       },
     },
     ref: {
       control: false,
-      description: 'React ref for the underlying `<details>` element.',
+      description:
+        'React ref for the underlying `<details>` element when you need direct DOM access.',
       table: {
         category: 'Advanced',
       },
@@ -53,44 +86,73 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  render: (args) => (
-    <Details {...args}>
-      <p>
-        An NHS number is a 10 digit number, like 485 777 3456.
-      </p>
-      <p>
-        You can find your NHS number on any document sent to you by the NHS.
-      </p>
-    </Details>
-  ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      source: {
+        code: defaultDetailsCode,
+      },
+      description: {
+        story:
+          'A realistic collapsed Details example with short, plain text content inside the disclosure panel.',
+      },
+    },
+  },
+};
+
+export const Builder: Story = {
+  parameters: {
+    controls: {
+      include: ['summary', 'open', 'children'],
+    },
+    docs: {
+      description: {
+        story:
+          'Interactive builder story. Use the real `summary`, `open`, and `children` props to explore the component without switching to raw JSON editing.',
+      },
+    },
+  },
 };
 
 export const Open: Story = {
   args: {
     open: true,
     summary: 'Where can I find my NHS number?',
+    children: 'An NHS number is a 10 digit number, like 485 777 3456.',
   },
-  render: (args) => (
-    <Details {...args}>
-      <p>
-        An NHS number is a 10 digit number, like 485 777 3456.
-      </p>
-      <p>
-        You can find your NHS number on any document sent to you by the NHS.
-      </p>
-    </Details>
-  ),
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
+      source: {
+        code: openDetailsCode,
+      },
       description: {
         story:
-          'Open state example for the details variant. Use this when you want the disclosure pre-expanded on first render.',
+          'Open state example for the Details variant. Use this when you want the disclosure pre-expanded on first render.',
       },
     },
   },
 };
 
 export const WithRichContent: Story = {
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      source: {
+        code: richContentDetailsCode,
+      },
+      description: {
+        story:
+          'Example content with paragraphs and a list. The component keeps the summary compact while still supporting richer disclosure content below it.',
+      },
+    },
+  },
   render: () => (
     <Details summary="What can I use my NHS number for?">
       <p>
@@ -103,15 +165,4 @@ export const WithRichContent: Story = {
       </ul>
     </Details>
   ),
-  parameters: {
-    controls: {
-      disable: true,
-    },
-    docs: {
-      description: {
-        story:
-          'Example content with paragraphs and a list. The component keeps the summary compact while still supporting richer disclosure content below it.',
-      },
-    },
-  },
 };

--- a/packages/react-components/src/components/Details/Details.test.tsx
+++ b/packages/react-components/src/components/Details/Details.test.tsx
@@ -1,0 +1,57 @@
+import { createRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import { axe } from 'vitest-axe';
+import { describe, expect, it } from 'vitest';
+import { Details } from './Details';
+
+describe('Details', () => {
+  it('renders the compact disclosure summary icons and content panel', () => {
+    const { container } = render(
+      <Details summary="Where can I find my NHS number?">
+        <p>Example content</p>
+      </Details>,
+    );
+
+    expect(screen.getByText('Where can I find my NHS number?')).toHaveClass(
+      'ofh-details__summary-text',
+    );
+    expect(container.querySelector('.ofh-details')).toBeInTheDocument();
+    expect(container.querySelector('.ofh-details__summary--details')).toBeInTheDocument();
+    expect(container.querySelector('.ofh-icon--ChevronRight')).toBeInTheDocument();
+    expect(container.querySelector('.ofh-icon--ExpandMore')).toBeInTheDocument();
+    expect(container.querySelector('.ofh-details__panel--details')).toBeInTheDocument();
+  });
+
+  it('forwards standard details attributes and refs', () => {
+    const ref = createRef<HTMLDetailsElement>();
+
+    render(
+      <Details
+        ref={ref}
+        summary="Status"
+        data-testid="details-root"
+        open
+      >
+        <p>Open content</p>
+      </Details>,
+    );
+
+    const details = screen.getByTestId('details-root');
+
+    expect(details).toHaveAttribute('open');
+    expect(ref.current).toBeInstanceOf(HTMLDetailsElement);
+    expect(ref.current).toHaveClass('ofh-details');
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <Details summary="More information">
+        <p>Helpful content</p>
+      </Details>,
+    );
+
+    const results = await axe(container);
+
+    expect(results.violations).toHaveLength(0);
+  });
+});

--- a/packages/react-components/src/components/Details/Details.test.tsx
+++ b/packages/react-components/src/components/Details/Details.test.tsx
@@ -18,7 +18,7 @@ describe('Details', () => {
     expect(container.querySelector('.ofh-details')).toBeInTheDocument();
     expect(container.querySelector('.ofh-details__summary--details')).toBeInTheDocument();
     expect(container.querySelector('.ofh-icon--ChevronRight')).toBeInTheDocument();
-    expect(container.querySelector('.ofh-icon--ExpandMore')).toBeInTheDocument();
+    expect(container.querySelector('.ofh-icon--ChevronDown')).toBeInTheDocument();
     expect(container.querySelector('.ofh-details__panel--details')).toBeInTheDocument();
   });
 

--- a/packages/react-components/src/components/Details/Details.tsx
+++ b/packages/react-components/src/components/Details/Details.tsx
@@ -1,0 +1,15 @@
+import {
+  DetailsFamilyBase,
+  type DetailsFamilyProps,
+} from '../_internal/DetailsFamily';
+
+export type DetailsProps = DetailsFamilyProps;
+
+export const Details = (props: DetailsProps) => (
+  <DetailsFamilyBase
+    {...props}
+    variant="details"
+  />
+);
+
+Details.displayName = 'Details';

--- a/packages/react-components/src/components/Details/index.ts
+++ b/packages/react-components/src/components/Details/index.ts
@@ -1,0 +1,2 @@
+export { Details } from './Details';
+export type { DetailsProps } from './Details';

--- a/packages/react-components/src/components/Expander/Expander.stories.tsx
+++ b/packages/react-components/src/components/Expander/Expander.stories.tsx
@@ -1,0 +1,111 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Expander } from './Expander';
+
+const meta: Meta<typeof Expander> = {
+  title: 'Components/Content presentation/Expander',
+  component: Expander,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Use Expander for larger blocks of content that deserve more visual prominence than Details. It uses the same shared internal renderer but keeps a separate public export so the semantic difference stays clear in consumer code and in the docs.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    summary: 'Opening times',
+    open: false,
+  },
+  argTypes: {
+    summary: {
+      control: 'text',
+      description: 'Summary text shown in the clickable header.',
+    },
+    open: {
+      control: 'boolean',
+      description: 'Sets the native `<details open>` state.',
+    },
+    children: {
+      control: false,
+      description: 'Content shown when the expander is expanded.',
+    },
+    className: {
+      control: false,
+      description:
+        'Additional classes added to the root `<details>` element for layout or integration hooks.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+    ref: {
+      control: false,
+      description: 'React ref for the underlying `<details>` element.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <Expander {...args}>
+      <p>
+        We are open Monday to Friday, 9am to 6pm.
+      </p>
+      <p>Saturday appointments are limited.</p>
+    </Expander>
+  ),
+};
+
+export const Open: Story = {
+  args: {
+    open: true,
+    summary: 'Opening times',
+  },
+  render: (args) => (
+    <Expander {...args}>
+      <p>
+        We are open Monday to Friday, 9am to 6pm.
+      </p>
+      <p>Saturday appointments are limited.</p>
+    </Expander>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Open state example for the expander variant. The icon switches to the remove-circle glyph and the content panel becomes visible immediately.',
+      },
+    },
+  },
+};
+
+export const WithRichContent: Story = {
+  render: () => (
+    <Expander summary="What do I need to bring?">
+      <p>Bring any documents we have asked for in your appointment letter.</p>
+      <ul>
+        <li>photo ID</li>
+        <li>your NHS number if you know it</li>
+        <li>any relevant medical documents</li>
+      </ul>
+    </Expander>
+  ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'Example content for the expander variant. Use it for broader, more prominent disclosures that need more visual weight than the details pattern.',
+      },
+    },
+  },
+};

--- a/packages/react-components/src/components/Expander/Expander.stories.tsx
+++ b/packages/react-components/src/components/Expander/Expander.stories.tsx
@@ -123,7 +123,7 @@ export const Grouped: Story = {
     },
   },
   render: () => (
-    <div style={{ display: 'grid', gap: '0.75rem', maxWidth: '42rem' }}>
+    <div className="ofh-expander-group" style={{ maxWidth: '42rem' }}>
       <Expander summary="How to measure your blood glucose levels">
         <p>
           Wash your hands and use the blood glucose monitor as described in

--- a/packages/react-components/src/components/Expander/Expander.stories.tsx
+++ b/packages/react-components/src/components/Expander/Expander.stories.tsx
@@ -1,6 +1,46 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Expander } from './Expander';
 
+const defaultExpanderCode = `import { Expander } from '@ourfuturehealth/react-components';
+
+<Expander summary="Opening times">
+  We are open Monday to Friday, 9am to 6pm.
+</Expander>;
+`;
+
+const openExpanderCode = `import { Expander } from '@ourfuturehealth/react-components';
+
+<Expander summary="Opening times" open>
+  We are open Monday to Friday, 9am to 6pm.
+</Expander>;
+`;
+
+const richContentExpanderCode = `import { Expander } from '@ourfuturehealth/react-components';
+
+<Expander summary="What do I need to bring?">
+  <p>
+    Bring any documents we have asked for in your appointment letter.
+  </p>
+  <ul>
+    <li>photo ID</li>
+    <li>your NHS number if you know it</li>
+    <li>any relevant medical documents</li>
+  </ul>
+</Expander>;
+`;
+
+const groupedExpanderCode = `import { Expander } from '@ourfuturehealth/react-components';
+
+<div className="ofh-expander-group" style={{ maxWidth: '42rem' }}>
+  <Expander summary="How to measure your blood glucose levels">
+    Wash your hands and use the blood glucose monitor as described in your care plan.
+  </Expander>
+  <Expander summary="When to check your blood glucose level">
+    Your care team will tell you when and how often to check your blood glucose level.
+  </Expander>
+</div>;
+`;
+
 const meta: Meta<typeof Expander> = {
   title: 'Components/Expander',
   component: Expander,
@@ -9,7 +49,7 @@ const meta: Meta<typeof Expander> = {
     docs: {
       description: {
         component:
-          'Use Expander when users may feel overwhelmed by the amount of information and need it broken into smaller sections. Prefer Details when only some users need the content and the disclosure should stay visually lighter.',
+          'Use Expander when users may feel overwhelmed by the amount of information and need it broken into smaller sections. The React API is intentionally small: `summary` is the clickable label, `open` controls the initial expanded state, and `children` is the content shown inside the disclosure panel. Prefer Details when only some users need the content and the disclosure should stay visually lighter.',
       },
     },
   },
@@ -17,31 +57,36 @@ const meta: Meta<typeof Expander> = {
   args: {
     summary: 'Opening times',
     open: false,
+    children: 'We are open Monday to Friday, 9am to 6pm.',
   },
   argTypes: {
     summary: {
       control: 'text',
-      description: 'Summary text shown in the clickable header.',
+      description:
+        'Clickable label shown in the closed state. Keep it short and descriptive so users know what the disclosure contains.',
     },
     open: {
       control: 'boolean',
-      description: 'Sets the native `<details open>` state.',
+      description:
+        'Opens the disclosure on first render. Use this when the supporting content is important enough to show immediately.',
     },
     children: {
-      control: false,
-      description: 'Content shown when the expander is expanded.',
+      control: 'text',
+      description:
+        'Content shown inside the disclosure panel after the summary. This can be plain text or richer React content.',
     },
     className: {
       control: false,
       description:
-        'Additional classes added to the root `<details>` element for layout or integration hooks.',
+        'Additional classes added to the root `<details>` element. Use this for layout or integration hooks, not to change the built-in Expander behaviour.',
       table: {
         category: 'Advanced',
       },
     },
     ref: {
       control: false,
-      description: 'React ref for the underlying `<details>` element.',
+      description:
+        'React ref for the underlying `<details>` element when you need direct DOM access.',
       table: {
         category: 'Advanced',
       },
@@ -53,34 +98,53 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  render: (args) => (
-    <Expander {...args}>
-      <p>
-        We are open Monday to Friday, 9am to 6pm.
-      </p>
-      <p>Saturday appointments are limited.</p>
-    </Expander>
-  ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      source: {
+        code: defaultExpanderCode,
+      },
+      description: {
+        story:
+          'A realistic collapsed Expander example with short, plain text content inside the disclosure panel.',
+      },
+    },
+  },
+};
+
+export const Builder: Story = {
+  parameters: {
+    controls: {
+      include: ['summary', 'open', 'children'],
+    },
+    docs: {
+      description: {
+        story:
+          'Interactive builder story. Use the real `summary`, `open`, and `children` props to explore the component without switching to raw JSON editing.',
+      },
+    },
+  },
 };
 
 export const Open: Story = {
   args: {
     open: true,
     summary: 'Opening times',
+    children: 'We are open Monday to Friday, 9am to 6pm.',
   },
-  render: (args) => (
-    <Expander {...args}>
-      <p>
-        We are open Monday to Friday, 9am to 6pm.
-      </p>
-      <p>Saturday appointments are limited.</p>
-    </Expander>
-  ),
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
+      source: {
+        code: openExpanderCode,
+      },
       description: {
         story:
-          'Open state example for the expander variant. The icon switches to the remove-circle glyph and the content panel becomes visible immediately.',
+          'Open state example for the Expander variant. The icon switches to the remove-circle glyph and the content panel becomes visible immediately.',
       },
     },
   },
@@ -102,26 +166,18 @@ export const WithRichContent: Story = {
       disable: true,
     },
     docs: {
+      source: {
+        code: richContentExpanderCode,
+      },
       description: {
         story:
-          'Example content for the expander variant. Use it for broader, more prominent disclosures that need more visual weight than the details pattern.',
+          'Example content for the Expander variant. Use it for broader, more prominent disclosures that need more visual weight than the Details pattern.',
       },
     },
   },
 };
 
 export const Grouped: Story = {
-  parameters: {
-    controls: {
-      disable: true,
-    },
-    docs: {
-      description: {
-        story:
-          'Grouped expanders, matching the docs-site example for pages that need several expandable sections in a row.',
-      },
-    },
-  },
   render: () => (
     <div className="ofh-expander-group" style={{ maxWidth: '42rem' }}>
       <Expander summary="How to measure your blood glucose levels">
@@ -138,4 +194,18 @@ export const Grouped: Story = {
       </Expander>
     </div>
   ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      source: {
+        code: groupedExpanderCode,
+      },
+      description: {
+        story:
+          'Grouped expanders, matching the docs-site example for pages that need several expandable sections in a row.',
+      },
+    },
+  },
 };

--- a/packages/react-components/src/components/Expander/Expander.stories.tsx
+++ b/packages/react-components/src/components/Expander/Expander.stories.tsx
@@ -2,14 +2,14 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Expander } from './Expander';
 
 const meta: Meta<typeof Expander> = {
-  title: 'Components/Content presentation/Expander',
+  title: 'Components/Expander',
   component: Expander,
   parameters: {
     layout: 'padded',
     docs: {
       description: {
         component:
-          'Use Expander for larger blocks of content that deserve more visual prominence than Details. It uses the same shared internal renderer but keeps a separate public export so the semantic difference stays clear in consumer code and in the docs.',
+          'Use Expander when users may feel overwhelmed by the amount of information and need it broken into smaller sections. Prefer Details when only some users need the content and the disclosure should stay visually lighter.',
       },
     },
   },
@@ -108,4 +108,34 @@ export const WithRichContent: Story = {
       },
     },
   },
+};
+
+export const Grouped: Story = {
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'Grouped expanders, matching the docs-site example for pages that need several expandable sections in a row.',
+      },
+    },
+  },
+  render: () => (
+    <div style={{ display: 'grid', gap: '0.75rem', maxWidth: '42rem' }}>
+      <Expander summary="How to measure your blood glucose levels">
+        <p>
+          Wash your hands and use the blood glucose monitor as described in
+          your care plan.
+        </p>
+      </Expander>
+      <Expander summary="When to check your blood glucose level">
+        <p>
+          Your care team will tell you when and how often to check your blood
+          glucose level.
+        </p>
+      </Expander>
+    </div>
+  ),
 };

--- a/packages/react-components/src/components/Expander/Expander.stories.tsx
+++ b/packages/react-components/src/components/Expander/Expander.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import { Expander } from './Expander';
 
 const defaultExpanderCode = `import { Expander } from '@ourfuturehealth/react-components';
@@ -41,6 +42,13 @@ const groupedExpanderCode = `import { Expander } from '@ourfuturehealth/react-co
 </div>;
 `;
 
+const expanderUsageExample = `import { Expander } from '@ourfuturehealth/react-components';
+
+<Expander summary="Opening times">
+  We are open Monday to Friday, 9am to 6pm.
+</Expander>;
+`;
+
 const meta: Meta<typeof Expander> = {
   title: 'Components/Expander',
   component: Expander,
@@ -51,6 +59,32 @@ const meta: Meta<typeof Expander> = {
         component:
           'Use Expander when users may feel overwhelmed by the amount of information and need it broken into smaller sections. The React API is intentionally small: `summary` is the clickable label, `open` controls the initial expanded state, and `children` is the content shown inside the disclosure panel. Prefer Details when only some users need the content and the disclosure should stay visually lighter.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Use <code>Expander</code> when a larger block of information needs
+            to be broken into smaller sections without losing prominence. Pass
+            the clickable label through <code>summary</code> and the disclosure
+            content through <code>children</code>.
+          </p>
+          <p>
+            Set <code>open</code> when the section should be expanded on first
+            render. If the disclosure is lighter-weight supporting information,
+            prefer <code>Details</code>.
+          </p>
+          <Source code={expanderUsageExample} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes of={Expander} exclude={['ref']} />
+
+          <h2>Examples</h2>
+          <Stories title="Examples" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],

--- a/packages/react-components/src/components/Expander/Expander.test.tsx
+++ b/packages/react-components/src/components/Expander/Expander.test.tsx
@@ -19,7 +19,7 @@ describe('Expander', () => {
     expect(container.querySelector('.ofh-expander')).toBeInTheDocument();
     expect(container.querySelector('.ofh-details__summary--expander')).toBeInTheDocument();
     expect(container.querySelector('.ofh-icon--AddCircle')).toBeInTheDocument();
-    expect(container.querySelector('.ofh-icon--RemoveCircle')).toBeInTheDocument();
+    expect(container.querySelector('.ofh-icon--MinusCircle')).toBeInTheDocument();
     expect(container.querySelector('.ofh-details__panel--expander')).toBeInTheDocument();
   });
 

--- a/packages/react-components/src/components/Expander/Expander.test.tsx
+++ b/packages/react-components/src/components/Expander/Expander.test.tsx
@@ -1,0 +1,58 @@
+import { createRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import { axe } from 'vitest-axe';
+import { describe, expect, it } from 'vitest';
+import { Expander } from './Expander';
+
+describe('Expander', () => {
+  it('renders the expanded accordion summary icons and content panel', () => {
+    const { container } = render(
+      <Expander summary="Opening times">
+        <p>Example content</p>
+      </Expander>,
+    );
+
+    expect(screen.getByText('Opening times')).toHaveClass(
+      'ofh-details__summary-text',
+    );
+    expect(container.querySelector('.ofh-details')).toBeInTheDocument();
+    expect(container.querySelector('.ofh-expander')).toBeInTheDocument();
+    expect(container.querySelector('.ofh-details__summary--expander')).toBeInTheDocument();
+    expect(container.querySelector('.ofh-icon--AddCircle')).toBeInTheDocument();
+    expect(container.querySelector('.ofh-icon--RemoveCircle')).toBeInTheDocument();
+    expect(container.querySelector('.ofh-details__panel--expander')).toBeInTheDocument();
+  });
+
+  it('forwards standard details attributes and refs', () => {
+    const ref = createRef<HTMLDetailsElement>();
+
+    render(
+      <Expander
+        ref={ref}
+        summary="Status"
+        data-testid="expander-root"
+        open
+      >
+        <p>Open content</p>
+      </Expander>,
+    );
+
+    const expander = screen.getByTestId('expander-root');
+
+    expect(expander).toHaveAttribute('open');
+    expect(ref.current).toBeInstanceOf(HTMLDetailsElement);
+    expect(ref.current).toHaveClass('ofh-expander');
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <Expander summary="More information">
+        <p>Helpful content</p>
+      </Expander>,
+    );
+
+    const results = await axe(container);
+
+    expect(results.violations).toHaveLength(0);
+  });
+});

--- a/packages/react-components/src/components/Expander/Expander.tsx
+++ b/packages/react-components/src/components/Expander/Expander.tsx
@@ -1,0 +1,15 @@
+import {
+  DetailsFamilyBase,
+  type DetailsFamilyProps,
+} from '../_internal/DetailsFamily';
+
+export type ExpanderProps = DetailsFamilyProps;
+
+export const Expander = (props: ExpanderProps) => (
+  <DetailsFamilyBase
+    {...props}
+    variant="expander"
+  />
+);
+
+Expander.displayName = 'Expander';

--- a/packages/react-components/src/components/Expander/index.ts
+++ b/packages/react-components/src/components/Expander/index.ts
@@ -1,0 +1,2 @@
+export { Expander } from './Expander';
+export type { ExpanderProps } from './Expander';

--- a/packages/react-components/src/components/_internal/DetailsFamily.tsx
+++ b/packages/react-components/src/components/_internal/DetailsFamily.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { Icon } from '../Icon/Icon';
+import { Icon } from '../Icon';
 import { joinClasses } from '../../internal/ofhUtils';
 
 export type DetailsFamilyVariant = 'details' | 'expander';

--- a/packages/react-components/src/components/_internal/DetailsFamily.tsx
+++ b/packages/react-components/src/components/_internal/DetailsFamily.tsx
@@ -13,11 +13,11 @@ const summaryIcons: Record<
 > = {
   details: {
     closed: 'ChevronRight',
-    open: 'ExpandMore',
+    open: 'ChevronDown',
   },
   expander: {
     closed: 'AddCircle',
-    open: 'RemoveCircle',
+    open: 'MinusCircle',
   },
 };
 

--- a/packages/react-components/src/components/_internal/DetailsFamily.tsx
+++ b/packages/react-components/src/components/_internal/DetailsFamily.tsx
@@ -1,0 +1,118 @@
+import type React from 'react';
+import { Icon } from '../Icon/Icon';
+import { joinClasses } from '../../internal/ofhUtils';
+
+export type DetailsFamilyVariant = 'details' | 'expander';
+
+const summaryIcons: Record<
+  DetailsFamilyVariant,
+  {
+    closed: string;
+    open: string;
+  }
+> = {
+  details: {
+    closed: 'ChevronRight',
+    open: 'ExpandMore',
+  },
+  expander: {
+    closed: 'AddCircle',
+    open: 'RemoveCircle',
+  },
+};
+
+export interface DetailsFamilyBaseProps
+  extends Omit<
+    React.DetailsHTMLAttributes<HTMLDetailsElement>,
+    'children' | 'ref'
+  > {
+  /**
+   * Summary text or nodes shown in the clickable header.
+   */
+  summary: React.ReactNode;
+  /**
+   * Content shown when the details element is expanded.
+   */
+  children: React.ReactNode;
+  /**
+   * Shared internal variant selector.
+   */
+  variant: DetailsFamilyVariant;
+  /**
+   * React ref for the underlying details element.
+   */
+  ref?: React.Ref<HTMLDetailsElement>;
+}
+
+export type DetailsFamilyProps = Omit<DetailsFamilyBaseProps, 'variant'>;
+
+export const DetailsFamilyBase = ({
+  summary,
+  children,
+  variant,
+  className = '',
+  ref,
+  ...props
+}: DetailsFamilyBaseProps) => {
+  const iconNames = summaryIcons[variant];
+  const rootClassName = joinClasses(
+    'ofh-details',
+    variant === 'expander' && 'ofh-expander',
+    className,
+  );
+
+  return (
+    <details
+      {...props}
+      ref={ref}
+      className={rootClassName}
+    >
+      <summary
+        className={joinClasses(
+          'ofh-details__summary',
+          `ofh-details__summary--${variant}`,
+        )}
+      >
+        <span
+          className={joinClasses(
+            'ofh-details__summary-icon',
+            `ofh-details__summary-icon--${variant}-closed`,
+          )}
+          aria-hidden="true"
+        >
+          <Icon
+            name={iconNames.closed}
+            size={32}
+            className="ofh-details__summary-icon-svg"
+          />
+        </span>
+        <span
+          className={joinClasses(
+            'ofh-details__summary-icon',
+            `ofh-details__summary-icon--${variant}-open`,
+          )}
+          aria-hidden="true"
+        >
+          <Icon
+            name={iconNames.open}
+            size={32}
+            className="ofh-details__summary-icon-svg"
+          />
+        </span>
+        <span className="ofh-details__summary-text">{summary}</span>
+      </summary>
+      <div className="ofh-details__text">
+        <div
+          className={joinClasses(
+            'ofh-details__panel',
+            `ofh-details__panel--${variant}`,
+          )}
+        >
+          {children}
+        </div>
+      </div>
+    </details>
+  );
+};
+
+DetailsFamilyBase.displayName = 'DetailsFamilyBase';

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -37,6 +37,12 @@ export type {
 export { Fieldset } from './components/Fieldset';
 export type { FieldsetProps } from './components/Fieldset';
 
+export { Details } from './components/Details';
+export type { DetailsProps } from './components/Details';
+
+export { Expander } from './components/Expander';
+export type { ExpanderProps } from './components/Expander';
+
 export { Textarea } from './components/Textarea';
 export type { TextareaProps } from './components/Textarea';
 

--- a/packages/site/views/design-system/components/details/index.njk
+++ b/packages/site/views/design-system/components/details/index.njk
@@ -3,7 +3,7 @@
 {% set subSection = "Components" %}
 {% set pageDescription = "Make a page easier to scan by letting users reveal more detailed information only if they need it." %}
 {% set theme = "Content presentation" %}
-{% set dateUpdated = "November 2019" %}
+{% set dateUpdated = "April 2026" %}
 {% set backlog_issue_id = "30" %}
 
 {% extends "app-layout.njk" %}
@@ -34,6 +34,15 @@
   <h2 id="how-it-works">How to use details</h2>
   <p>The details component is a short link that expands to show more text when a user clicks on it.</p>
   <p>Make the link text short and descriptive so users can quickly work out if they need to click on it.</p>
+
+  <h3 id="details-with-rich-content">Details with rich content</h3>
+  <p>Details can contain more than a single sentence. Use paragraphs, lists, and links inside the revealed panel when that helps explain supporting information clearly.</p>
+
+  {{ designExample({
+    group: "components",
+    item: "details",
+    type: "rich-content"
+  }) }}
 
   <h2 id="details-and-expanders">Details and expanders</h2>
   <p>Details and expanders both hide sections of content which a user can choose to reveal.</p>

--- a/packages/site/views/design-system/components/details/rich-content/index.njk
+++ b/packages/site/views/design-system/components/details/rich-content/index.njk
@@ -1,0 +1,16 @@
+{% from 'details/macro.njk' import details %}
+
+{{ details({
+  "text": "What can I use my NHS number for?",
+  "attributes": {
+    "open": "open"
+  },
+  "html": "
+  <p>The number helps different NHS services match your records correctly.</p>
+  <ul>
+    <li>book appointments</li>
+    <li>view test results</li>
+    <li>share records between services</li>
+  </ul>
+  "
+}) }}

--- a/packages/site/views/design-system/components/expander/index.njk
+++ b/packages/site/views/design-system/components/expander/index.njk
@@ -3,7 +3,7 @@
 {% set subSection = "Components" %}
 {% set pageDescription = "Make a complex topic easier to digest by letting users reveal more detailed information only if they need it." %}
 {% set theme = "Content presentation" %}
-{% set dateUpdated = "November 2021" %}
+{% set dateUpdated = "April 2026" %}
 {% set backlog_issue_id = "29" %}
 
 {% extends "app-layout.njk" %}

--- a/packages/toolkit/components/details/README.md
+++ b/packages/toolkit/components/details/README.md
@@ -27,8 +27,8 @@ For this component to be accessible and compatible with older browsers, include 
       </svg>
     </span>
     <span class="ofh-details__summary-icon ofh-details__summary-icon--details-open" aria-hidden="true">
-      <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--ExpandMore ofh-details__summary-icon-svg" aria-hidden="true" focusable="false" width="32" height="32">
-        <use href="/assets/icons/icon-sprite.svg#ofh-icon-ExpandMore"></use>
+      <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--ChevronDown ofh-details__summary-icon-svg" aria-hidden="true" focusable="false" width="32" height="32">
+        <use href="/assets/icons/icon-sprite.svg#ofh-icon-ChevronDown"></use>
       </svg>
     </span>
     <span class="ofh-details__summary-text">Where can I find my NHS number?</span>
@@ -93,8 +93,8 @@ Find out more about the expander component and when to use it in the [design sys
       </svg>
     </span>
     <span class="ofh-details__summary-icon ofh-details__summary-icon--expander-open" aria-hidden="true">
-      <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--RemoveCircle ofh-details__summary-icon-svg" aria-hidden="true" focusable="false" width="32" height="32">
-        <use href="/assets/icons/icon-sprite.svg#ofh-icon-RemoveCircle"></use>
+      <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--MinusCircle ofh-details__summary-icon-svg" aria-hidden="true" focusable="false" width="32" height="32">
+        <use href="/assets/icons/icon-sprite.svg#ofh-icon-MinusCircle"></use>
       </svg>
     </span>
     <span class="ofh-details__summary-text">Opening times</span>
@@ -208,8 +208,8 @@ Find out more about the expander component and when to use it in the [design sys
         </svg>
       </span>
       <span class="ofh-details__summary-icon ofh-details__summary-icon--expander-open" aria-hidden="true">
-        <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--RemoveCircle ofh-details__summary-icon-svg" aria-hidden="true" focusable="false" width="32" height="32">
-          <use href="/assets/icons/icon-sprite.svg#ofh-icon-RemoveCircle"></use>
+        <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--MinusCircle ofh-details__summary-icon-svg" aria-hidden="true" focusable="false" width="32" height="32">
+          <use href="/assets/icons/icon-sprite.svg#ofh-icon-MinusCircle"></use>
         </svg>
       </span>
       <span class="ofh-details__summary-text">How to measure your blood glucose levels</span>
@@ -235,8 +235,8 @@ Find out more about the expander component and when to use it in the [design sys
         </svg>
       </span>
       <span class="ofh-details__summary-icon ofh-details__summary-icon--expander-open" aria-hidden="true">
-        <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--RemoveCircle ofh-details__summary-icon-svg" aria-hidden="true" focusable="false" width="32" height="32">
-          <use href="/assets/icons/icon-sprite.svg#ofh-icon-RemoveCircle"></use>
+        <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--MinusCircle ofh-details__summary-icon-svg" aria-hidden="true" focusable="false" width="32" height="32">
+          <use href="/assets/icons/icon-sprite.svg#ofh-icon-MinusCircle"></use>
         </svg>
       </span>
       <span class="ofh-details__summary-text">When to check your blood glucose level</span>

--- a/packages/toolkit/components/details/README.md
+++ b/packages/toolkit/components/details/README.md
@@ -4,7 +4,6 @@
 
 > Icon migration: this component now renders icons using `components/icon/macro.njk` and the Material SVG sprite.
 
-
 Find out more about the details component and when to use it in the [design system docs website](https://designsystem.ourfuturehealth.org.uk/design-system/components/details).
 
 ## Dependencies
@@ -21,29 +20,39 @@ For this component to be accessible and compatible with older browsers, include 
 
 ```html
 <details class="ofh-details">
-  <summary class="ofh-details__summary">
-    <span class="ofh-details__summary-text">
-    Where can I find my NHS number?
+  <summary class="ofh-details__summary ofh-details__summary--details">
+    <span class="ofh-details__summary-icon ofh-details__summary-icon--details-closed" aria-hidden="true">
+      <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--ChevronRight ofh-details__summary-icon-svg" aria-hidden="true" focusable="false" width="32" height="32">
+        <use href="/assets/icons/icon-sprite.svg#ofh-icon-ChevronRight"></use>
+      </svg>
     </span>
+    <span class="ofh-details__summary-icon ofh-details__summary-icon--details-open" aria-hidden="true">
+      <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--ExpandMore ofh-details__summary-icon-svg" aria-hidden="true" focusable="false" width="32" height="32">
+        <use href="/assets/icons/icon-sprite.svg#ofh-icon-ExpandMore"></use>
+      </svg>
+    </span>
+    <span class="ofh-details__summary-text">Where can I find my NHS number?</span>
   </summary>
   <div class="ofh-details__text">
-    <p>An NHS number is a 10 digit number, like 485 777 3456.</p>
-    <p>You can find your NHS number on any document sent to you by the NHS. This may include:</p>
-    <ul>
-      <li>prescriptions</li>
-      <li>test results</li>
-      <li>hospital referral letters</li>
-      <li>appointment letters</li>
-      <li>your NHS medical card</li>
-    </ul>
-    <p>Ask your GP practice for help if you can't find your NHS number.</p>
+    <div class="ofh-details__panel ofh-details__panel--details">
+      <p>An NHS number is a 10 digit number, like 485 777 3456.</p>
+      <p>You can find your NHS number on any document sent to you by the NHS. This may include:</p>
+      <ul>
+        <li>prescriptions</li>
+        <li>test results</li>
+        <li>hospital referral letters</li>
+        <li>appointment letters</li>
+        <li>your NHS medical card</li>
+      </ul>
+      <p>Ask your GP practice for help if you can't find your NHS number.</p>
+    </div>
   </div>
 </details>
 ```
 
 #### Nunjucks macro
 
-```
+```njk
 {% from 'components/details/macro.njk' import details %}
 
 {{ details({
@@ -77,55 +86,65 @@ Find out more about the expander component and when to use it in the [design sys
 
 ```html
 <details class="ofh-details ofh-expander">
-  <summary class="ofh-details__summary">
-    <span class="ofh-details__summary-text">
-    Opening times
+  <summary class="ofh-details__summary ofh-details__summary--expander">
+    <span class="ofh-details__summary-icon ofh-details__summary-icon--expander-closed" aria-hidden="true">
+      <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--AddCircle ofh-details__summary-icon-svg" aria-hidden="true" focusable="false" width="32" height="32">
+        <use href="/assets/icons/icon-sprite.svg#ofh-icon-AddCircle"></use>
+      </svg>
     </span>
+    <span class="ofh-details__summary-icon ofh-details__summary-icon--expander-open" aria-hidden="true">
+      <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--RemoveCircle ofh-details__summary-icon-svg" aria-hidden="true" focusable="false" width="32" height="32">
+        <use href="/assets/icons/icon-sprite.svg#ofh-icon-RemoveCircle"></use>
+      </svg>
+    </span>
+    <span class="ofh-details__summary-text">Opening times</span>
   </summary>
   <div class="ofh-details__text">
-    <table>
-      <tbody>
-        <tr>
-          <th><strong>Day of the week</strong></th>
-          <th><strong>Opening hours</strong></th>
-        </tr>
-        <tr>
-          <th>Monday</th>
-          <td>9am to 6pm</td>
-        </tr>
-        <tr>
-          <th>Tuesday</th>
-          <td>9am to 6pm</td>
-        </tr>
-        <tr>
-          <th>Wednesday</th>
-          <td>9am to 6pm</td>
-        </tr>
-        <tr>
-          <th>Thursday</th>
-          <td>9am to 6pm</td>
-        </tr>
-        <tr>
-          <th>Friday</th>
-          <td>9am to 6pm</td>
-        </tr>
-        <tr>
-          <th>Saturday</th>
-          <td>9am to 1pm</td>
-        </tr>
-        <tr>
-          <th>Sunday</th>
-          <td>Closed</td>
-        </tr>
-      </tbody>
-    </table>
+    <div class="ofh-details__panel ofh-details__panel--expander">
+      <table>
+        <tbody>
+          <tr>
+            <th><strong>Day of the week</strong></th>
+            <th><strong>Opening hours</strong></th>
+          </tr>
+          <tr>
+            <th>Monday</th>
+            <td>9am to 6pm</td>
+          </tr>
+          <tr>
+            <th>Tuesday</th>
+            <td>9am to 6pm</td>
+          </tr>
+          <tr>
+            <th>Wednesday</th>
+            <td>9am to 6pm</td>
+          </tr>
+          <tr>
+            <th>Thursday</th>
+            <td>9am to 6pm</td>
+          </tr>
+          <tr>
+            <th>Friday</th>
+            <td>9am to 6pm</td>
+          </tr>
+          <tr>
+            <th>Saturday</th>
+            <td>9am to 1pm</td>
+          </tr>
+          <tr>
+            <th>Sunday</th>
+            <td>Closed</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </details>
 ```
 
 #### Nunjucks macro
 
-```
+```njk
 {% from 'components/details/macro.njk' import details %}
 
 {{ details({
@@ -182,36 +201,56 @@ Find out more about the expander component and when to use it in the [design sys
 ```html
 <div class="ofh-expander-group">
   <details class="ofh-details ofh-expander">
-    <summary class="ofh-details__summary">
-      <span class="ofh-details__summary-text">
-      How to measure your blood glucose levels
+    <summary class="ofh-details__summary ofh-details__summary--expander">
+      <span class="ofh-details__summary-icon ofh-details__summary-icon--expander-closed" aria-hidden="true">
+        <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--AddCircle ofh-details__summary-icon-svg" aria-hidden="true" focusable="false" width="32" height="32">
+          <use href="/assets/icons/icon-sprite.svg#ofh-icon-AddCircle"></use>
+        </svg>
       </span>
+      <span class="ofh-details__summary-icon ofh-details__summary-icon--expander-open" aria-hidden="true">
+        <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--RemoveCircle ofh-details__summary-icon-svg" aria-hidden="true" focusable="false" width="32" height="32">
+          <use href="/assets/icons/icon-sprite.svg#ofh-icon-RemoveCircle"></use>
+        </svg>
+      </span>
+      <span class="ofh-details__summary-text">How to measure your blood glucose levels</span>
     </summary>
     <div class="ofh-details__text">
-      <p>Testing your blood at home is quick and easy, although it can be uncomfortable. It does get better.</p>
-      <p>You would have been given:</p>
-      <ul>
-        <li>a blood glucose metre</li>
-        <li>small needles called lancets</li>
-        <li>a plastic pen to hold the lancest</li>
-        <li>small test strips</li>
-      </ul>
+      <div class="ofh-details__panel ofh-details__panel--expander">
+        <p>Testing your blood at home is quick and easy, although it can be uncomfortable. It does get better.</p>
+        <p>You would have been given:</p>
+        <ul>
+          <li>a blood glucose metre</li>
+          <li>small needles called lancets</li>
+          <li>a plastic pen to hold the lancets</li>
+          <li>small test strips</li>
+        </ul>
+      </div>
     </div>
   </details>
   <details class="ofh-details ofh-expander">
-    <summary class="ofh-details__summary">
-      <span class="ofh-details__summary-text">
-      When to check your blood glucose level
+    <summary class="ofh-details__summary ofh-details__summary--expander">
+      <span class="ofh-details__summary-icon ofh-details__summary-icon--expander-closed" aria-hidden="true">
+        <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--AddCircle ofh-details__summary-icon-svg" aria-hidden="true" focusable="false" width="32" height="32">
+          <use href="/assets/icons/icon-sprite.svg#ofh-icon-AddCircle"></use>
+        </svg>
       </span>
+      <span class="ofh-details__summary-icon ofh-details__summary-icon--expander-open" aria-hidden="true">
+        <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--RemoveCircle ofh-details__summary-icon-svg" aria-hidden="true" focusable="false" width="32" height="32">
+          <use href="/assets/icons/icon-sprite.svg#ofh-icon-RemoveCircle"></use>
+        </svg>
+      </span>
+      <span class="ofh-details__summary-text">When to check your blood glucose level</span>
     </summary>
     <div class="ofh-details__text">
-      <p>Try to check your blood:</p>
-      <ul>
-        <li>before meals</li>
-        <li>2 to 3 hours after meals</li>
-        <li>before, during (take a break) and after exercise</li>
-      </ul>
-      <p>This helps you understand your blood glucose levels and how they’re affected by meals and exercise. It should help you have more stable blood glucose levels.</p>
+      <div class="ofh-details__panel ofh-details__panel--expander">
+        <p>Try to check your blood:</p>
+        <ul>
+          <li>before meals</li>
+          <li>2 to 3 hours after meals</li>
+          <li>before, during (take a break) and after exercise</li>
+        </ul>
+        <p>This helps you understand your blood glucose levels and how they’re affected by meals and exercise. It should help you have more stable blood glucose levels.</p>
+      </div>
     </div>
   </details>
 </div>
@@ -219,7 +258,7 @@ Find out more about the expander component and when to use it in the [design sys
 
 #### Nunjucks macro
 
-```
+```njk
 {% from 'components/details/macro.njk' import details %}
 
 <div class="ofh-expander-group">
@@ -232,7 +271,7 @@ Find out more about the expander component and when to use it in the [design sys
     <ul>
       <li>a blood glucose metre</li>
       <li>small needles called lancets</li>
-      <li>a plastic pen to hold the lancest</li>
+      <li>a plastic pen to hold the lancets</li>
       <li>small test strips</li>
     </ul>
     "
@@ -261,9 +300,9 @@ The details Nunjucks macro takes the following arguments:
 
 | Name         | Type     | Required  | Description |
 | -------------|----------|-----------|-------------|
-| text         | string   | Yes       | Text to be displayed on the expander component. |
-| HTML         | string   | Yes       | HTML content to be displayed within the expander component |
-| classes      | string   | No        | Optional additional classes to add to the anchor tag. Separate each class with a space. |
-| attributes   | object   | No        | Any extra HTML attributes (for example data attributes) to add to the anchor tag. |
+| text         | string   | Yes       | Text shown in the summary link. |
+| HTML         | string   | Yes       | HTML content shown when the component expands. |
+| classes      | string   | No        | Optional additional classes to add to the root `<details>`. Separate each class with a space. |
+| attributes   | object   | No        | Any extra HTML attributes (for example data attributes) to add to the root `<details>`. |
 
-If you are using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `html` can be a [security risk](https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting). Read more about this in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).
+If you are using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `html`, can be a [security risk](https://developer.mozilla.org/en-US/docs/Glossary/XSS). Read more about this in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).

--- a/packages/toolkit/components/details/_details.scss
+++ b/packages/toolkit/components/details/_details.scss
@@ -22,37 +22,39 @@
   @include ofh-responsive-margin(16, 'bottom');
   @include ofh-typography-responsive('paragraph-md');
 
-  display: block;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  align-items: flex-start;
 }
 
 .ofh-details__summary {
+  align-items: center;
+  background: transparent;
   color: $ofh-color-foreground-link-default;
   cursor: pointer;
-  display: inline-block; /* [2] */
-  padding-left: $ofh-size-24;
-  position: relative; /* [3] */
+  display: inline-flex;
+  gap: $ofh-size-8;
+  max-width: 100%;
+  position: relative;
+  list-style: none;
+  text-decoration: underline;
+
+  &--details {
+    width: auto;
+  }
+
+  &--expander {
+    width: 100%;
+  }
 
   &:hover {
     color: $ofh-color-foreground-link-hover;
   }
 
-  &::before {
-    bottom: 0;
-    content: '';
-    left: 0;
-    margin: auto;
-    position: absolute;
-    top: 0;
-
-    @include govuk-shape-arrow($direction: right, $base: 14px);
-  }
-
   &:focus {
     @include ofh-focused-text();
-
-    .ofh-icon {
-      fill: $ofh-color-foreground-brand-blue-navy;
-    }
+    color: $ofh-color-foreground-link-hover;
   }
 
   &:hover,
@@ -63,36 +65,60 @@
   }
 }
 
-.ofh-details[open] > .ofh-details__summary::before {
-  @include govuk-shape-arrow($direction: down, $base: 14px);
+.ofh-details__summary::-webkit-details-marker {
+  display: none;
 }
 
 .ofh-details__summary-text {
-  text-decoration: underline; /* [4] */
+  text-decoration: underline;
 }
 
-.ofh-details__summary::-webkit-details-marker {
-  display: none; /* [5] */
+.ofh-details__summary-icon {
+  flex: 0 0 auto;
+  line-height: 0;
+}
+
+.ofh-details__summary-icon-svg {
+  display: block;
+}
+
+.ofh-details__summary-icon--details-open,
+.ofh-details__summary-icon--expander-open {
+  display: none;
+}
+
+.ofh-details[open] .ofh-details__summary-icon--details-closed,
+.ofh-details[open] .ofh-details__summary-icon--expander-closed {
+  display: none;
+}
+
+.ofh-details[open] .ofh-details__summary-icon--details-open,
+.ofh-details[open] .ofh-details__summary-icon--expander-open {
+  display: inline-flex;
+}
+
+.ofh-details[open] {
+  gap: $ofh-size-8;
 }
 
 .ofh-details__text {
-  border-left: $ofh-size-4 solid $ofh-color-greyscale-5;
-  margin-top: $ofh-size-8;
-  padding: $ofh-size-16;
-  padding-left: 20px; /* [6] */
+  width: 100%;
+}
 
-  @include top-and-bottom();
+.ofh-details__panel {
+  color: $ofh-color-foreground-primary;
+}
+
+.ofh-details__panel--details {
+  border-left: $ofh-size-4 solid $ofh-color-greyscale-5;
+  padding: $ofh-size-16;
+  padding-left: 20px;
 }
 
 /**
  * Expander variation.
  *
- * 1. !important used because the icon is populated
- *    by the JavaScript polyfill
- * 2. Remove the default hover, focus and active
- *    styles for this component.
- * 3. -2px left margin to align the icon to the content.
- * 4. When a group of details is used reduce the
+ * 1. When a group of details is used reduce the
  *    margin between them so they sit together.
  */
 
@@ -105,6 +131,7 @@ $expander-border-hover-color: $ofh-color-greyscale-4;
   background-color: $ofh-color-greyscale-white;
   border: $expander-border-width solid $expander-border-color;
   border-bottom-width: $expander-border-bottom-width;
+  padding: $ofh-size-24;
 
   &:hover {
     border-color: $expander-border-hover-color;
@@ -112,94 +139,36 @@ $expander-border-hover-color: $ofh-color-greyscale-4;
 
   .ofh-details__summary {
     background-color: $ofh-color-greyscale-white;
-    border-top: $ofh-stroke-weight-4 solid transparent;
-    display: block;
-    padding: $ofh-size-24 - $ofh-stroke-weight-4 $ofh-size-24 $ofh-size-24;
-
-    @include mq($until: tablet) {
-      padding: $ofh-size-16 - $ofh-stroke-weight-4 $ofh-size-16 $ofh-size-16;
-    }
-
-    &::before {
-      display: none !important; /* stylelint-disable-line declaration-no-important */ /* [1] */
-    }
-
-    &:hover {
-      .ofh-details__summary-text {
-        color: $ofh-color-foreground-link-hover;
-      }
-    }
-
-    &:focus {
-      box-shadow: none;
-      outline: none;
-
-      .ofh-details__summary-text {
-        @include ofh-focused-text();
-      }
-
-      .ofh-details__expander-icon {
-        color: $ofh-color-foreground-brand-blue-navy;
-      }
-    }
+    display: flex;
+    width: 100%;
   }
 
-  .ofh-details__summary-text {
-    cursor: pointer;
-    display: inline-block;
-    padding: $ofh-size-4 $ofh-size-4 $ofh-size-4 $ofh-size-32;
-    position: relative;
+  .ofh-details__summary:hover {
+    .ofh-details__summary-text {
+      color: $ofh-color-foreground-link-hover;
+    }
   }
 
   .ofh-details__text {
-    @include ofh-responsive-padding(16, 'bottom');
-    @include ofh-responsive-padding(16, 'left');
-    @include ofh-responsive-padding(16, 'right');
-    @include ofh-responsive-padding(0, 'top');
+    padding-left: $ofh-size-16;
+  }
 
-    border-left: 0;
-    margin-left: 0;
-    margin-top: 0;
+  .ofh-details__panel {
+    padding: $ofh-size-24;
+  }
+
+  .ofh-details__summary-text {
+    flex: 1 1 auto;
   }
 }
 
 .ofh-expander[open] {
-  border-bottom-width: $expander-border-width;
-
-  .ofh-details__summary {
-    &:focus {
-      &:hover {
-        .ofh-details__summary-text {
-          text-decoration: none;
-        }
-      }
-    }
-  }
-}
-
-.ofh-details__expander-icon {
-  color: $ofh-color-foreground-link-default;
-  height: 32px;
-  left: -2px;
-  position: absolute;
-  top: calc(50% - 16px);
-  width: 32px;
-}
-
-.ofh-details__expander-icon--collapse {
-  display: none;
-}
-
-.ofh-expander[open] .ofh-details__expander-icon--expand {
-  display: none;
-}
-
-.ofh-expander[open] .ofh-details__expander-icon--collapse {
-  display: inline-block;
+  border-bottom-width: $expander-border-bottom-width;
+  gap: $ofh-size-24;
 }
 
 .ofh-expander-group {
-  /* [4] */
+  /* [1] */
 
   > .ofh-details {
     @include ofh-responsive-margin(4, 'bottom');

--- a/packages/toolkit/components/details/_details.scss
+++ b/packages/toolkit/components/details/_details.scss
@@ -22,10 +22,10 @@
   @include ofh-responsive-margin(16, 'bottom');
   @include ofh-typography-responsive('paragraph-md');
 
+  align-items: flex-start;
   display: flex;
   flex-direction: column;
   gap: 0;
-  align-items: flex-start;
 }
 
 .ofh-details__summary {
@@ -35,9 +35,9 @@
   cursor: pointer;
   display: inline-flex;
   gap: $ofh-size-8;
+  list-style: none;
   max-width: 100%;
   position: relative;
-  list-style: none;
   text-decoration: underline;
 
   &--details {
@@ -54,6 +54,7 @@
 
   &:focus {
     @include ofh-focused-text();
+
     color: $ofh-color-foreground-link-hover;
   }
 
@@ -109,10 +110,24 @@
   color: $ofh-color-foreground-primary;
 }
 
+.ofh-details__summary--details + .ofh-details__text {
+  padding-left: $ofh-size-16;
+}
+
 .ofh-details__panel--details {
-  border-left: $ofh-size-4 solid $ofh-color-greyscale-5;
-  padding: $ofh-size-16;
-  padding-left: 20px;
+  position: relative;
+
+  @include ofh-responsive-padding(24);
+
+  &::before {
+    background-color: $ofh-color-greyscale-5;
+    bottom: 0;
+    content: '';
+    left: -$ofh-size-2;
+    position: absolute;
+    top: 0;
+    width: $ofh-size-4;
+  }
 }
 
 /**
@@ -131,7 +146,8 @@ $expander-border-hover-color: $ofh-color-greyscale-4;
   background-color: $ofh-color-greyscale-white;
   border: $expander-border-width solid $expander-border-color;
   border-bottom-width: $expander-border-bottom-width;
-  padding: $ofh-size-24;
+
+  @include ofh-responsive-padding(24);
 
   &:hover {
     border-color: $expander-border-hover-color;
@@ -150,11 +166,7 @@ $expander-border-hover-color: $ofh-color-greyscale-4;
   }
 
   .ofh-details__text {
-    padding-left: $ofh-size-16;
-  }
-
-  .ofh-details__panel {
-    padding: $ofh-size-24;
+    padding-left: 0;
   }
 
   .ofh-details__summary-text {
@@ -164,7 +176,8 @@ $expander-border-hover-color: $ofh-color-greyscale-4;
 
 .ofh-expander[open] {
   border-bottom-width: $expander-border-bottom-width;
-  gap: $ofh-size-24;
+
+  @include ofh-responsive-gap-y(24);
 }
 
 .ofh-expander-group {

--- a/packages/toolkit/components/details/_details.scss
+++ b/packages/toolkit/components/details/_details.scss
@@ -108,6 +108,8 @@
 
 .ofh-details__panel {
   color: $ofh-color-foreground-primary;
+
+  @include top-and-bottom();
 }
 
 .ofh-details__summary--details + .ofh-details__text {

--- a/packages/toolkit/components/details/template.njk
+++ b/packages/toolkit/components/details/template.njk
@@ -1,18 +1,38 @@
 {% from '../icon/macro.njk' import icon %}
 
-<details class="ofh-details
-{%- if params.classes %} {{ params.classes }}{% endif %}"
+{% set isExpander = params.classes and 'ofh-expander' in params.classes %}
+
+<details class="ofh-details{% if params.classes %} {{ params.classes }}{% endif %}"
 {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
-  <summary class="ofh-details__summary">
+  <summary class="ofh-details__summary{% if isExpander %} ofh-details__summary--expander{% else %} ofh-details__summary--details{% endif %}">
+    {%- if isExpander -%}
+      <span class="ofh-details__summary-icon ofh-details__summary-icon--expander-closed" aria-hidden="true">
+        {{ icon({ "name": "AddCircle", "size": 32, "classes": "ofh-details__summary-icon-svg" }) }}
+      </span>
+      <span class="ofh-details__summary-icon ofh-details__summary-icon--expander-open" aria-hidden="true">
+        {{ icon({ "name": "RemoveCircle", "size": 32, "classes": "ofh-details__summary-icon-svg" }) }}
+      </span>
+    {%- else -%}
+      <span class="ofh-details__summary-icon ofh-details__summary-icon--details-closed" aria-hidden="true">
+        {{ icon({ "name": "ChevronRight", "size": 32, "classes": "ofh-details__summary-icon-svg" }) }}
+      </span>
+      <span class="ofh-details__summary-icon ofh-details__summary-icon--details-open" aria-hidden="true">
+        {{ icon({ "name": "ExpandMore", "size": 32, "classes": "ofh-details__summary-icon-svg" }) }}
+      </span>
+    {%- endif -%}
     <span class="ofh-details__summary-text">
-      {%- if params.classes and 'ofh-expander' in params.classes -%}
-        {{ icon({ "name": "AddCircle", "size": 32, "classes": "ofh-details__expander-icon ofh-details__expander-icon--expand" }) }}
-        {{ icon({ "name": "MinusCircle", "size": 32, "classes": "ofh-details__expander-icon ofh-details__expander-icon--collapse" }) }}
-      {%- endif -%}
       {{ params.text }}
     </span>
   </summary>
   <div class="ofh-details__text">
-    {{- params.HTML | safe }}
+    {%- if isExpander -%}
+      <div class="ofh-details__panel ofh-details__panel--expander">
+        {{- params.HTML | safe }}
+      </div>
+    {%- else -%}
+      <div class="ofh-details__panel ofh-details__panel--details">
+        {{- params.HTML | safe }}
+      </div>
+    {%- endif -%}
   </div>
 </details>

--- a/packages/toolkit/components/details/template.njk
+++ b/packages/toolkit/components/details/template.njk
@@ -1,6 +1,7 @@
 {% from '../icon/macro.njk' import icon %}
 
 {% set isExpander = params.classes and 'ofh-expander' in params.classes %}
+{% set contentHtml = params.html if params.html else params.HTML %}
 
 <details class="ofh-details{% if params.classes %} {{ params.classes }}{% endif %}"
 {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
@@ -10,14 +11,14 @@
         {{ icon({ "name": "AddCircle", "size": 32, "classes": "ofh-details__summary-icon-svg" }) }}
       </span>
       <span class="ofh-details__summary-icon ofh-details__summary-icon--expander-open" aria-hidden="true">
-        {{ icon({ "name": "RemoveCircle", "size": 32, "classes": "ofh-details__summary-icon-svg" }) }}
+        {{ icon({ "name": "MinusCircle", "size": 32, "classes": "ofh-details__summary-icon-svg" }) }}
       </span>
     {%- else -%}
       <span class="ofh-details__summary-icon ofh-details__summary-icon--details-closed" aria-hidden="true">
         {{ icon({ "name": "ChevronRight", "size": 32, "classes": "ofh-details__summary-icon-svg" }) }}
       </span>
       <span class="ofh-details__summary-icon ofh-details__summary-icon--details-open" aria-hidden="true">
-        {{ icon({ "name": "ExpandMore", "size": 32, "classes": "ofh-details__summary-icon-svg" }) }}
+        {{ icon({ "name": "ChevronDown", "size": 32, "classes": "ofh-details__summary-icon-svg" }) }}
       </span>
     {%- endif -%}
     <span class="ofh-details__summary-text">
@@ -27,11 +28,11 @@
   <div class="ofh-details__text">
     {%- if isExpander -%}
       <div class="ofh-details__panel ofh-details__panel--expander">
-        {{- params.HTML | safe }}
+        {{- contentHtml | safe }}
       </div>
     {%- else -%}
       <div class="ofh-details__panel ofh-details__panel--details">
-        {{- params.HTML | safe }}
+        {{- contentHtml | safe }}
       </div>
     {%- endif -%}
   </div>

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/toolkit",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "Our Future Health design system toolkit contains the code you need to start building user interfaces for Our Future Health websites and services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
This PR delivers **DSE-326 / DSE-328 details and expander refresh** across toolkit, React, the docs site, and Storybook.

It aligns the details-family components with the current Figma patterns, updates toolkit and React coverage for both `Details` and `Expander`, and brings Storybook into the newer `Docs` / `Default` / `Builder` / showcase teaching pattern.

Ticket: DSE-326 / DSE-328

## Release scope
- `@ourfuturehealth/toolkit` -> `4.11.0`
- `@ourfuturehealth/react-components` -> `0.10.0`
- updates release metadata in `CHANGELOG.md`, `UPGRADING.md`, `docs/release-versioning-strategy.md`, `docs/consuming-react-components.md`, and `packages/react-components/README.md`

## Breaking Changes
- None.

## Key Changes
- refreshes toolkit details-family behaviour and styling for `Details` and `Expander`
- adds/aligns the React `Details` and `Expander` components
- keeps the intended distinction between the two patterns clear:
  - `Details` for lighter supporting information
  - `Expander` for more prominent expandable content
- improves Storybook docs pages so they teach the real React API more clearly
- keeps `Default` stories as realistic fixed examples, `Builder` stories as the interactive surface, and showcase stories as fixed usage examples
- improves copyable usage snippets for the details-family components in Storybook docs

## Validation
- `npm test`
- `pnpm lint`
- `pnpm build`
- `pnpm docs:release-contract`
- `pnpm smoke:release-artifacts`
- `pnpm --filter=@ourfuturehealth/react-components build:storybook`
- manual QA on details-family Storybook stories

## Reviewer Focus
- `Details` and `Expander` should both be aligned with the updated component work
- Storybook should now teach both components using the newer docs/default/builder/showcase pattern
- the grouped expander story should clearly demonstrate the intended grouped layout
- release metadata should line up on `toolkit-v4.11.0` / `react-v0.10.0`
