### PR TITLE
DSE-331 :: Summary List FE update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ### 2026-04-20
 
+#### @ourfuturehealth/toolkit 4.12.0 (`toolkit-v4.12.0`)
+
+##### Changed
+
+- Refreshed the toolkit `summary-list` component to the current Figma structure, including padded and compact row treatments, clearer stacked action spacing, and the no-border compact variant
+- Expanded the toolkit summary-list macro to support explicit `padded` and `noBorder` options while preserving class-based compatibility for existing no-border usage
+- Updated the summary-list docs page, examples, macro options, and README guidance so the compact and no-border variants are taught consistently
+
+#### @ourfuturehealth/react-components 0.11.0 (`react-v0.11.0`)
+
+##### Added
+
+- First public React `SummaryList` component with toolkit-parity row structure, optional action links, compact spacing, and no-border support
+- Storybook docs and unit/accessibility coverage for the React summary-list variants
+
+##### Changed
+
+- Aligned the React summary-list teaching surface with the toolkit docs so reviewers and consumers see the same default, compact, without-actions, and without-border variants
+
 #### @ourfuturehealth/toolkit 4.11.0 (`toolkit-v4.11.0`)
 
 ##### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,10 +62,6 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 #### @ourfuturehealth/react-components 0.9.0 (`react-v0.9.0`)
 
-##### ⚠️ BREAKING CHANGES
-
-- React `Icon` and `Card` icon configuration no longer accept `spritePath`. React icons now always render from bundled toolkit SVG data.
-
 ##### Changed
 
 - Reorganized React Storybook so the link family is taught under `Components / Link / ...`
@@ -78,6 +74,14 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
   - `LinkAction`
   - `LinkIcon`
   - `LinkSkip`
+
+### 2026-04-15
+
+#### @ourfuturehealth/react-components 0.8.0 (`react-v0.8.0`)
+
+##### ⚠️ BREAKING CHANGES
+
+- React `Icon` and `Card` icon configuration no longer accept `spritePath`. React icons now always render from bundled toolkit SVG data.
 
 ##### Fixed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -10,7 +10,7 @@ This guide provides detailed migration instructions for upgrading between versio
 | ------------------------------------------------------- | ------------- | --------------------- | ------------------------------------- |
 | [v4.12.0 / React v0.11.0](#upgrading-to-v4120--react-v0110) | April 2026    | No breaking changes | 🟢 Low - adopt the public React summary list if needed |
 | [v4.11.0 / React v0.10.0](#upgrading-to-v4110--react-v0100) | April 2026    | No breaking changes | 🟢 Low - adopt the public React details family if needed |
-| [v4.10.0 / React v0.9.0](#upgrading-to-v4100--react-v090) | April 2026    | React `spritePath` removal | 🟢 Low - Remove the deprecated prop and adopt canonical names for new usage |
+| [v4.10.0 / React v0.9.0](#upgrading-to-v4100--react-v090) | April 2026    | No breaking changes | 🟢 Low - Adopt the public link family and canonical names for new usage |
 | [React v0.8.0](#upgrading-to-react-v080)                | April 2026    | React `spritePath` removal | 🟢 Low - Remove the deprecated prop      |
 | [v4.9.0 / React v0.7.0](#upgrading-to-v490--react-v070) | April 2026    | Icon naming sync    | 🟡 Medium - Search/replace icon names  |
 | [v4.8.0 / React v0.6.0](#upgrading-to-v480--react-v060) | March 2026    | No breaking changes | 🟢 Low - only relevant if you adopted the earlier TextInput prototype |
@@ -127,7 +127,7 @@ import {
 
 ### Breaking Changes
 
-`@ourfuturehealth/react-components` removes the `spritePath` prop from the public `Icon` API and from `Card` icon configuration. React icons now always render from bundled toolkit SVG data.
+None.
 
 Toolkit macro paths and site routes now teach the canonical names below, while compatibility aliases remain available in this release:
 
@@ -147,10 +147,9 @@ This release introduces the public React link family and aligns the toolkit link
 
 ### Migration Steps
 
-1. Remove any `spritePath` prop from `Icon` usage and any `spritePath` field from `Card` icon configuration objects.
-2. Adopt the new public React `LinkAction`, `LinkIcon`, and `LinkSkip` components where you want React parity for the link family.
-3. Prefer the canonical toolkit macro paths and macro names when touching existing templates.
-4. Re-run manual QA for keyboard and focus behavior, especially for `LinkSkip`, `LinkIcon`, and any icon-bearing surfaces such as `Icon`, `Select`, and `Card`.
+1. Adopt the new public React `LinkAction`, `LinkIcon`, and `LinkSkip` components where you want React parity for the link family.
+2. Prefer the canonical toolkit macro paths and macro names when touching existing templates.
+3. Re-run manual QA for keyboard and focus behavior, especially for `LinkSkip`, `LinkIcon`, and any icon-bearing surfaces such as `Icon`, `Select`, and `Card`.
 
 #### React example
 
@@ -163,10 +162,6 @@ import {
   LinkSkip,
 } from '@ourfuturehealth/react-components';
 ```
-
-### Toolkit reminder
-
-Toolkit/Nunjucks icon consumers are unchanged. They must still serve `icon-sprite.svg` at a public URL, default `/assets/icons/icon-sprite.svg`, or override that URL with `spritePath`.
 
 ## Upgrading to React v0.8.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,6 +8,7 @@ This guide provides detailed migration instructions for upgrading between versio
 
 | Version                                                 | Date          | Breaking Changes      | Migration Complexity                  |
 | ------------------------------------------------------- | ------------- | --------------------- | ------------------------------------- |
+| [v4.12.0 / React v0.11.0](#upgrading-to-v4120--react-v0110) | April 2026    | No breaking changes | 🟢 Low - adopt the public React summary list if needed |
 | [v4.11.0 / React v0.10.0](#upgrading-to-v4110--react-v0100) | April 2026    | No breaking changes | 🟢 Low - adopt the public React details family if needed |
 | [v4.10.0 / React v0.9.0](#upgrading-to-v4100--react-v090) | April 2026    | React `spritePath` removal | 🟢 Low - Remove the deprecated prop and adopt canonical names for new usage |
 | [v4.9.0 / React v0.7.0](#upgrading-to-v490--react-v070) | April 2026    | Icon naming sync    | 🟡 Medium - Search/replace icon names  |
@@ -18,6 +19,63 @@ This guide provides detailed migration instructions for upgrading between versio
 | [v4.3.0 / React v0.2.0](#upgrading-to-v430--react-v020) | March 2026    | Button variant naming      | 🟡 Medium - Find/replace required        |
 | [v4.1.0](#upgrading-to-v410)                            | February 2026 | Spacing scale indices      | 🟡 Medium - Index updates required       |
 | [v4.0.0](#upgrading-to-v400-monorepo-restructure)       | 2025          | Monorepo restructure       | 🔴 High - Installation & paths change    |
+
+---
+
+## Upgrading to v4.12.0 / React v0.11.0
+
+**Released:** April 2026
+**Affected packages:**
+
+- `@ourfuturehealth/toolkit` v4.12.0+
+- `@ourfuturehealth/react-components` v0.11.0+
+
+### Breaking Changes
+
+None.
+
+### Release Overview
+
+This release refreshes the toolkit `summary-list` component to the current design-system treatment and introduces the first public React `SummaryList` component.
+
+- Toolkit consumers can now use the explicit `padded: false` and `noBorder: true` macro options instead of relying only on manual class combinations.
+- Existing toolkit templates that already apply `ofh-summary-list--no-border` continue to work in this release.
+- React consumers can now adopt the public `SummaryList` component instead of carrying local review-answer list markup.
+
+### Migration Steps
+
+1. Adopt the public React `SummaryList` where you need toolkit-parity summary rows in React.
+2. Prefer the explicit toolkit macro options for compact and no-border variants when touching existing Nunjucks templates.
+3. Re-run visual QA for stacked mobile/tablet rows and action-link labelling if you have local summary-list overrides.
+
+#### React example
+
+**New in `react-v0.11.0`:**
+
+```tsx
+import { SummaryList } from '@ourfuturehealth/react-components';
+```
+
+#### Toolkit example
+
+**Before (`toolkit-v4.11.0`):**
+
+```njk
+{{ summaryList({
+  classes: 'ofh-summary-list--no-border',
+  rows: rows
+}) }}
+```
+
+**After (`toolkit-v4.12.0`):**
+
+```njk
+{{ summaryList({
+  padded: false,
+  noBorder: true,
+  rows: rows
+}) }}
+```
 
 ---
 
@@ -108,25 +166,6 @@ import {
 ### Toolkit reminder
 
 Toolkit/Nunjucks icon consumers are unchanged. They must still serve `icon-sprite.svg` at a public URL, default `/assets/icons/icon-sprite.svg`, or override that URL with `spritePath`.
-
-#### Toolkit example
-
-**Before (`toolkit-v4.9.0`):**
-
-```njk
-{% from "components/action-link/macro.njk" import actionLink %}
-{% from "components/back-link/macro.njk" import backLink %}
-{% from "components/skip-link/macro.njk" import skipLink %}
-```
-
-**After (`toolkit-v4.10.0`):**
-
-```njk
-{% from "components/link-action/macro.njk" import linkAction %}
-{% from "components/link-icon/macro.njk" import linkIcon %}
-{% from "components/link-skip/macro.njk" import linkSkip %}
-```
-
 ## Upgrading to v4.9.0 / React v0.7.0
 
 **Released:** April 2026

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -11,6 +11,7 @@ This guide provides detailed migration instructions for upgrading between versio
 | [v4.12.0 / React v0.11.0](#upgrading-to-v4120--react-v0110) | April 2026    | No breaking changes | 🟢 Low - adopt the public React summary list if needed |
 | [v4.11.0 / React v0.10.0](#upgrading-to-v4110--react-v0100) | April 2026    | No breaking changes | 🟢 Low - adopt the public React details family if needed |
 | [v4.10.0 / React v0.9.0](#upgrading-to-v4100--react-v090) | April 2026    | React `spritePath` removal | 🟢 Low - Remove the deprecated prop and adopt canonical names for new usage |
+| [React v0.8.0](#upgrading-to-react-v080)                | April 2026    | React `spritePath` removal | 🟢 Low - Remove the deprecated prop      |
 | [v4.9.0 / React v0.7.0](#upgrading-to-v490--react-v070) | April 2026    | Icon naming sync    | 🟡 Medium - Search/replace icon names  |
 | [v4.8.0 / React v0.6.0](#upgrading-to-v480--react-v060) | March 2026    | No breaking changes | 🟢 Low - only relevant if you adopted the earlier TextInput prototype |
 | [v4.7.0 / React v0.5.0](#upgrading-to-v470--react-v050) | March 2026    | Card family realignment | 🟡 Medium - API migration recommended |
@@ -166,6 +167,57 @@ import {
 ### Toolkit reminder
 
 Toolkit/Nunjucks icon consumers are unchanged. They must still serve `icon-sprite.svg` at a public URL, default `/assets/icons/icon-sprite.svg`, or override that URL with `spritePath`.
+
+## Upgrading to React v0.8.0
+
+**Released:** April 2026
+**Affected packages:**
+
+- `@ourfuturehealth/react-components` v0.8.0+
+
+### Breaking Changes
+
+`@ourfuturehealth/react-components` removes the `spritePath` prop from the public `Icon` API and from `Card` icon configuration. React icons now always render from bundled toolkit SVG data.
+
+### Migration Steps
+
+1. Remove any `spritePath` prop from `Icon` usage.
+2. Remove any `spritePath` field from `Card` icon configuration objects.
+3. Re-run visual checks for icon-bearing surfaces such as `Icon`, `Select`, `Card`, and `Checkboxes`.
+
+#### React example
+
+**Before:**
+
+```tsx
+<Icon name="Search" spritePath="/assets/icons/icon-sprite.svg" />
+
+<Card
+  icon={{
+    name: 'Search',
+    spritePath: '/assets/icons/icon-sprite.svg',
+  }}
+/>
+```
+
+**After:**
+
+```tsx
+<Icon name="Search" />
+
+<Card
+  icon={{
+    name: 'Search',
+  }}
+/>
+```
+
+If an application previously passed `spritePath` in React, that prop should now be removed.
+
+### Toolkit reminder
+
+Toolkit/Nunjucks icon consumers are unchanged. They must still serve `icon-sprite.svg` at a public URL, default `/assets/icons/icon-sprite.svg`, or override that URL with `spritePath`.
+
 ## Upgrading to v4.9.0 / React v0.7.0
 
 **Released:** April 2026

--- a/docs/consuming-react-components.md
+++ b/docs/consuming-react-components.md
@@ -131,6 +131,8 @@ The React components package currently provides the following components:
 - `Checkboxes` - Grouped checkbox inputs with hints, exclusive options, and conditional reveals
 - `Radios` - Grouped radio inputs with hints and conditional reveals
 - `Icon` - Toolkit icon component with fixed and responsive sizing using bundled SVG data
+- `SummaryList` - Review-answer and key-value summary rows with optional actions
+- `Icon` - Toolkit icon component with fixed and responsive sizing using bundled SVG data
 - `ErrorSummary` - Page-level validation summaries with linked errors
 - `Tag` - Status tags aligned with toolkit Tag variants
 - `Card` - Content presentation cards for summaries, status, and next steps

--- a/docs/release-versioning-strategy.md
+++ b/docs/release-versioning-strategy.md
@@ -33,6 +33,7 @@ For consumer migration instructions, use [Upgrading Guide](../UPGRADING.md).
 | ----------------------------------- | --------------------- | ---------------- |
 | `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.12.0` |
 | `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.11.0`   |
+| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.11.0`   |
 
 The release workflow still accepts legacy toolkit tags in the `v*` format for backward compatibility, but new toolkit releases should use `toolkit-v*`.
 

--- a/docs/release-versioning-strategy.md
+++ b/docs/release-versioning-strategy.md
@@ -31,8 +31,8 @@ For consumer migration instructions, use [Upgrading Guide](../UPGRADING.md).
 
 | Package                             | Canonical tag pattern | Example tag      |
 | ----------------------------------- | --------------------- | ---------------- |
-| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.11.0` |
-| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.10.0`  |
+| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.12.0` |
+| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.11.0`   |
 
 The release workflow still accepts legacy toolkit tags in the `v*` format for backward compatibility, but new toolkit releases should use `toolkit-v*`.
 
@@ -60,7 +60,7 @@ Consumers must install the package release tarball:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/toolkit": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/toolkit-v4.11.0/ourfuturehealth-toolkit-4.11.0.tgz"
+    "@ourfuturehealth/toolkit": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/toolkit-v4.12.0/ourfuturehealth-toolkit-4.12.0.tgz"
   }
 }
 ```
@@ -70,7 +70,7 @@ React consumers follow the same contract:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.10.0/ourfuturehealth-react-components-0.10.0.tgz"
+    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.11.0/ourfuturehealth-react-components-0.11.0.tgz"
   }
 }
 ```
@@ -132,6 +132,8 @@ This table is a visual aid for pre-monorepo versus post-monorepo releases.
 | 23    | `react-v0.9.0`    | N/A            | `0.9.0`       | Monorepo       | Released               |
 | 24    | `toolkit-v4.11.0` | `4.11.0`       | N/A           | Monorepo       | Released               |
 | 25    | `react-v0.10.0`   | N/A            | `0.10.0`      | Monorepo       | Released               |
+| 26    | `toolkit-v4.12.0` | `4.12.0`       | N/A           | Monorepo       | Released               |
+| 27    | `react-v0.11.0`   | N/A            | `0.11.0`      | Monorepo       | Released               |
 
 ## References
 

--- a/docs/release-versioning-strategy.md
+++ b/docs/release-versioning-strategy.md
@@ -129,12 +129,13 @@ This table is a visual aid for pre-monorepo versus post-monorepo releases.
 | 19    | `react-v0.6.0`   | N/A             | `0.6.0`       | Monorepo       | Released               |
 | 20    | `toolkit-v4.9.0` | `4.9.0`         | N/A           | Monorepo       | Released               |
 | 21    | `react-v0.7.0`   | N/A             | `0.7.0`       | Monorepo       | Released               |
-| 22    | `toolkit-v4.10.0` | `4.10.0`       | N/A           | Monorepo       | Released               |
-| 23    | `react-v0.9.0`    | N/A            | `0.9.0`       | Monorepo       | Released               |
-| 24    | `toolkit-v4.11.0` | `4.11.0`       | N/A           | Monorepo       | Released               |
-| 25    | `react-v0.10.0`   | N/A            | `0.10.0`      | Monorepo       | Released               |
-| 26    | `toolkit-v4.12.0` | `4.12.0`       | N/A           | Monorepo       | Released               |
-| 27    | `react-v0.11.0`   | N/A            | `0.11.0`      | Monorepo       | Released               |
+| 22    | `react-v0.8.0`    | N/A            | `0.8.0`       | Monorepo       | Released               |
+| 23    | `toolkit-v4.10.0` | `4.10.0`       | N/A           | Monorepo       | Released               |
+| 24    | `react-v0.9.0`    | N/A            | `0.9.0`       | Monorepo       | Released               |
+| 25    | `toolkit-v4.11.0` | `4.11.0`       | N/A           | Monorepo       | Released               |
+| 26    | `react-v0.10.0`   | N/A            | `0.10.0`      | Monorepo       | Released               |
+| 27    | `toolkit-v4.12.0` | `4.12.0`       | N/A           | Monorepo       | Released               |
+| 28    | `react-v0.11.0`   | N/A            | `0.11.0`      | Monorepo       | Released               |
 
 ## References
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -9,7 +9,7 @@ Install the packaged GitHub release artifact:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.10.0/ourfuturehealth-react-components-0.10.0.tgz",
+    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.11.0/ourfuturehealth-react-components-0.11.0.tgz",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   }
@@ -59,6 +59,7 @@ import {
   LinkSkip,
   Radios,
   Select,
+  SummaryList,
   Tag,
   Textarea,
   TextInput,
@@ -76,6 +77,15 @@ function App() {
     { value: 'email', label: 'Email' },
     { value: 'phone', label: 'Phone' },
     { value: 'post', label: 'Post' },
+  ];
+  const summaryRows = [
+    {
+      key: { text: 'Name' },
+      value: { text: 'Sarah Philips' },
+      actions: {
+        items: [{ href: '#name', text: 'Change', visuallyHiddenText: 'name' }],
+      },
+    },
   ];
 
   return (
@@ -96,6 +106,15 @@ function App() {
         We will review your answers and let you know if we need any more
         information.
       </Expander>
+      <SummaryList rows={summaryRows} />
+      <Details summary="Why we ask for this">
+        We use your answers to tailor the information you see next.
+      </Details>
+      <Expander summary="What happens next">
+        We will review your answers and let you know if we need any more
+        information.
+      </Expander>
+      <SummaryList rows={summaryRows} />
       <Tag variant="brand">Beta</Tag>
       <Button variant="contained">Click me</Button>
       <Icon name="Search" size={24} />
@@ -204,6 +223,7 @@ The package also provides:
 - `Checkboxes`
 - `Radios`
 - `Icon`
+- `SummaryList`
 
 ### ErrorSummary
 

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/react-components",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "description": "React component library for OFH Design System",
   "packageManager": "pnpm@10.29.2",

--- a/packages/react-components/src/components/SummaryList/SummaryList.stories.tsx
+++ b/packages/react-components/src/components/SummaryList/SummaryList.stories.tsx
@@ -37,7 +37,7 @@ const defaultRows = [
 ];
 
 const meta: Meta<typeof SummaryList> = {
-  title: 'Components/SummaryList',
+  title: 'Components/Summary list',
   component: SummaryList,
   parameters: {
     layout: 'padded',

--- a/packages/react-components/src/components/SummaryList/SummaryList.stories.tsx
+++ b/packages/react-components/src/components/SummaryList/SummaryList.stories.tsx
@@ -1,5 +1,10 @@
+import type { ComponentProps } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { SummaryList } from './SummaryList';
+
+type SummaryListStoryArgs = ComponentProps<typeof SummaryList> & {
+  showActions?: boolean;
+};
 
 const defaultRows = [
   {
@@ -36,7 +41,155 @@ const defaultRows = [
   },
 ];
 
-const meta: Meta<typeof SummaryList> = {
+const rowsWithoutActions = defaultRows.map((row) => {
+  const nextRow = { ...row };
+  delete nextRow.actions;
+  return nextRow;
+});
+
+const defaultSummaryListCode = `import { SummaryList } from '@ourfuturehealth/react-components';
+
+const defaultRows = [
+  {
+    key: { text: 'Name' },
+    value: { text: 'Sarah Philips' },
+    actions: {
+      items: [
+        {
+          href: '#name',
+          text: 'Change',
+          visuallyHiddenText: 'name',
+        },
+      ],
+    },
+  },
+  {
+    key: { text: 'Date of birth' },
+    value: { text: '5 January 1978' },
+    actions: {
+      items: [
+        {
+          href: '#date-of-birth',
+          text: 'Change',
+          visuallyHiddenText: 'date of birth',
+        },
+      ],
+    },
+  },
+  {
+    key: { text: 'Contact details' },
+    value: {
+      html: '<p>07700 900457</p><p>sarah.phillips@example.com</p>',
+    },
+  },
+];
+
+<SummaryList rows={defaultRows} padded />;
+`;
+
+const compactSummaryListCode = `import { SummaryList } from '@ourfuturehealth/react-components';
+
+const defaultRows = [
+  {
+    key: { text: 'Name' },
+    value: { text: 'Sarah Philips' },
+    actions: {
+      items: [
+        {
+          href: '#name',
+          text: 'Change',
+          visuallyHiddenText: 'name',
+        },
+      ],
+    },
+  },
+  {
+    key: { text: 'Date of birth' },
+    value: { text: '5 January 1978' },
+    actions: {
+      items: [
+        {
+          href: '#date-of-birth',
+          text: 'Change',
+          visuallyHiddenText: 'date of birth',
+        },
+      ],
+    },
+  },
+  {
+    key: { text: 'Contact details' },
+    value: {
+      html: '<p>07700 900457</p><p>sarah.phillips@example.com</p>',
+    },
+  },
+];
+
+<SummaryList rows={defaultRows} padded={false} />;
+`;
+
+const withoutActionsSummaryListCode = `import { SummaryList } from '@ourfuturehealth/react-components';
+
+const rowsWithoutActions = [
+  {
+    key: { text: 'Name' },
+    value: { text: 'Sarah Philips' },
+  },
+  {
+    key: { text: 'Date of birth' },
+    value: { text: '5 January 1978' },
+  },
+  {
+    key: { text: 'Contact details' },
+    value: {
+      html: '<p>07700 900457</p><p>sarah.phillips@example.com</p>',
+    },
+  },
+];
+
+<SummaryList rows={rowsWithoutActions} padded />;
+`;
+
+const withoutBorderSummaryListCode = `import { SummaryList } from '@ourfuturehealth/react-components';
+
+const defaultRows = [
+  {
+    key: { text: 'Name' },
+    value: { text: 'Sarah Philips' },
+    actions: {
+      items: [
+        {
+          href: '#name',
+          text: 'Change',
+          visuallyHiddenText: 'name',
+        },
+      ],
+    },
+  },
+  {
+    key: { text: 'Date of birth' },
+    value: { text: '5 January 1978' },
+    actions: {
+      items: [
+        {
+          href: '#date-of-birth',
+          text: 'Change',
+          visuallyHiddenText: 'date of birth',
+        },
+      ],
+    },
+  },
+  {
+    key: { text: 'Contact details' },
+    value: {
+      html: '<p>07700 900457</p><p>sarah.phillips@example.com</p>',
+    },
+  },
+];
+
+<SummaryList rows={defaultRows} padded={false} noBorder />;
+`;
+
+const meta: Meta<SummaryListStoryArgs> = {
   title: 'Components/Summary list',
   component: SummaryList,
   parameters: {
@@ -44,7 +197,7 @@ const meta: Meta<typeof SummaryList> = {
     docs: {
       description: {
         component:
-          'Use Summary List to show key-value pairs such as review answers. The React component mirrors the toolkit `<dl>` markup, supports the same action links, and exposes the padded and compact spacing variants used in the design system docs.',
+          'Use Summary List to show key-value pairs such as review answers. The React API is intentionally small: `rows` defines the content, `padded` switches between the roomier and denser layouts, and `noBorder` removes the separators between rows. `classes`, `className`, `attributes`, and `ref` are integration props rather than the main consumer API. The Builder story uses a Storybook-only `showActions` helper so you can flip row actions on and off without editing raw JSON.',
       },
     },
   },
@@ -52,22 +205,38 @@ const meta: Meta<typeof SummaryList> = {
   args: {
     rows: defaultRows,
     padded: true,
+    noBorder: false,
+    showActions: true,
   },
+  render: ({ showActions = true, rows = defaultRows, ...args }) => (
+    <SummaryList
+      {...args}
+      rows={showActions ? rows : rowsWithoutActions}
+    />
+  ),
   argTypes: {
     rows: {
       control: false,
       description:
-        'The list rows rendered as key/value pairs with optional action links.',
+        'Ordered key/value rows rendered in the summary list. Each row can also include optional action links when users need a way to change an answer.',
     },
     padded: {
       control: 'boolean',
       description:
-        'Use the relaxed spacing from the Figma reference. Turn this off for the denser compact layout.',
+        'Use the roomier spacing from the Figma reference. Turn this off for the denser compact layout.',
     },
     noBorder: {
       control: 'boolean',
       description:
         'Removes the separator line between rows while keeping the rest of the summary list structure intact.',
+    },
+    showActions: {
+      control: 'boolean',
+      description:
+        'Storybook-only helper used by the Builder story to show or hide the row action links without editing the raw rows array.',
+      table: {
+        disable: true,
+      },
     },
     classes: {
       control: false,
@@ -79,7 +248,7 @@ const meta: Meta<typeof SummaryList> = {
     },
     className: {
       control: false,
-      description: 'React className for the root `<dl>` element.',
+      description: 'React `className` for the root `<dl>` element.',
       table: {
         category: 'Advanced',
       },
@@ -105,20 +274,74 @@ const meta: Meta<typeof SummaryList> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      source: {
+        code: defaultSummaryListCode,
+      },
+      description: {
+        story:
+          'A realistic summary list with action links and mixed content types, including HTML content for the contact details row.',
+      },
+    },
+  },
+};
+
+export const Builder: Story = {
+  parameters: {
+    controls: {
+      include: ['showActions', 'padded', 'noBorder'],
+    },
+    docs: {
+      description: {
+        story:
+          'Interactive builder story. Use the Storybook-only `showActions` helper together with the real `padded` and `noBorder` props to explore the component without raw JSON editing.',
+      },
+    },
+  },
+};
 
 export const Compact: Story = {
   args: {
     padded: false,
   },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      source: {
+        code: compactSummaryListCode,
+      },
+      description: {
+        story:
+          'The compact layout uses the denser spacing variant while keeping the same row content.',
+      },
+    },
+  },
 };
 
 export const WithoutActions: Story = {
   args: {
-    rows: defaultRows.map((row) => ({
-      key: row.key,
-      value: row.value,
-    })),
+    rows: rowsWithoutActions,
+  },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      source: {
+        code: withoutActionsSummaryListCode,
+      },
+      description: {
+        story:
+          'Summary list rows without action links. Use this when the content is read-only.',
+      },
+    },
   },
 };
 
@@ -126,5 +349,19 @@ export const WithoutBorder: Story = {
   args: {
     padded: false,
     noBorder: true,
+  },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      source: {
+        code: withoutBorderSummaryListCode,
+      },
+      description: {
+        story:
+          'Compact summary list rows with the row separators removed.',
+      },
+    },
   },
 };

--- a/packages/react-components/src/components/SummaryList/SummaryList.stories.tsx
+++ b/packages/react-components/src/components/SummaryList/SummaryList.stories.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import { SummaryList } from './SummaryList';
 
 type SummaryListStoryArgs = ComponentProps<typeof SummaryList> & {
@@ -189,6 +190,44 @@ const defaultRows = [
 <SummaryList rows={defaultRows} padded={false} noBorder />;
 `;
 
+const summaryListUsageExample = `import { SummaryList } from '@ourfuturehealth/react-components';
+
+const rows = [
+  {
+    key: { text: 'Name' },
+    value: { text: 'Sarah Philips' },
+    actions: {
+      items: [
+        {
+          href: '#name',
+          text: 'Change',
+          visuallyHiddenText: 'name',
+        },
+      ],
+    },
+  },
+  {
+    key: { text: 'Date of birth' },
+    value: { text: '5 January 1978' },
+  },
+];
+
+<SummaryList rows={rows} padded />;
+`;
+
+const summaryListRowsShapeExample = `type SummaryListRow = {
+  key: { text?: string; html?: string };
+  value: { text?: string; html?: string };
+  actions?: {
+    items: Array<{
+      href: string;
+      text: string;
+      visuallyHiddenText?: string;
+    }>;
+  };
+};
+`;
+
 const meta: Meta<SummaryListStoryArgs> = {
   title: 'Components/Summary list',
   component: SummaryList,
@@ -199,6 +238,52 @@ const meta: Meta<SummaryListStoryArgs> = {
         component:
           'Use Summary List to show key-value pairs such as review answers. The React API is intentionally small: `rows` defines the content, `padded` switches between the roomier and denser layouts, and `noBorder` removes the separators between rows. `classes`, `className`, `attributes`, and `ref` are integration props rather than the main consumer API. The Builder story uses a Storybook-only `showActions` helper so you can flip row actions on and off without editing raw JSON.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Use <code>SummaryList</code> to show key-value answers such as
+            review information before submission. Pass the content through the{' '}
+            <code>rows</code> array, then use <code>padded</code> and{' '}
+            <code>noBorder</code> to switch between the published layout
+            variants.
+          </p>
+          <p>
+            Add row <code>actions</code> only when users need a clear way to
+            change an answer. Use HTML values sparingly when the value cell
+            needs richer markup such as stacked contact details.
+          </p>
+          <Source code={summaryListUsageExample} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes
+            of={SummaryList}
+            include={['rows', 'padded', 'noBorder', 'classes', 'className', 'attributes']}
+          />
+
+          <h2>
+            <code>rows</code> shape
+          </h2>
+          <p>
+            Each entry in the <code>rows</code> array follows this shape:
+          </p>
+          <Source code={summaryListRowsShapeExample} language="tsx" />
+
+          <h2>Storybook builder helpers</h2>
+          <p>
+            <code>showActions</code> is only used by the Storybook{' '}
+            <code>Builder</code> story so you can toggle the row actions on and
+            off without editing the real <code>rows</code> prop directly. It is
+            not a React prop accepted by <code>SummaryList</code>.
+          </p>
+
+          <h2>Examples</h2>
+          <Stories title="Examples" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],

--- a/packages/react-components/src/components/SummaryList/SummaryList.stories.tsx
+++ b/packages/react-components/src/components/SummaryList/SummaryList.stories.tsx
@@ -1,0 +1,130 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { SummaryList } from './SummaryList';
+
+const defaultRows = [
+  {
+    key: { text: 'Name' },
+    value: { text: 'Sarah Philips' },
+    actions: {
+      items: [
+        {
+          href: '#name',
+          text: 'Change',
+          visuallyHiddenText: 'name',
+        },
+      ],
+    },
+  },
+  {
+    key: { text: 'Date of birth' },
+    value: { text: '5 January 1978' },
+    actions: {
+      items: [
+        {
+          href: '#date-of-birth',
+          text: 'Change',
+          visuallyHiddenText: 'date of birth',
+        },
+      ],
+    },
+  },
+  {
+    key: { text: 'Contact details' },
+    value: {
+      html: '<p>07700 900457</p><p>sarah.phillips@example.com</p>',
+    },
+  },
+];
+
+const meta: Meta<typeof SummaryList> = {
+  title: 'Components/SummaryList',
+  component: SummaryList,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Use Summary List to show key-value pairs such as review answers. The React component mirrors the toolkit `<dl>` markup, supports the same action links, and exposes the padded and compact spacing variants used in the design system docs.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    rows: defaultRows,
+    padded: true,
+  },
+  argTypes: {
+    rows: {
+      control: false,
+      description:
+        'The list rows rendered as key/value pairs with optional action links.',
+    },
+    padded: {
+      control: 'boolean',
+      description:
+        'Use the relaxed spacing from the Figma reference. Turn this off for the denser compact layout.',
+    },
+    noBorder: {
+      control: 'boolean',
+      description:
+        'Removes the separator line between rows while keeping the rest of the summary list structure intact.',
+    },
+    classes: {
+      control: false,
+      description:
+        'Toolkit-style additional classes for the root `<dl>` element.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+    className: {
+      control: false,
+      description: 'React className for the root `<dl>` element.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+    attributes: {
+      control: false,
+      description:
+        'Additional HTML attributes forwarded to the root `<dl>` element.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+    ref: {
+      control: false,
+      description: 'React ref for the root `<dl>` element.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Compact: Story = {
+  args: {
+    padded: false,
+  },
+};
+
+export const WithoutActions: Story = {
+  args: {
+    rows: defaultRows.map((row) => ({
+      key: row.key,
+      value: row.value,
+    })),
+  },
+};
+
+export const WithoutBorder: Story = {
+  args: {
+    padded: false,
+    noBorder: true,
+  },
+};

--- a/packages/react-components/src/components/SummaryList/SummaryList.test.tsx
+++ b/packages/react-components/src/components/SummaryList/SummaryList.test.tsx
@@ -1,0 +1,139 @@
+import { createRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import { axe } from 'vitest-axe';
+import { describe, expect, it } from 'vitest';
+import { SummaryList } from './SummaryList';
+
+describe('SummaryList', () => {
+  const rows = [
+    {
+      key: { text: 'Name' },
+      value: { text: 'Sarah Philips' },
+      actions: {
+        items: [
+          {
+            href: '#name',
+            text: 'Change',
+            visuallyHiddenText: 'name',
+          },
+        ],
+      },
+    },
+    {
+      key: { text: 'Contact details' },
+      value: {
+        html: '<p>07700 900457</p><p>sarah.phillips@example.com</p>',
+      },
+    },
+  ];
+
+  it('renders summary list rows with toolkit classes', () => {
+    render(<SummaryList rows={rows} />);
+
+    const summaryList = document.querySelector('.ofh-summary-list');
+
+    expect(summaryList).toHaveClass(
+      'ofh-summary-list',
+      'ofh-summary-list--padded',
+    );
+    expect(document.querySelectorAll('.ofh-summary-list__row')).toHaveLength(2);
+    expect(screen.getByText('Name')).toHaveClass('ofh-summary-list__key');
+    expect(screen.getByText('Sarah Philips')).toHaveClass(
+      'ofh-summary-list__value',
+    );
+    expect(
+      screen.getByRole('link', { name: 'Change name' }),
+    ).toBeInTheDocument();
+  });
+
+  it('prefers html content over text content', () => {
+    render(
+      <SummaryList
+        rows={[
+          {
+            key: {
+              text: 'Fallback key',
+              html: '<span>HTML key</span>',
+            },
+            value: {
+              text: 'Fallback value',
+              html: '<span>HTML value</span>',
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('HTML key')).toBeInTheDocument();
+    expect(screen.queryByText('Fallback key')).not.toBeInTheDocument();
+    expect(screen.getByText('HTML value')).toBeInTheDocument();
+    expect(screen.queryByText('Fallback value')).not.toBeInTheDocument();
+  });
+
+  it('renders multiple actions with visible separators', () => {
+    render(
+      <SummaryList
+        rows={[
+          {
+            key: { text: 'Name' },
+            value: { text: 'Sarah Philips' },
+            actions: {
+              items: [
+                {
+                  href: '#change',
+                  text: 'Change',
+                  visuallyHiddenText: 'name',
+                },
+                {
+                  href: '#remove',
+                  text: 'Remove',
+                  visuallyHiddenText: 'name',
+                },
+              ],
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: 'Change name' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Remove name' })).toBeInTheDocument();
+    expect(document.querySelectorAll('.ofh-summary-list__actions-list-item')).toHaveLength(2);
+  });
+
+  it('applies compact and no-border modifiers together', () => {
+    render(
+      <SummaryList
+        rows={rows}
+        padded={false}
+        noBorder
+        className="custom-summary-list"
+      />,
+    );
+
+    const summaryList = document.querySelector('.ofh-summary-list');
+
+    expect(summaryList).toHaveClass(
+      'ofh-summary-list--compact',
+      'ofh-summary-list--no-border',
+      'custom-summary-list',
+    );
+  });
+
+  it('forwards refs to the summary list element', () => {
+    const ref = createRef<HTMLDListElement>();
+
+    render(<SummaryList ref={ref} rows={rows} />);
+
+    expect(ref.current).toBeInstanceOf(HTMLDListElement);
+    expect(ref.current).toHaveClass('ofh-summary-list');
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(<SummaryList rows={rows} />);
+
+    const results = await axe(container);
+
+    expect(results.violations).toHaveLength(0);
+  });
+});

--- a/packages/react-components/src/components/SummaryList/SummaryList.tsx
+++ b/packages/react-components/src/components/SummaryList/SummaryList.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { joinClasses } from '../../internal/ofhUtils';
+
+export interface SummaryListContent {
+  text?: React.ReactNode;
+  html?: string;
+  classes?: string;
+}
+
+export interface SummaryListActionItem {
+  href: string;
+  text?: React.ReactNode;
+  html?: string;
+  visuallyHiddenText?: string;
+  attributes?: Omit<
+    React.AnchorHTMLAttributes<HTMLAnchorElement>,
+    'children' | 'dangerouslySetInnerHTML' | 'href' | 'ref'
+  >;
+}
+
+export interface SummaryListRow {
+  key: SummaryListContent;
+  value: SummaryListContent;
+  actions?: {
+    items: SummaryListActionItem[];
+    classes?: string;
+  };
+  classes?: string;
+}
+
+export interface SummaryListProps
+  extends Omit<React.HTMLAttributes<HTMLDListElement>, 'children' | 'ref'> {
+  rows: SummaryListRow[];
+  padded?: boolean;
+  noBorder?: boolean;
+  classes?: string;
+  attributes?: Record<string, string | number | boolean | null | undefined>;
+  ref?: React.Ref<HTMLDListElement>;
+}
+
+function renderSummaryListContent(
+  tagName: 'dt' | 'dd',
+  content: SummaryListContent,
+  className: string,
+) {
+  if (content.html) {
+    return React.createElement(tagName, {
+      className,
+      dangerouslySetInnerHTML: { __html: content.html },
+    });
+  }
+
+  return React.createElement(tagName, { className }, content.text);
+}
+
+function renderActionLink(
+  action: SummaryListActionItem,
+) {
+  const visibleContent = action.html ? (
+    <span dangerouslySetInnerHTML={{ __html: action.html }} />
+  ) : (
+    action.text
+  );
+
+  return (
+    <a
+      {...action.attributes}
+      href={action.href}
+    >
+      {visibleContent}
+      {action.visuallyHiddenText ? (
+        <>
+          {' '}
+          <span className="ofh-u-visually-hidden">
+            {action.visuallyHiddenText}
+          </span>
+        </>
+      ) : null}
+    </a>
+  );
+}
+
+export const SummaryList = ({
+  rows,
+  padded = true,
+  noBorder = false,
+  classes = '',
+  className = '',
+  attributes,
+  ref,
+  ...props
+}: SummaryListProps) => {
+  const summaryListClasses = joinClasses(
+    'ofh-summary-list',
+    padded ? 'ofh-summary-list--padded' : 'ofh-summary-list--compact',
+    noBorder ? 'ofh-summary-list--no-border' : undefined,
+    classes,
+    className,
+  );
+
+  return (
+    <dl {...attributes} {...props} ref={ref} className={summaryListClasses}>
+      {rows.map((row, rowIndex) => {
+        const rowClasses = joinClasses(
+          'ofh-summary-list__row',
+          row.classes,
+        );
+        const keyClassName = joinClasses(
+          'ofh-summary-list__key',
+          row.key.classes,
+        );
+        const valueClassName = joinClasses(
+          'ofh-summary-list__value',
+          row.value.classes,
+        );
+        const actionsClassName = joinClasses(
+          'ofh-summary-list__actions',
+          row.actions?.classes,
+        );
+
+        return (
+          <div className={rowClasses} key={`summary-list-row-${rowIndex}`}>
+            {renderSummaryListContent('dt', row.key, keyClassName)}
+            {renderSummaryListContent('dd', row.value, valueClassName)}
+            {row.actions?.items?.length ? (
+              <dd className={actionsClassName}>
+                {row.actions.items.length === 1 ? (
+                  renderActionLink(row.actions.items[0])
+                ) : (
+                  <ul className="ofh-summary-list__actions-list">
+                    {row.actions.items.map((action, index) => (
+                      <li
+                        className="ofh-summary-list__actions-list-item"
+                        key={`${action.href}-${index}`}
+                      >
+                        {renderActionLink(action)}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </dd>
+            ) : null}
+          </div>
+        );
+      })}
+    </dl>
+  );
+};
+
+SummaryList.displayName = 'SummaryList';

--- a/packages/react-components/src/components/SummaryList/SummaryList.tsx
+++ b/packages/react-components/src/components/SummaryList/SummaryList.tsx
@@ -99,7 +99,12 @@ export const SummaryList = ({
   );
 
   return (
-    <dl {...attributes} {...props} ref={ref} className={summaryListClasses}>
+    <dl
+      {...(attributes as React.HTMLAttributes<HTMLDListElement>)}
+      {...props}
+      ref={ref}
+      className={summaryListClasses}
+    >
       {rows.map((row, rowIndex) => {
         const rowClasses = joinClasses(
           'ofh-summary-list__row',

--- a/packages/react-components/src/components/SummaryList/index.ts
+++ b/packages/react-components/src/components/SummaryList/index.ts
@@ -1,0 +1,7 @@
+export { SummaryList } from './SummaryList';
+export type {
+  SummaryListActionItem,
+  SummaryListContent,
+  SummaryListProps,
+  SummaryListRow,
+} from './SummaryList';

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -85,3 +85,11 @@ export type { CardDoDontItem, CardDoDontProps } from './components/CardDoDont';
 
 export { Tag } from './components/Tag';
 export type { TagProps, TagVariant } from './components/Tag';
+
+export { SummaryList } from './components/SummaryList';
+export type {
+  SummaryListActionItem,
+  SummaryListContent,
+  SummaryListProps,
+  SummaryListRow,
+} from './components/SummaryList';

--- a/packages/site/views/design-system/components/summary-list/index.njk
+++ b/packages/site/views/design-system/components/summary-list/index.njk
@@ -3,7 +3,7 @@
 {% set subSection = "Components" %}
 {% set pageDescription = "Use the summary list to summarise information, for example, a user’s responses at the end of a form." %}
 {% set theme = "Content presentation" %}
-{% set dateUpdated = "August 2020" %}
+{% set dateUpdated = "April 2026" %}
 {% set backlog_issue_id = "36" %}
 
 {% extends "app-layout.njk" %}
@@ -35,22 +35,10 @@
   <h2>How to use summary lists</h2>
   <p>There are 2 ways to use the summary list component. You can use HTML or, if you’re using <a href="https://mozilla.github.io/nunjucks/">Nunjucks</a> or the <a href="https://nhsuk-prototype-kit.azurewebsites.net/docs">NHS.UK prototype kit</a>, you can use the Nunjucks macro.</p>
 
-  {{ designExample({
-    group: "components",
-    item: "summary-list",
-    type: "default"
-  }) }}
-
   <h3 id="summary-list-with-actions">Summary list with actions</h3>
-  <p>You can add actions to a summary list, like a "Change" link to let users go back and edit their answer.</p>
+  <p>The default example above shows the summary list with actions, including the standard "Change" links that let users go back and edit an answer.</p>
   <p>People who use assistive technology, like a screen reader, may hear the action links out of context and not know what they do. To give more context, add visually hidden text to the links. This means a screen reader user will hear a meaningful action, like "Change name" or "Change date of birth".</p>
   <p>On larger screens, the list uses a three-column layout with the key taking about one quarter of the width, the value taking about two quarters, and the actions taking the remaining quarter. The default layout keeps the row spacing padded; set <code>padded: false</code> for the denser version.</p>
-
-  {{ designExample({
-    group: "components",
-    item: "summary-list",
-    type: "default"
-  }) }}
 
   <h3 id="summary-list-without-actions">Summary list without actions</h3>
 

--- a/packages/site/views/design-system/components/summary-list/index.njk
+++ b/packages/site/views/design-system/components/summary-list/index.njk
@@ -41,9 +41,10 @@
     type: "default"
   }) }}
 
-  <h3 id="label-text-inputs">Summary list with actions</h3>
+  <h3 id="summary-list-with-actions">Summary list with actions</h3>
   <p>You can add actions to a summary list, like a "Change" link to let users go back and edit their answer.</p>
   <p>People who use assistive technology, like a screen reader, may hear the action links out of context and not know what they do. To give more context, add visually hidden text to the links. This means a screen reader user will hear a meaningful action, like "Change name" or "Change date of birth".</p>
+  <p>On larger screens, the list uses a three-column layout with the key taking about one quarter of the width, the value taking about two quarters, and the actions taking the remaining quarter. The default layout keeps the row spacing padded; set <code>padded: false</code> for the denser version.</p>
 
   {{ designExample({
     group: "components",
@@ -51,7 +52,7 @@
     type: "default"
   }) }}
 
-  <h3 id="label-text-inputs">Summary list without actions</h3>
+  <h3 id="summary-list-without-actions">Summary list without actions</h3>
 
   {{ designExample({
     group: "components",
@@ -59,8 +60,8 @@
     type: "without-action"
   }) }}
 
-  <h3 id="label-text-inputs">Summary list without actions or borders</h3>
-  <p class="rich-text">If you do not include actions in your summary list and it would be better for your design to remove the separating borders, use the <code>nhsuk-summary-list--no-border</code> class.</p>
+  <h3 id="summary-list-without-actions-or-borders">Summary list without actions or borders</h3>
+  <p class="rich-text">If you want the denser spacing from the compact layout, set <code>padded: false</code>. If you also want to remove the separating borders, add the <code>ofh-summary-list--no-border</code> class.</p>
 
   {{ designExample({
     group: "components",

--- a/packages/site/views/design-system/components/summary-list/macro-options.json
+++ b/packages/site/views/design-system/components/summary-list/macro-options.json
@@ -82,6 +82,12 @@
               "type": "string",
               "required": false,
               "description": "Actions rely on context from the surrounding content so may require additional accessible text, text supplied to this option is appended to the end, use `html` for more complicated scenarios."
+            },
+            {
+              "name": "attributes",
+              "type": "object",
+              "required": false,
+              "description": "HTML attributes (for example data attributes) to add to the action link."
             }
           ]
         }

--- a/packages/site/views/design-system/components/summary-list/macro-options.json
+++ b/packages/site/views/design-system/components/summary-list/macro-options.json
@@ -98,6 +98,18 @@
       "type": "object",
       "required": false,
       "description": "HTML attributes (for example data attributes) to add to the summary list container."
+    },
+    {
+      "name": "padded",
+      "type": "boolean",
+      "required": false,
+      "description": "Use the default padded spacing on larger screens. Set to `false` for the denser compact layout."
+    },
+    {
+      "name": "noBorder",
+      "type": "boolean",
+      "required": false,
+      "description": "Remove the separator line between rows while keeping the rest of the summary list structure intact."
     }
   ]
 }

--- a/packages/site/views/design-system/components/summary-list/without-border/index.njk
+++ b/packages/site/views/design-system/components/summary-list/without-border/index.njk
@@ -1,6 +1,7 @@
 {% from 'summary-list/macro.njk' import summaryList %}
 
 {{ summaryList({
+  padded: false,
   classes: 'ofh-summary-list--no-border',
   rows: [
     {

--- a/packages/site/views/examples/components/summary-list/without-border.njk
+++ b/packages/site/views/examples/components/summary-list/without-border.njk
@@ -12,6 +12,7 @@
         <div class="ofh-grid-column-two-thirds">
 
           {{ summaryList({
+            padded: false,
             classes: 'ofh-summary-list--no-border',
             rows: [
               {

--- a/packages/toolkit/components/summary-list/README.md
+++ b/packages/toolkit/components/summary-list/README.md
@@ -251,7 +251,7 @@
 #### HTML markup
 
 ```html
-<dl class="ofh-summary-list ofh-summary-list--no-border">
+<dl class="ofh-summary-list ofh-summary-list--compact ofh-summary-list--no-border">
   <div class="ofh-summary-list__row">
     <dt class="ofh-summary-list__key">
       Name
@@ -296,6 +296,7 @@
 {% from "components/summary-list/macro.njk" import summaryList %}
 
 {{ summaryList({
+  padded: false,
   classes: 'ofh-summary-list--no-border',
   rows: [
     {

--- a/packages/toolkit/components/summary-list/README.md
+++ b/packages/toolkit/components/summary-list/README.md
@@ -345,19 +345,23 @@ The summary list Nunjucks macro takes the following arguments:
 | -----------------|----------|-----------|-------------|
 | classes          | string   | No        | Classes to add to the container. |
 | attributes       | object   | No        | HTML attributes (for example data attributes) to add to the container. |
+| padded           | boolean  | No        | Uses the default padded spacing. Set to `false` for the denser compact layout. |
+| noBorder         | boolean  | No        | Removes the separator line between rows while keeping the rest of the summary list structure intact. |
 | rows             | array    | Yes       | Array of row item objects. |
+| rows.classes     | string   | No        | Classes to add to the row `div`. |
 | rows.key.text    | string   | Yes       | If html is set, this is not required. Text to use within the each key. If html is provided, the text argument will be ignored. |
 | rows.key.html    | string   | Yes       | |
 | rows.key.classes | string   | No        | Classes to add to the key wrapper. |
 | rows.value.text	 | string   | Yes        | If html is set, this is not required. Text to use within the each value. If html is provided, the text argument will be ignored. |
 | rows.value.html  | string   | Yes        | If text is set, this is not required. HTML to use within the each value. If html is provided, the text argument will be ignored. |
-| rows.key.classes | string   | No         | Classes to add to the value wrapper. |
+| rows.value.classes | string | No         | Classes to add to the value wrapper. |
+| rows.actions.classes | string | No       | Classes to add to the actions wrapper. |
 | rows.actions.items | array   | No        | Array of action item objects. |
-| action.items.classes | string   | No     | Classes to add to the actions wrapper. |
-| action.items.href | string   | Yes     | The value of the link href attribute for an action item. |
-| action.items.text | string   | Yes     | If html is set, this is not required. Text to use within each action item. If html is provided, the text argument will be ignored. |
-| action.items.html | string   | Yes     | If text is set, this is not required. HTML to use within the each action item. If html is provided, the text argument will be ignored. |
-| action.items.visuallyHiddenText	 | string   | Yes     | Actions rely on context from the surrounding content so may require additional accessible text, text supplied to this option is appended to the end, use html for more complicated scenarios. |
+| rows.actions.items.href | string | Yes   | The value of the link href attribute for an action item. |
+| rows.actions.items.text | string | Yes   | If html is set, this is not required. Text to use within each action item. If html is provided, the text argument will be ignored. |
+| rows.actions.items.html | string | Yes   | If text is set, this is not required. HTML to use within each action item. If html is provided, the text argument will be ignored. |
+| rows.actions.items.visuallyHiddenText | string | No | Actions rely on context from the surrounding content so may require additional accessible text, text supplied to this option is appended to the end, use html for more complicated scenarios. |
+| rows.actions.items.attributes | object | No | HTML attributes (for example data attributes) to add to the action link. |
 
 If you are using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `html` can be a [security risk](https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting). Read more about this in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).
 

--- a/packages/toolkit/components/summary-list/_summary-list.scss
+++ b/packages/toolkit/components/summary-list/_summary-list.scss
@@ -77,7 +77,7 @@
 }
 
 .ofh-summary-list__actions {
-  margin-top: $ofh-size-4;
+  @include ofh-responsive-margin(16, 'top');
 
   @include mq($from: tablet) {
     margin-top: 0;

--- a/packages/toolkit/components/summary-list/_summary-list.scss
+++ b/packages/toolkit/components/summary-list/_summary-list.scss
@@ -7,33 +7,33 @@
  * https://github.com/alphagov/govuk-frontend
  *
  * 1. Required to allow us to wrap words that overflow.
- * 2. Reset default user agent styles
- * 3. Automatic wrapping for unbreakable text (e.g. URLs)
- * 4. Fallback for older browsers only
+ * 2. Reset default user agent styles.
+ * 3. Automatic wrapping for unbreakable text (e.g. URLs).
+ * 4. Fallback for older browsers only.
  */
 
 .ofh-summary-list {
   @include ofh-font($size: 'paragraph-md');
-
-  @include mq($from: tablet) {
-    display: table;
-    table-layout: fixed; /* [1] */
-    width: 100%;
-  }
-
   margin: 0; /* [2] */
-
   @include ofh-responsive-margin(32, 'bottom');
 }
 
 .ofh-summary-list__row {
-  @include mq($until: tablet) {
-    border-bottom: 1px solid $ofh-color-border-primary;
-    margin-bottom: $ofh-size-16;
-  }
+  border-bottom: 1px solid $ofh-color-border-primary;
+  margin: 0; /* [2] */
+  padding-block: $ofh-size-16;
 
   @include mq($from: tablet) {
-    display: table-row;
+    display: grid;
+    gap: $ofh-size-24;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 2fr) minmax(0, 0.75fr);
+    padding-block: $ofh-size-16;
+  }
+}
+
+.ofh-summary-list--compact .ofh-summary-list__row {
+  @include mq($from: tablet) {
+    padding-block: $ofh-size-8;
   }
 }
 
@@ -41,51 +41,27 @@
 .ofh-summary-list__value,
 .ofh-summary-list__actions {
   margin: 0; /* [2] */
-  vertical-align: top;
-
-  @include mq($from: tablet) {
-    border-bottom: 1px solid $ofh-color-border-primary;
-    display: table-cell;
-    padding-bottom: $ofh-size-8;
-    padding-right: $ofh-size-24;
-    padding-top: $ofh-size-8;
-  }
-}
-
-.ofh-summary-list__actions {
-  margin-bottom: $ofh-size-16;
-
-  @include mq($from: tablet) {
-    padding-right: 0;
-    text-align: right;
-    width: 20%;
-  }
-}
-
-.ofh-summary-list__key,
-.ofh-summary-list__value {
-  /* [3] */
   overflow-wrap: break-word;
+  vertical-align: top;
   word-wrap: break-word; /* [4] */
+
+  @include mq($from: tablet) {
+    min-width: 0;
+  }
 }
 
 .ofh-summary-list__key {
   @include ofh-typography-weight-bold;
-
   margin-bottom: $ofh-size-4;
 
   @include mq($from: tablet) {
-    width: 30%;
+    margin-bottom: 0;
   }
 }
 
 .ofh-summary-list__value {
-  @include mq($until: tablet) {
-    margin-bottom: $ofh-size-16;
-  }
-
   @include mq($from: tablet) {
-    width: 50%;
+    margin-bottom: 0;
   }
 }
 
@@ -97,33 +73,39 @@
   margin-bottom: 0;
 }
 
+.ofh-summary-list__actions {
+  margin-top: $ofh-size-4;
+
+  @include mq($from: tablet) {
+    margin-top: 0;
+    text-align: right;
+  }
+}
+
+.ofh-summary-list__actions a {
+  display: inline-block;
+}
+
 .ofh-summary-list__actions-list {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0 $ofh-size-8;
+  list-style: none;
   margin: 0; /* [2] */
   padding: 0; /* [2] */
-  width: 100%;
 }
 
 .ofh-summary-list__actions-list-item {
-  display: inline;
-  margin-right: $ofh-size-8;
-  padding-right: $ofh-size-8;
+  display: inline-flex;
 }
 
 .ofh-summary-list__actions-list-item:not(:last-child) {
   border-right: 1px solid $ofh-color-border-primary;
-}
-
-.ofh-summary-list__actions-list-item:last-child {
-  border: 0;
-  margin-right: 0;
-  padding-right: 0;
+  padding-right: $ofh-size-8;
 }
 
 .ofh-summary-list--no-border {
-  .ofh-summary-list__key,
-  .ofh-summary-list__value,
-  .ofh-summary-list__actions,
   .ofh-summary-list__row {
-    border: 0;
+    border-bottom: 0;
   }
 }

--- a/packages/toolkit/components/summary-list/_summary-list.scss
+++ b/packages/toolkit/components/summary-list/_summary-list.scss
@@ -14,7 +14,9 @@
 
 .ofh-summary-list {
   @include ofh-font($size: 'paragraph-md');
+
   margin: 0; /* [2] */
+
   @include ofh-responsive-margin(32, 'bottom');
 }
 
@@ -52,6 +54,7 @@
 
 .ofh-summary-list__key {
   @include ofh-typography-weight-bold;
+
   margin-bottom: $ofh-size-4;
 
   @include mq($from: tablet) {

--- a/packages/toolkit/components/summary-list/template.njk
+++ b/packages/toolkit/components/summary-list/template.njk
@@ -13,7 +13,7 @@
 {% else %}
   {% set summaryListClasses = summaryListClasses + ' ofh-summary-list--compact' %}
 {% endif %}
-{% if params.noBorder or 'ofh-summary-list--no-border' in (params.classes or '') %}
+{% if params.noBorder and 'ofh-summary-list--no-border' not in (params.classes or '') %}
   {% set summaryListClasses = summaryListClasses + ' ofh-summary-list--no-border' %}
 {% endif %}
 {% if params.classes %}

--- a/packages/toolkit/components/summary-list/template.njk
+++ b/packages/toolkit/components/summary-list/template.njk
@@ -1,29 +1,43 @@
 {%- macro _link(action) %}
-  <a href="{{ action.href }}">
+  <a href="{{ action.href }}"{% if action.attributes %}{% for attribute, value in action.attributes %} {{attribute}}="{{value}}"{% endfor %}{% endif %}>
     {{ action.html | safe if action.html else action.text }}
     {%- if action.visuallyHiddenText -%}
-      <span class="ofh-u-visually-hidden"> {{ action.visuallyHiddenText }}</span>
+      <span class="ofh-u-visually-hidden">{{ action.visuallyHiddenText }}</span>
     {% endif -%}
   </a>
 {% endmacro -%}
-<dl class="ofh-summary-list {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+
+{% set summaryListClasses = 'ofh-summary-list' %}
+{% if params.padded != false %}
+  {% set summaryListClasses = summaryListClasses + ' ofh-summary-list--padded' %}
+{% else %}
+  {% set summaryListClasses = summaryListClasses + ' ofh-summary-list--compact' %}
+{% endif %}
+{% if params.noBorder or 'ofh-summary-list--no-border' in (params.classes or '') %}
+  {% set summaryListClasses = summaryListClasses + ' ofh-summary-list--no-border' %}
+{% endif %}
+{% if params.classes %}
+  {% set summaryListClasses = summaryListClasses + ' ' + params.classes %}
+{% endif %}
+
+<dl class="{{ summaryListClasses }}"{% for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   {% for row in params.rows %}
-    <div class="ofh-summary-list__row">
+    <div class="ofh-summary-list__row {%- if row.classes %} {{ row.classes }}{% endif %}">
       <dt class="ofh-summary-list__key {%- if row.key.classes %} {{ row.key.classes }}{% endif %}">
         {{ row.key.html | safe if row.key.html else row.key.text }}
       </dt>
       <dd class="ofh-summary-list__value {%- if row.value.classes %} {{ row.value.classes }}{% endif %}">
-        {{ row.value.html | indent(8) | trim | safe if row.value.html else row.value.text }}
+        {{ row.value.html | safe if row.value.html else row.value.text }}
       </dd>
       {% if row.actions.items %}
         <dd class="ofh-summary-list__actions {%- if row.actions.classes %} {{ row.actions.classes }}{% endif %}">
           {% if row.actions.items.length == 1 %}
-            {{ _link(row.actions.items[0]) | indent(12) | trim }}
+            {{ _link(row.actions.items[0]) | trim }}
           {% else %}
             <ul class="ofh-summary-list__actions-list">
               {% for action in row.actions.items %}
                 <li class="ofh-summary-list__actions-list-item">
-                  {{ _link(action) | indent(18) | trim }}
+                  {{ _link(action) | trim }}
                 </li>
               {% endfor %}
             </ul>

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/toolkit",
-  "version": "4.11.0",
+  "version": "4.12.0",
   "description": "Our Future Health design system toolkit contains the code you need to start building user interfaces for Our Future Health websites and services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
This PR delivers **DSE-331 summary list refresh** across toolkit, React, the docs site, and Storybook.

It aligns the summary list with the current Figma treatment, introduces the first public React `SummaryList` component, and updates Storybook so the summary list stories follow the newer `Docs` / `Default` / `Builder` / showcase teaching pattern.

Ticket: DSE-331

## Release scope
- `@ourfuturehealth/toolkit` -> `4.12.0`
- `@ourfuturehealth/react-components` -> `0.11.0`
- updates release metadata in `CHANGELOG.md`, `UPGRADING.md`, `docs/release-versioning-strategy.md`, `docs/consuming-react-components.md`, and `packages/react-components/README.md`

## Breaking Changes
- None.

## Key Changes
- refreshes the toolkit `summary-list` component to the current Figma structure across the default, compact, without-actions, and no-border treatments
- adds explicit toolkit macro options for `padded: false` and `noBorder: true` while preserving compatibility for existing `ofh-summary-list--no-border` usage
- adds the first public React `SummaryList` component with optional action links, compact spacing, and no-border support
- keeps toolkit, docs site, and Storybook aligned on the same summary-row structure and responsive stacked action treatment
- fixes stacked action spacing on smaller breakpoints so the responsive spacing matches the current Figma token behaviour
- updates Storybook docs so they teach the real React API more clearly, including the `rows` shape and the distinction between real props and the Storybook-only `showActions` helper
- keeps `Default` as a realistic fixed example, `Builder` as the interactive surface, and the other stories as fixed showcase examples
- backfills the missing `react-v0.8.0` release-history entry so the changelog, upgrading guide, and version-correlation docs accurately reflect the earlier React-only `spritePath` removal release

## Validation
- `npm test`
- `pnpm lint`
- `pnpm build`
- `pnpm docs:release-contract`
- `pnpm smoke:release-artifacts`
- `pnpm --filter=@ourfuturehealth/react-components build:storybook`
- manual QA on summary list docs, Storybook stories, and responsive behavior

## Reviewer Focus
- summary-list spacing and stacked action treatment on smaller breakpoints
- explicit `padded` and `noBorder` macro options versus existing class-based compatibility
- Storybook should now teach the component using the newer docs/default/builder/showcase pattern
- the React `SummaryList` API and the `rows` shape guidance should be easy for consumers to follow
- release metadata should line up on `toolkit-v4.12.0` / `react-v0.11.0`
- release-history docs should now include the previously missing `react-v0.8.0` entry
