### PR TITLE
Fix React icon rendering in published consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ## Monorepo Package Releases (`toolkit-v*`, `react-v*`)
 
+### Unreleased
+
+#### @ourfuturehealth/react-components 0.8.0 (`react-v0.8.0`)
+
+##### ⚠️ BREAKING CHANGES
+
+- React `Icon` and `Card` icon configuration no longer accept `spritePath`. React icons now always render from bundled toolkit SVG data.
+
+##### Fixed
+
+- React icons now render correctly in published-consumer installs by inlining the requested bundled SVG symbol instead of referencing a bundled `data:` sprite URL.
+
 ### 2026-04-09
 
 #### @ourfuturehealth/toolkit 4.9.0 (`toolkit-v4.9.0`)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,18 +6,69 @@ This guide provides detailed migration instructions for upgrading between versio
 
 ## Breaking Changes by Version
 
-| Version                                                 | Date          | Breaking Changes      | Migration Complexity                  |
-| ------------------------------------------------------- | ------------- | --------------------- | ------------------------------------- |
-| [v4.9.0 / React v0.7.0](#upgrading-to-v490--react-v070) | April 2026    | Icon naming sync    | 🟡 Medium - Search/replace icon names  |
-| [v4.8.0 / React v0.6.0](#upgrading-to-v480--react-v060) | March 2026    | No breaking changes | 🟢 Low - only relevant if you adopted the earlier TextInput prototype |
-| [v4.7.0 / React v0.5.0](#upgrading-to-v470--react-v050) | March 2026    | Card family realignment | 🟡 Medium - API migration recommended |
-| [v4.6.0 / React v0.4.0](#upgrading-to-v460--react-v040) | March 2026    | Tag default + naming  | 🟡 Medium - Search/replace recommended |
+| Version                                                 | Date          | Breaking Changes           | Migration Complexity                     |
+| ------------------------------------------------------- | ------------- | -------------------------- | ---------------------------------------- |
+| [React v0.8.0](#upgrading-to-react-v080)                | April 2026    | React `spritePath` removal | 🟢 Low - Remove the deprecated prop      |
+| [v4.9.0 / React v0.7.0](#upgrading-to-v490--react-v070) | April 2026    | Icon naming sync           | 🟡 Medium - Search/replace icon names    |
+| [v4.8.0 / React v0.6.0](#upgrading-to-v480--react-v060) | March 2026    | No breaking changes        | 🟢 Low - only relevant if you adopted the earlier TextInput prototype |
+| [v4.7.0 / React v0.5.0](#upgrading-to-v470--react-v050) | March 2026    | Card family realignment    | 🟡 Medium - API migration recommended    |
+| [v4.6.0 / React v0.4.0](#upgrading-to-v460--react-v040) | March 2026    | Tag default + naming       | 🟡 Medium - Search/replace recommended   |
 | [v4.5.0](#upgrading-to-v450)                            | March 2026    | Spacing and typography API changes | 🟡 Medium - Replace legacy APIs and recheck overrides |
-| [v4.3.0 / React v0.2.0](#upgrading-to-v430--react-v020) | March 2026    | Button variant naming | 🟡 Medium - Find/replace required     |
-| [v4.1.0](#upgrading-to-v410)                            | February 2026 | Spacing scale indices | 🟡 Medium - Index updates required    |
-| [v4.0.0](#upgrading-to-v400-monorepo-restructure)       | 2025          | Monorepo restructure  | 🔴 High - Installation & paths change |
+| [v4.3.0 / React v0.2.0](#upgrading-to-v430--react-v020) | March 2026    | Button variant naming      | 🟡 Medium - Find/replace required        |
+| [v4.1.0](#upgrading-to-v410)                            | February 2026 | Spacing scale indices      | 🟡 Medium - Index updates required       |
+| [v4.0.0](#upgrading-to-v400-monorepo-restructure)       | 2025          | Monorepo restructure       | 🔴 High - Installation & paths change    |
 
 ---
+
+## Upgrading to React v0.8.0
+
+**Planned:** April 2026
+**Affected packages:**
+
+- `@ourfuturehealth/react-components` v0.8.0+
+
+### Breaking Changes
+
+`@ourfuturehealth/react-components` removes the `spritePath` prop from the public `Icon` API and from `Card` icon configuration. React icons now always render from bundled toolkit SVG data.
+
+### Migration Steps
+
+1. Remove any `spritePath` prop from `Icon` usage.
+2. Remove any `spritePath` field from `Card` icon configuration objects.
+3. Re-run visual checks for icon-bearing surfaces such as `Icon`, `Select`, `Card`, and `Checkboxes`.
+
+#### React example
+
+**Before:**
+
+```tsx
+<Icon name="Search" spritePath="/assets/icons/icon-sprite.svg" />
+
+<Card
+  icon={{
+    name: 'Search',
+    spritePath: '/assets/icons/icon-sprite.svg',
+  }}
+/>
+```
+
+**After:**
+
+```tsx
+<Icon name="Search" />
+
+<Card
+  icon={{
+    name: 'Search',
+  }}
+/>
+```
+
+If an application previously passed `spritePath` in React, that prop should now be removed.
+
+### Toolkit reminder
+
+Toolkit/Nunjucks icon consumers are unchanged. They must still serve `icon-sprite.svg` at a public URL, default `/assets/icons/icon-sprite.svg`, or override that URL with `spritePath`.
 
 ## Upgrading to v4.9.0 / React v0.7.0
 

--- a/docs/consuming-react-components.md
+++ b/docs/consuming-react-components.md
@@ -130,7 +130,7 @@ The React components package currently provides the following components:
 - `CharacterCount` - Text input and textarea variants with count feedback
 - `Checkboxes` - Grouped checkbox inputs with hints, exclusive options, and conditional reveals
 - `Radios` - Grouped radio inputs with hints and conditional reveals
-- `Icon` - Toolkit sprite icon component with fixed and responsive sizing
+- `Icon` - Toolkit icon component with fixed and responsive sizing using bundled SVG data
 - `ErrorSummary` - Page-level validation summaries with linked errors
 - `Tag` - Status tags aligned with toolkit Tag variants
 - `Card` - Content presentation cards for summaries, status, and next steps

--- a/docs/contributing/material-icons.md
+++ b/docs/contributing/material-icons.md
@@ -111,6 +111,8 @@ The macro renders:
 - An `<svg>` element with `.ofh-icon` classes
 - A `<use href="/assets/icons/icon-sprite.svg#ofh-icon-<name>">`
 
+Toolkit consumers must make that sprite file available at a public URL the browser can request. Installing the package places the file in `node_modules/@ourfuturehealth/toolkit/assets/icons/icon-sprite.svg`, but the consuming app still needs to copy or serve it as `/assets/icons/icon-sprite.svg`, or override the URL with `spritePath`.
+
 Example usage:
 
 ```njk
@@ -133,7 +135,7 @@ React icon names should stay aligned with toolkit `manifest.json` and the genera
 Current React approach:
 
 - Reuses the toolkit sprite semantics (`name`, `size`, responsive sizing, decorative vs titled)
-- Defaults to the bundled toolkit sprite asset and references symbols with `<use>`
+- Bundles toolkit icon data into the React package and renders the requested symbol inline
 - Treats icon-name changes as consumer-facing API changes that must be documented in release notes and the upgrading guide
 
 Related package: [`packages/react-components/`](../../packages/react-components/)

--- a/docs/installation/installing-with-npm.md
+++ b/docs/installation/installing-with-npm.md
@@ -27,7 +27,7 @@ Add the dependency to `package.json`:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/toolkit": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/toolkit-v4.0.0/ourfuturehealth-toolkit-4.0.0.tgz"
+    "@ourfuturehealth/toolkit": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/toolkit-v{version}/ourfuturehealth-toolkit-{version}.tgz"
   }
 }
 ```
@@ -42,7 +42,7 @@ npm install
 yarn install
 ```
 
-Use a specific tag for production upgrades. Replace `4.0.0` with the toolkit version you intend to consume.
+Use a specific tag for production upgrades. Replace `{version}` with the toolkit version you intend to consume.
 
 ### Unreleased maintainer testing
 
@@ -67,7 +67,7 @@ You will usually need these pieces:
 
 - [Importing styles](#importing-styles)
 - [Importing JavaScript](#importing-javascript)
-- [Importing assets (optional)](#importing-assets-optional)
+- [Importing assets](#importing-assets)
 
 ## Importing styles
 
@@ -152,9 +152,21 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 ```
 
-## Importing assets (optional)
+## Importing assets
 
 Toolkit assets are available under `node_modules/@ourfuturehealth/toolkit/assets/`.
+
+If you use the toolkit `icon` macro or any toolkit component that renders an icon, your app must also publish the sprite file at a browser-visible URL. The default toolkit path is `/assets/icons/icon-sprite.svg`, so the usual setup is to copy:
+
+- `node_modules/@ourfuturehealth/toolkit/assets/icons/icon-sprite.svg`
+
+to:
+
+- `/assets/icons/icon-sprite.svg`
+
+The browser cannot read files directly from `node_modules`, so installing the package is not enough on its own.
+
+If your app serves the sprite from a different public URL, pass that URL to the toolkit icon macro with `spritePath`.
 
 ```html
 <link rel="shortcut icon" href="path-to-assets/favicons/favicon.ico" type="image/x-icon" />

--- a/docs/release-versioning-strategy.md
+++ b/docs/release-versioning-strategy.md
@@ -60,7 +60,7 @@ Consumers must install the package release tarball:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/toolkit": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/toolkit-v4.9.0/ourfuturehealth-toolkit-4.9.0.tgz"
+    "@ourfuturehealth/toolkit": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/toolkit-v{version}/ourfuturehealth-toolkit-{version}.tgz"
   }
 }
 ```
@@ -70,7 +70,7 @@ React consumers follow the same contract:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.7.0/ourfuturehealth-react-components-0.7.0.tgz"
+    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v{version}/ourfuturehealth-react-components-{version}.tgz"
   }
 }
 ```
@@ -126,8 +126,9 @@ This table is a visual aid for pre-monorepo versus post-monorepo releases.
 | 17    | `react-v0.5.0`   | N/A             | `0.5.0`       | Monorepo       | Released               |
 | 18    | `toolkit-v4.8.0` | `4.8.0`         | N/A           | Monorepo       | Released               |
 | 19    | `react-v0.6.0`   | N/A             | `0.6.0`       | Monorepo       | Released               |
-| 20    | `toolkit-v4.9.0` | `4.9.0`         | N/A           | Monorepo       | Planned in this branch |
-| 21    | `react-v0.7.0`   | N/A             | `0.7.0`       | Monorepo       | Planned in this branch |
+| 20    | `toolkit-v4.9.0` | `4.9.0`         | N/A           | Monorepo       | Released               |
+| 21    | `react-v0.7.0`   | N/A             | `0.7.0`       | Monorepo       | Released               |
+| 22    | `react-v0.8.0`   | N/A             | `0.8.0`       | Monorepo       | Planned in this branch |
 
 ## References
 

--- a/packages/example-react-consumer-app/README.md
+++ b/packages/example-react-consumer-app/README.md
@@ -7,6 +7,9 @@ This app is intentionally configured as a standalone published-consumer example:
 - it installs the released `@ourfuturehealth/react-components` tarball
 - it imports the published theme stylesheet bundle
 - it does not use the monorepo workspace protocol
+- it exercises icon-bearing components such as `Icon`, `Select`, `Card`, and `Checkboxes`
+
+The dependency in `package.json` intentionally stays on the current published release tag. For unreleased branch validation, use the local tarball workflow below.
 
 ## Install and run
 
@@ -29,6 +32,7 @@ pnpm dev:react-consumer
 - a published tarball install works in a real consumer app
 - the exported React components render in a Vite application
 - the published stylesheet entrypoints load correctly
+- current input-family and icon-bearing components can be smoke-tested outside Storybook
 
 This makes it useful as guidance for future React consumers outside the toolkit repo.
 

--- a/packages/example-react-consumer-app/package-lock.json
+++ b/packages/example-react-consumer-app/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example-react-consumer-app",
       "version": "0.0.0",
       "dependencies": {
-        "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.5.0/ourfuturehealth-react-components-0.5.0.tgz",
+        "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.7.0/ourfuturehealth-react-components-0.7.0.tgz",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
       },
@@ -24,7 +24,7 @@
         "globals": "^16.5.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.46.4",
-        "vite": "^7.2.4"
+        "vite": "^7.3.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -58,6 +58,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1011,9 +1012,9 @@
       }
     },
     "node_modules/@ourfuturehealth/react-components": {
-      "version": "0.5.0",
-      "resolved": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.5.0/ourfuturehealth-react-components-0.5.0.tgz",
-      "integrity": "sha512-tzrbnh5Inf+zUIE/mY7lmtuvnKFKm8hv/eQT/K+2yGXixNJE7X1Iluv1OMHMwjWngAkJJR9iAD7sythJ6jFrVA==",
+      "version": "0.7.0",
+      "resolved": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.7.0/ourfuturehealth-react-components-0.7.0.tgz",
+      "integrity": "sha512-xNoC6BmH5RLsvWKW4/dJhUP/6Mh4GJ5tZJRbBTg/SMOu5W74m7lIZgzmtAFu1rHpaBbQ3hyCnMtsPmqk0ocM0Q==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^19.2.4",
@@ -1442,6 +1443,7 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1452,6 +1454,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1511,6 +1514,7 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -1788,6 +1792,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1896,6 +1901,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2117,6 +2123,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2803,6 +2810,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2864,6 +2872,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2873,6 +2882,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3069,6 +3079,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3155,6 +3166,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3276,6 +3288,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/packages/example-react-consumer-app/package.json
+++ b/packages/example-react-consumer-app/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint . --ignore-pattern '*.config.js'"
   },
   "dependencies": {
-    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.5.0/ourfuturehealth-react-components-0.5.0.tgz",
+    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.7.0/ourfuturehealth-react-components-0.7.0.tgz",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/packages/example-react-consumer-app/src/App.css
+++ b/packages/example-react-consumer-app/src/App.css
@@ -1,8 +1,12 @@
+/*
+ * This published-consumer example uses plain CSS instead of toolkit Sass imports,
+ * so these values mirror the closest design-system static tokens directly.
+ */
 #root {
   min-height: 100vh;
   background:
-    radial-gradient(circle at top left, rgba(0, 102, 102, 0.08), transparent 28rem),
-    linear-gradient(180deg, #f5f7f8 0%, #ffffff 100%);
+    radial-gradient(circle at top left, rgba(0, 160, 138, 0.08), transparent 28rem),
+    linear-gradient(180deg, #f4f4f4 0%, #ffffff 100%);
 }
 
 body {
@@ -43,10 +47,10 @@ body {
 
 .consumer-app__panel {
   padding: 1.5rem;
-  border: 1px solid #d8dde0;
+  border: 1px solid #d1d1d1;
   border-radius: 1rem;
   background-color: #ffffff;
-  box-shadow: 0 0.5rem 1.5rem rgba(18, 38, 49, 0.06);
+  box-shadow: 0 0.5rem 1.5rem rgba(27, 27, 27, 0.06);
 }
 
 .consumer-app__section-title {
@@ -66,7 +70,7 @@ body {
 
 .consumer-app__status {
   margin: 1rem 0 0;
-  color: #0f766e;
+  color: #00725f;
   font-weight: 600;
 }
 
@@ -88,9 +92,9 @@ body {
   gap: 0.5rem;
   min-width: 8rem;
   padding: 0.75rem 1rem;
-  border: 1px solid #d8dde0;
+  border: 1px solid #d1d1d1;
   border-radius: 0.75rem;
-  background-color: #f8fafb;
+  background-color: #e8e8e8;
 }
 
 .consumer-app__icon-label {

--- a/packages/example-react-consumer-app/src/App.css
+++ b/packages/example-react-consumer-app/src/App.css
@@ -77,6 +77,27 @@ body {
   gap: 0.75rem;
 }
 
+.consumer-app__icon-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.consumer-app__icon-swatch {
+  display: grid;
+  gap: 0.5rem;
+  min-width: 8rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid #d8dde0;
+  border-radius: 0.75rem;
+  background-color: #f8fafb;
+}
+
+.consumer-app__icon-label {
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
 .consumer-app__tag-row {
   margin-top: 1rem;
 }

--- a/packages/example-react-consumer-app/src/App.tsx
+++ b/packages/example-react-consumer-app/src/App.tsx
@@ -1,41 +1,107 @@
-import { useId, useMemo, useState } from 'react';
+import { useId, useState } from 'react';
 import {
   Button,
   Card,
   CardCallout,
   CardDoDont,
+  Checkboxes,
   ErrorSummary,
+  Icon,
+  Radios,
+  Select,
   Tag,
   TextInput,
+  Textarea,
 } from '@ourfuturehealth/react-components';
 import './App.css';
+
+const serviceItems = [
+  { text: 'Choose a support topic', value: '' },
+  { text: 'Participant support', value: 'participant-support' },
+  { text: 'Appointments and logistics', value: 'appointments' },
+  { text: 'Results and follow-up', value: 'results' },
+];
+
+const contactMethodItems = [
+  {
+    value: 'email',
+    label: 'Email',
+    hint: 'Best when you want a written response with links and next steps.',
+  },
+  {
+    value: 'phone',
+    label: 'Phone call',
+    hint: 'Useful for time-sensitive requests or more complex questions.',
+  },
+];
+
+const updatePreferenceItems = [
+  {
+    value: 'appointments',
+    label: 'Appointment reminders',
+    hint: 'Get reminders before booked research visits.',
+  },
+  {
+    value: 'results',
+    label: 'Results updates',
+    hint: 'Hear when new information is available in your OFH account.',
+  },
+  {
+    value: 'research',
+    label: 'Research opportunities',
+    hint: 'Receive invitations to relevant studies and follow-up surveys.',
+  },
+];
+
+const iconExamples = [
+  { name: 'UnfoldMore', label: 'Select affordance' },
+  { name: 'CalendarOutline', label: 'Scheduling' },
+  { name: 'CheckCircle', label: 'Success state' },
+] as const;
+
+type ErrorSummaryItem = {
+  href: string;
+  text: string;
+};
 
 function App() {
   const nameId = useId();
   const emailId = useId();
+  const serviceId = useId();
+  const notesId = useId();
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
+  const [service, setService] = useState('');
+  const [notes, setNotes] = useState('');
+  const [contactMethod, setContactMethod] = useState('email');
+  const [updatePreferences, setUpdatePreferences] = useState<string[]>([
+    'appointments',
+    'results',
+  ]);
   const [showErrors, setShowErrors] = useState(false);
 
-  const errors = useMemo(() => {
-    const nextErrors = [];
+  const errors: ErrorSummaryItem[] = [];
 
-    if (!name.trim()) {
-      nextErrors.push({
-        href: `#${nameId}`,
-        text: 'Enter your full name',
-      });
-    }
+  if (!name.trim()) {
+    errors.push({
+      href: `#${nameId}`,
+      text: 'Enter your full name',
+    });
+  }
 
-    if (!email.trim()) {
-      nextErrors.push({
-        href: `#${emailId}`,
-        text: 'Enter your email address',
-      });
-    }
+  if (!email.trim()) {
+    errors.push({
+      href: `#${emailId}`,
+      text: 'Enter your email address',
+    });
+  }
 
-    return nextErrors;
-  }, [email, emailId, name, nameId]);
+  if (!service) {
+    errors.push({
+      href: `#${serviceId}`,
+      text: 'Choose a support topic',
+    });
+  }
 
   const hasSubmissionErrors = showErrors && errors.length > 0;
 
@@ -46,18 +112,25 @@ function App() {
   const handleReset = () => {
     setName('');
     setEmail('');
+    setService('');
+    setNotes('');
+    setContactMethod('email');
+    setUpdatePreferences(['appointments', 'results']);
     setShowErrors(false);
   };
 
   return (
     <main className="consumer-app">
       <header className="consumer-app__hero">
-        <Tag variant="brand">Published tarball consumer</Tag>
+        <div className="consumer-app__tag-row">
+          <Tag variant="brand">Published tarball consumer</Tag>
+        </div>
         <h1 className="consumer-app__title">React consumer example</h1>
         <p className="consumer-app__lede">
           This app demonstrates how an external React application consumes the
           published <code>@ourfuturehealth/react-components</code> package and
-          one of its theme stylesheets.
+          one of its theme stylesheets. It now exercises direct icons, icon-led
+          cards, selection controls, and the input family more thoroughly.
         </p>
       </header>
 
@@ -72,10 +145,18 @@ function App() {
       <section className="consumer-app__grid">
         <div className="consumer-app__stack">
           <Card
-            heading="Profile details"
-            description="This section shows TextInput, ErrorSummary, Button, and Tag working together in a consumer app."
-            helperText="The form is intentionally simple and is here to validate basic interactive states."
-            tag={{ variant: 'blue', children: 'Interactive demo' }}
+            heading="Support request"
+            description="This card validates icon rendering, metadata icons, tags, and action-link treatment in a published-consumer setup."
+            helperText="Use the form below to exercise current input and selection states."
+            tag={{ variant: 'blue', children: 'Smoke test' }}
+            icon={{
+              name: 'CalendarOutline',
+              title: 'Scheduling icon',
+            }}
+            metadataItems={[
+              { icon: 'ClockOutline', text: 'Approx. 3 minute completion' },
+              { icon: 'LocationOutline', text: 'Participant services team' },
+            ]}
           />
 
           <section className="consumer-app__panel">
@@ -88,7 +169,7 @@ function App() {
                 hint="Enter the name that appears on your OFH account"
                 value={name}
                 onChange={(event) => setName(event.target.value)}
-                error={hasSubmissionErrors && !name.trim() ? 'Enter your full name' : ''}
+                errorMessage={hasSubmissionErrors && !name.trim() ? 'Enter your full name' : ''}
                 required
               />
             </div>
@@ -101,9 +182,34 @@ function App() {
                 type="email"
                 value={email}
                 onChange={(event) => setEmail(event.target.value)}
-                error={hasSubmissionErrors && !email.trim() ? 'Enter your email address' : ''}
+                errorMessage={
+                  hasSubmissionErrors && !email.trim() ? 'Enter your email address' : ''
+                }
                 width="three-quarters"
                 required
+              />
+            </div>
+
+            <div className="consumer-app__field">
+              <Select
+                id={serviceId}
+                label="Support topic"
+                hint="Select shows the published Select chevron and current option styling."
+                items={serviceItems}
+                value={service}
+                onChange={(event) => setService(String(event.target.value))}
+                errorMessage={hasSubmissionErrors && !service ? 'Choose a support topic' : ''}
+              />
+            </div>
+
+            <div className="consumer-app__field">
+              <Textarea
+                id={notesId}
+                label="Additional notes"
+                hint="Textarea is included here as another current input-family component."
+                rows={5}
+                value={notes}
+                onChange={(event) => setNotes(event.target.value)}
               />
             </div>
 
@@ -129,12 +235,54 @@ function App() {
             text="This example is intended to mirror an external consumer using the published release tarball, not a workspace dependency."
           />
 
+          <section className="consumer-app__panel">
+            <h2 className="consumer-app__section-title">Selection controls</h2>
+
+            <Radios
+              name="contact-method"
+              legend="Preferred contact method"
+              hint="This validates radio inputs and legend support in the published app."
+              value={contactMethod}
+              onChange={(value) => setContactMethod(String(value))}
+              items={contactMethodItems}
+            />
+
+            <div className="consumer-app__field">
+              <Checkboxes
+                name="updates"
+                legend="Updates you would like to receive"
+                hint="Checkboxes exercise another icon-bearing control because the check mark uses the shared React Icon."
+                value={updatePreferences}
+                onChange={(values) =>
+                  setUpdatePreferences(values.map((value) => String(value)))
+                }
+                items={updatePreferenceItems}
+              />
+            </div>
+          </section>
+
+          <section className="consumer-app__panel">
+            <h2 className="consumer-app__section-title">Icon showcase</h2>
+            <div className="consumer-app__icon-row">
+              {iconExamples.map((iconExample) => (
+                <div className="consumer-app__icon-swatch" key={iconExample.name}>
+                  <Icon
+                    name={iconExample.name}
+                    title={iconExample.label}
+                    responsiveSize={24}
+                  />
+                  <span className="consumer-app__icon-label">{iconExample.label}</span>
+                </div>
+              ))}
+            </div>
+          </section>
+
           <CardDoDont
             type="do"
             items={[
               { item: 'Import one published theme stylesheet in your app entry point' },
-              { item: 'Install the release tarball rather than using git subdirectory syntax' },
-              { item: 'Keep React and React DOM aligned with the package peer dependencies' },
+              { item: 'Install the release tarball rather than using a workspace dependency' },
+              { item: 'Exercise at least one icon-bearing component when smoke testing a release' },
             ]}
           />
         </div>

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -9,12 +9,14 @@ Install the packaged GitHub release artifact:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.7.0/ourfuturehealth-react-components-0.7.0.tgz",
+    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v{version}/ourfuturehealth-react-components-{version}.tgz",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   }
 }
 ```
+
+Replace `{version}` with the React release you intend to consume.
 
 Then run your package manager install command. This release-tarball contract is smoke-tested against Yarn 1, npm, and pnpm.
 
@@ -242,7 +244,8 @@ A card for short do and don’t recommendation lists.
 
 ### Icons
 
-React components bundle the toolkit icon sprite automatically. Use the public `Icon` component rather than maintaining app-local sprite helpers or copying `/assets/icons/icon-sprite.svg` into your own app.
+React components bundle the toolkit icon data automatically. Use the public `Icon` component rather than maintaining app-local sprite helpers or copying `/assets/icons/icon-sprite.svg` into your own app.
+React `Icon` no longer supports overriding the sprite asset path.
 
 ### Tag
 

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/react-components",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "description": "React component library for OFH Design System",
   "packageManager": "pnpm@10.29.2",

--- a/packages/react-components/src/components/Card/Card.tsx
+++ b/packages/react-components/src/components/Card/Card.tsx
@@ -35,7 +35,6 @@ export interface CardIcon {
   color?: string;
   classes?: string;
   attributes?: React.SVGAttributes<SVGSVGElement>;
-  spritePath?: string;
 }
 
 export interface CardProps
@@ -270,7 +269,6 @@ export const Card = ({
                 icon.classes,
                 iconAttributes.className,
               )}
-              spritePath={icon.spritePath}
             />
           </div>
         ) : null}

--- a/packages/react-components/src/components/Icon/Icon.stories.tsx
+++ b/packages/react-components/src/components/Icon/Icon.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof Icon> = {
     docs: {
       description: {
         component:
-          'Use Icon to render toolkit sprite icons in React. Choose exactly one sizing mode: `size` for a fixed 16/24/32 icon, or `responsiveSize` to follow the toolkit iconography scale. The responsive scale maps `16` to `16/16/16`, `24` to `16/16/24`, and `32` to `24/24/32` across mobile, tablet, and desktop. Leave `title` empty for decorative icons. Any other SVG props, such as `aria-*`, `data-*`, or event handlers, are passed straight to the rendered `<svg>` element.',
+          'Use Icon to render toolkit icons in React. Choose exactly one sizing mode: `size` for a fixed 16/24/32 icon, or `responsiveSize` to follow the toolkit iconography scale. The responsive scale maps `16` to `16/16/16`, `24` to `16/16/24`, and `32` to `24/24/32` across mobile, tablet, and desktop. Leave `title` empty for decorative icons. Any other SVG props, such as `aria-*`, `data-*`, or event handlers, are passed straight to the rendered `<svg>` element.',
       },
     },
   },
@@ -24,7 +24,7 @@ const meta: Meta<typeof Icon> = {
       control: 'select',
       options: iconNameOptions,
       description:
-        'Toolkit icon name from the generated sprite manifest. This maps directly to a symbol in `icon-sprite.svg`.',
+        'Toolkit icon name from the generated manifest. This maps directly to bundled toolkit icon data in the React package.',
     },
     size: {
       control: 'radio',
@@ -60,14 +60,6 @@ const meta: Meta<typeof Icon> = {
       control: false,
       description:
         'Optional inline SVG styles. This merges with the `color` prop when both are provided.',
-      table: {
-        category: 'Advanced',
-      },
-    },
-    spritePath: {
-      control: false,
-      description:
-        'Advanced override for the generated icon sprite asset path. In normal app usage this should come from the default toolkit asset import.',
       table: {
         category: 'Advanced',
       },

--- a/packages/react-components/src/components/Icon/Icon.test.tsx
+++ b/packages/react-components/src/components/Icon/Icon.test.tsx
@@ -50,6 +50,24 @@ describe('Icon', () => {
     expect(icon).toHaveAttribute('height', '32');
   });
 
+  it('renders no bundled SVG body for an unknown icon name', () => {
+    const { container } = render(<Icon name="NotARealIcon" />);
+
+    const icon = container.querySelector('svg');
+    const use = container.querySelector('use');
+    const group = container.querySelector('g');
+
+    expect(icon).toHaveClass(
+      'ofh-icon',
+      'ofh-icon--material',
+      'ofh-icon--24',
+      'ofh-icon--NotARealIcon',
+    );
+    expect(icon).not.toHaveAttribute('viewBox');
+    expect(use).toBeNull();
+    expect(group).toBeNull();
+  });
+
   it('renders an accessible image when title is provided', () => {
     render(<Icon name="Check" title="Completed" />);
 

--- a/packages/react-components/src/components/Icon/Icon.test.tsx
+++ b/packages/react-components/src/components/Icon/Icon.test.tsx
@@ -5,11 +5,12 @@ import { describe, expect, it, vi } from 'vitest';
 import { Icon } from './Icon';
 
 describe('Icon', () => {
-  it('renders the default 24px sprite icon classes and href', () => {
+  it('renders the default 24px icon classes and bundled SVG body', () => {
     const { container } = render(<Icon name="Check" />);
 
     const icon = container.querySelector('svg');
     const use = container.querySelector('use');
+    const group = container.querySelector('g');
 
     expect(icon).toHaveClass(
       'ofh-icon',
@@ -17,7 +18,9 @@ describe('Icon', () => {
       'ofh-icon--24',
       'ofh-icon--Check',
     );
-    expect(use).toHaveAttribute('href', expect.stringContaining('#ofh-icon-Check'));
+    expect(icon).toHaveAttribute('viewBox', '0 0 24 24');
+    expect(use).toBeNull();
+    expect(group?.innerHTML).toContain('<path');
   });
 
   it('renders the requested fixed size class and dimensions', () => {
@@ -70,14 +73,13 @@ describe('Icon', () => {
     });
   });
 
-  it('passes through advanced svg props, spritePath, and event handlers', () => {
+  it('passes through advanced svg props and event handlers', () => {
     const handleClick = vi.fn();
 
     const { container } = render(
       <Icon
         name="Check"
         title="Completed"
-        spritePath="/custom/sprite.svg"
         data-track="icon-usage"
         aria-describedby="icon-help"
         tabIndex={-1}
@@ -87,13 +89,15 @@ describe('Icon', () => {
 
     const icon = screen.getByRole('img', { name: 'Completed' });
     const use = container.querySelector('use');
+    const group = container.querySelector('g');
 
     fireEvent.click(icon);
 
     expect(icon).toHaveAttribute('data-track', 'icon-usage');
     expect(icon).toHaveAttribute('aria-describedby', 'icon-help');
     expect(icon).toHaveAttribute('tabindex', '-1');
-    expect(use).toHaveAttribute('href', '/custom/sprite.svg#ofh-icon-Check');
+    expect(use).toBeNull();
+    expect(group?.innerHTML).toContain('<path');
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/react-components/src/components/Icon/Icon.tsx
+++ b/packages/react-components/src/components/Icon/Icon.tsx
@@ -1,4 +1,4 @@
-import defaultSpritePath from '@ourfuturehealth/toolkit/assets/icons/icon-sprite.svg?url';
+import bundledSpriteContent from '@ourfuturehealth/toolkit/assets/icons/icon-sprite.svg?raw';
 import type React from 'react';
 import { joinClasses } from '../../internal/ofhUtils';
 
@@ -9,7 +9,6 @@ interface BaseIconProps
   name: string;
   title?: string;
   color?: string;
-  spritePath?: string;
   ref?: React.Ref<SVGSVGElement>;
 }
 
@@ -28,24 +27,41 @@ export type IconProps = BaseIconProps & (
   | ResponsiveIconSizeProps
 );
 
+type BundledIconDefinition = {
+  body: string;
+  viewBox: string;
+};
+
+const bundledIcons = new Map<string, BundledIconDefinition>(
+  Array.from(
+    bundledSpriteContent.matchAll(
+      /<symbol id="ofh-icon-([^"]+)" viewBox="([^"]+)">([\s\S]*?)<\/symbol>/g,
+    ),
+    ([, name, viewBox, body]) => [name, { body, viewBox }],
+  ),
+);
+
 export const Icon = ({
   name,
   size = 24,
   responsiveSize,
   title,
   color,
-  spritePath = defaultSpritePath,
   ref,
   className = '',
   style,
   ...props
 }: IconProps) => {
+  const { spritePath: _spritePath, ...svgProps } = props as React.SVGAttributes<SVGSVGElement> & {
+    spritePath?: string;
+  };
   const iconSize = [16, 24, 32].includes(responsiveSize ?? size)
     ? (responsiveSize ?? size)
     : 24;
   const sizeClass = responsiveSize
     ? `ofh-icon--responsive-${iconSize}`
     : `ofh-icon--${iconSize}`;
+  const bundledIcon = bundledIcons.get(name);
   const iconStyle =
     color || style
       ? {
@@ -56,7 +72,7 @@ export const Icon = ({
 
   return (
     <svg
-      {...props}
+      {...svgProps}
       ref={ref}
       className={joinClasses(
         'ofh-icon',
@@ -70,10 +86,13 @@ export const Icon = ({
       role={title ? 'img' : undefined}
       width={iconSize}
       height={iconSize}
+      viewBox={bundledIcon?.viewBox}
       style={iconStyle}
     >
       {title ? <title>{title}</title> : null}
-      <use href={`${spritePath}#ofh-icon-${name}`}></use>
+      {bundledIcon ? (
+        <g dangerouslySetInnerHTML={{ __html: bundledIcon.body }}></g>
+      ) : null}
     </svg>
   );
 };

--- a/packages/react-components/src/components/Icon/Icon.tsx
+++ b/packages/react-components/src/components/Icon/Icon.tsx
@@ -35,9 +35,22 @@ type BundledIconDefinition = {
 const bundledIcons = new Map<string, BundledIconDefinition>(
   Array.from(
     bundledSpriteContent.matchAll(
-      /<symbol id="ofh-icon-([^"]+)" viewBox="([^"]+)">([\s\S]*?)<\/symbol>/g,
+      /<symbol\b([^>]*)>([\s\S]*?)<\/symbol>/g,
     ),
-    ([, name, viewBox, body]) => [name, { body, viewBox }],
+    ([, attributes, body]) => {
+      const idMatch = attributes.match(/\bid="ofh-icon-([^"]+)"/);
+      const viewBoxMatch = attributes.match(/\bviewBox="([^"]+)"/);
+
+      if (!idMatch || !viewBoxMatch) {
+        return null;
+      }
+
+      return [idMatch[1], { body, viewBox: viewBoxMatch[1] }] as const;
+    },
+  ).filter(
+    (
+      icon,
+    ): icon is readonly [string, BundledIconDefinition] => icon !== null,
   ),
 );
 

--- a/packages/react-components/src/components/Icon/Icon.tsx
+++ b/packages/react-components/src/components/Icon/Icon.tsx
@@ -52,9 +52,12 @@ export const Icon = ({
   style,
   ...props
 }: IconProps) => {
-  const { spritePath: _spritePath, ...svgProps } = props as React.SVGAttributes<SVGSVGElement> & {
-    spritePath?: string;
+  const svgProps = {
+    ...(props as React.SVGAttributes<SVGSVGElement> & {
+      spritePath?: string;
+    }),
   };
+  delete svgProps.spritePath;
   const iconSize = [16, 24, 32].includes(responsiveSize ?? size)
     ? (responsiveSize ?? size)
     : 24;

--- a/packages/react-components/src/types/css-modules.d.ts
+++ b/packages/react-components/src/types/css-modules.d.ts
@@ -12,3 +12,8 @@ declare module '*.svg?url' {
   const url: string;
   export default url;
 }
+
+declare module '*.svg?raw' {
+  const content: string;
+  export default content;
+}

--- a/packages/site/views/design-system/components/icon/index.njk
+++ b/packages/site/views/design-system/components/icon/index.njk
@@ -19,6 +19,7 @@
 
   <h2 id="how-to-use-icon">How to use Icon</h2>
   <p>Import the shared macro and pass the icon name in PascalCase, for example <code>Search</code> or <code>UnfoldMore</code>.</p>
+  <p>The macro expects the toolkit sprite to be served at <code>/assets/icons/icon-sprite.svg</code>. If your app publishes the sprite somewhere else, pass that public URL with <code>spritePath</code>.</p>
 
   {{ designExample({
     group: "components",

--- a/packages/site/views/design-system/components/icon/macro-options.json
+++ b/packages/site/views/design-system/components/icon/macro-options.json
@@ -46,7 +46,7 @@
       "name": "spritePath",
       "type": "string",
       "required": false,
-      "description": "Advanced override for the sprite URL. Defaults to `/assets/icons/icon-sprite.svg`."
+      "description": "Advanced override for the public toolkit sprite URL. Use this when your app serves `icon-sprite.svg` somewhere other than `/assets/icons/icon-sprite.svg`."
     }
   ]
 }

--- a/packages/toolkit/components/icon/README.md
+++ b/packages/toolkit/components/icon/README.md
@@ -15,6 +15,14 @@ Renders Material SVG icons from the toolkit sprite.
 
 Use either `size` or `responsiveSize`, not both.
 
+## Runtime asset requirement
+
+The icon macro renders a browser URL like `/assets/icons/icon-sprite.svg#ofh-icon-Search`.
+
+Installing `@ourfuturehealth/toolkit` puts the sprite file in `node_modules/@ourfuturehealth/toolkit/assets/icons/icon-sprite.svg`, but your app still needs to serve that file publicly for the browser. The usual setup is to copy it to `/assets/icons/icon-sprite.svg`.
+
+If your app serves the toolkit sprite from a different public URL, pass that URL with `spritePath`.
+
 ## Sizing modes
 
 - Fixed `size`


### PR DESCRIPTION
## Description

This PR delivers **the React icon consumer rendering fix** across `@ourfuturehealth/react-components`, the example external-consumer app, and the consumer/release docs.

The default React `Icon` path now inlines the requested bundled SVG symbol instead of referencing a bundled `data:` sprite URL, which is what broke icons in published-consumer installs even though Storybook still looked correct.

## Release scope

React-only release: bump `@ourfuturehealth/react-components` from `0.7.0` to `0.8.0`.

Toolkit gets docs-only clarification of the hosted sprite contract; there is no toolkit package version bump in this branch.

## Breaking Changes

`spritePath` was removed from the public React `Icon` API and from `Card` icon configuration. Toolkit/Nunjucks `spritePath` remains as the hosted-sprite URL override.

## Key Changes

- inline bundled React icon symbols by default so consumer `Icon`, `Select`, `Card`, and `Checkboxes` render correctly after install
- strengthen the packaged example React consumer app to exercise icon-bearing surfaces
- clarify toolkit vs React icon install/runtime expectations and add `0.8.0` changelog, upgrading, and versioning prep

## Validation

- `npm test` in `packages/react-components`
- `npm run build` in `packages/example-react-consumer-app`
- `pnpm build`
- `pnpm docs:release-contract`
- `pnpm smoke:release-artifacts react-components`
- manual QA across Storybook, docs site, and the example consumer app

`pnpm lint` currently fails in `packages/site` on existing HTMLHint `doctype-first` errors across generated pages such as `dist/accessibility/index.html` and `dist/site-map/index.html`.

## Reviewer Focus

- `packages/react-components/src/components/Icon/Icon.tsx`
- the React `spritePath` API removal and migration docs
- the example consumer app as a real published-tarball canary
