### PR TITLE
DSE-337 :: Footer FE update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,6 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ### 2026-04-20
 
-#### @ourfuturehealth/toolkit 4.12.1 (`toolkit-v4.12.1`)
-
-##### Changed
-
-- Updated the monorepo dependency overrides so toolkit release preparation resolves `lodash` and `lodash-es` to `4.18.1`, addressing the latest lodash code injection advisory in this repo
-
 #### @ourfuturehealth/toolkit 4.13.0 (`toolkit-v4.13.0`)
 
 ##### Changed
@@ -32,6 +26,12 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 ##### Changed
 
 - Simplified the React footer Storybook controls and added participant/research theme switching so reviewers and consumers can explore curated footer configurations without editing raw nested data structures
+
+#### @ourfuturehealth/toolkit 4.12.1 (`toolkit-v4.12.1`)
+
+##### Changed
+
+- Updated the monorepo dependency overrides so toolkit release preparation resolves `lodash` and `lodash-es` to `4.18.1`, addressing the latest lodash code injection advisory in this repo
 
 #### @ourfuturehealth/toolkit 4.12.0 (`toolkit-v4.12.0`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,25 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 - Updated the monorepo dependency overrides so toolkit release preparation resolves `lodash` and `lodash-es` to `4.18.1`, addressing the latest lodash code injection advisory in this repo
 
+#### @ourfuturehealth/toolkit 4.13.0 (`toolkit-v4.13.0`)
+
+##### Changed
+
+- Refreshed the toolkit `footer` component to the current design-system treatment, including responsive main/social spacing, optional legal and social sections, and text-only support links by default
+- Composed footer support links from the shared `link-icon` pattern so directional and external cues can be enabled with footer data instead of bespoke markup, and aligned the footer accent rule to the active theme tokens
+- Expanded the footer macro, docs page, macro options, and README guidance to cover minimal, icon-led support-link, and legal-plus-social variants while preserving legacy `URL` and `copyright` compatibility
+
+#### @ourfuturehealth/react-components 0.12.0 (`react-v0.12.0`)
+
+##### Added
+
+- First public React `Footer` component with toolkit-parity support links, small print, legal copy, optional social links, and icon-aware footer link items
+- Storybook coverage and unit/accessibility tests for default, minimal, icon-led support-link, and legal-plus-social footer variants
+
+##### Changed
+
+- Simplified the React footer Storybook controls and added participant/research theme switching so reviewers and consumers can explore curated footer configurations without editing raw nested data structures
+
 #### @ourfuturehealth/toolkit 4.12.0 (`toolkit-v4.12.0`)
 
 ##### Changed

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,6 +8,7 @@ This guide provides detailed migration instructions for upgrading between versio
 
 | Version                                                 | Date          | Breaking Changes      | Migration Complexity                  |
 | ------------------------------------------------------- | ------------- | --------------------- | ------------------------------------- |
+| [v4.13.0 / React v0.12.0](#upgrading-to-v4130--react-v0120) | April 2026    | No breaking changes | 🟢 Low - adopt the public React footer if needed |
 | [v4.12.0 / React v0.11.0](#upgrading-to-v4120--react-v0110) | April 2026    | No breaking changes | 🟢 Low - adopt the public React summary list if needed |
 | [v4.11.0 / React v0.10.0](#upgrading-to-v4110--react-v0100) | April 2026    | No breaking changes | 🟢 Low - adopt the public React details family if needed |
 | [v4.10.0 / React v0.9.0](#upgrading-to-v4100--react-v090) | April 2026    | No breaking changes | 🟢 Low - Adopt the public link family and canonical names for new usage |
@@ -20,6 +21,88 @@ This guide provides detailed migration instructions for upgrading between versio
 | [v4.3.0 / React v0.2.0](#upgrading-to-v430--react-v020) | March 2026    | Button variant naming      | 🟡 Medium - Find/replace required        |
 | [v4.1.0](#upgrading-to-v410)                            | February 2026 | Spacing scale indices      | 🟡 Medium - Index updates required       |
 | [v4.0.0](#upgrading-to-v400-monorepo-restructure)       | 2025          | Monorepo restructure       | 🔴 High - Installation & paths change    |
+
+---
+
+## Upgrading to v4.13.0 / React v0.12.0
+
+**Released:** April 2026
+**Affected packages:**
+
+- `@ourfuturehealth/toolkit` v4.13.0+
+- `@ourfuturehealth/react-components` v0.12.0+
+
+### Breaking Changes
+
+None.
+
+### Release Overview
+
+This release refreshes the toolkit `footer` component to the current design-system structure and introduces the first public React `Footer` component.
+
+- Toolkit consumers can keep the default footer support links text-only while opting into shared link-icon cues when directional or external hints add value.
+- Toolkit consumers can explicitly hide the small-print line with `smallPrint` while continuing to support the legacy `copyright` alias where no migration is needed.
+- React consumers can now adopt the public `Footer` component instead of carrying local footer markup and social-link wiring.
+
+### Migration Steps
+
+1. Adopt the public React `Footer` where you need toolkit-parity page footers in React.
+2. Prefer the footer macro/data options such as `smallPrint`, `legalText`, `socialLinks`, `iconPosition`, and `iconName` instead of bespoke footer markup when updating existing Nunjucks templates.
+3. Re-run visual QA at desktop, tablet, and mobile, and validate both participant and research themes if you have local footer overrides, because the spacing, wrapping, and accent-border behavior now follows the current footer spec more closely.
+
+#### React example
+
+**New in `react-v0.12.0`:**
+
+```tsx
+import { Footer } from '@ourfuturehealth/react-components';
+```
+
+#### Toolkit example
+
+**Before (`toolkit-v4.12.0`):**
+
+```njk
+{{ footer({
+  "links": [
+    {
+      "URL": "#privacy",
+      "label": "Privacy"
+    }
+  ],
+  "copyright": "&copy; Crown copyright"
+}) }}
+```
+
+**After (`toolkit-v4.13.0`):**
+
+```njk
+{{ footer({
+  "links": [
+    {
+      "url": "#overview",
+      "label": "Back to overview",
+      "iconName": "ChevronLeft",
+      "iconPosition": "left"
+    },
+    {
+      "url": "https://example.com/guidance",
+      "label": "External guidance",
+      "iconName": "Launch",
+      "iconPosition": "right"
+    }
+  ],
+  "smallPrint": "",
+  "legalText": "Organisation legal text.",
+  "socialLinks": [
+    {
+      "platform": "linkedin",
+      "href": "https://www.linkedin.com/company/our-future-health/",
+      "openInNewWindow": true
+    }
+  ]
+}) }}
+```
 
 ---
 

--- a/docs/consuming-react-components.md
+++ b/docs/consuming-react-components.md
@@ -123,6 +123,7 @@ The React components package currently provides the following components:
 - `Button` - Call-to-action buttons and links
 - `TextInput` - Text input fields with toolkit-parity hint, error, and width support
 - `Fieldset` - Semantic fieldset wrapper for grouped form questions and legends
+- `Footer` - Page footer with support links, optional small print and legal copy, and optional social links
 - `Textarea` - Multi-line text input fields
 - `Select` - Native select inputs with toolkit styling and icon affordance
 - `DateInput` - Grouped day/month/year input fields

--- a/docs/release-versioning-strategy.md
+++ b/docs/release-versioning-strategy.md
@@ -31,9 +31,8 @@ For consumer migration instructions, use [Upgrading Guide](../UPGRADING.md).
 
 | Package                             | Canonical tag pattern | Example tag      |
 | ----------------------------------- | --------------------- | ---------------- |
-| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.12.0` |
-| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.11.0`   |
-| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.11.0`   |
+| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.13.0` |
+| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.12.0`   |
 
 The release workflow still accepts legacy toolkit tags in the `v*` format for backward compatibility, but new toolkit releases should use `toolkit-v*`.
 
@@ -61,7 +60,7 @@ Consumers must install the package release tarball:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/toolkit": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/toolkit-v4.12.0/ourfuturehealth-toolkit-4.12.0.tgz"
+    "@ourfuturehealth/toolkit": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/toolkit-v4.13.0/ourfuturehealth-toolkit-4.13.0.tgz"
   }
 }
 ```
@@ -71,7 +70,7 @@ React consumers follow the same contract:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.11.0/ourfuturehealth-react-components-0.11.0.tgz"
+    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.12.0/ourfuturehealth-react-components-0.12.0.tgz"
   }
 }
 ```
@@ -136,6 +135,8 @@ This table is a visual aid for pre-monorepo versus post-monorepo releases.
 | 26    | `react-v0.10.0`   | N/A            | `0.10.0`      | Monorepo       | Released               |
 | 27    | `toolkit-v4.12.0` | `4.12.0`       | N/A           | Monorepo       | Released               |
 | 28    | `react-v0.11.0`   | N/A            | `0.11.0`      | Monorepo       | Released               |
+| 29    | `toolkit-v4.13.0` | `4.13.0`       | N/A           | Monorepo       | Released               |
+| 30    | `react-v0.12.0`   | N/A            | `0.12.0`      | Monorepo       | Released               |
 
 ## References
 

--- a/packages/react-components/.storybook/preview.ts
+++ b/packages/react-components/.storybook/preview.ts
@@ -2,8 +2,33 @@ import React from 'react';
 import type { Preview } from '@storybook/react-vite';
 import { namespaceStoryArgs } from './namespaceStoryArgs';
 
-// import design system styles
-import '../src/styles/main.scss';
+import participantThemeCss from './themes/participant.scss?inline';
+import researchThemeCss from './themes/research.scss?inline';
+
+const OFH_STORYBOOK_THEME_STYLE_ID = 'ofh-storybook-theme';
+const OFH_THEME_STYLES = {
+  participant: participantThemeCss,
+  research: researchThemeCss,
+} as const;
+
+type OFHTheme = keyof typeof OFH_THEME_STYLES;
+
+function ensureThemeStylesheet(theme: OFHTheme) {
+  const existingElement = document.getElementById(
+    OFH_STORYBOOK_THEME_STYLE_ID,
+  );
+  const styleElement =
+    existingElement instanceof HTMLStyleElement
+      ? existingElement
+      : document.createElement('style');
+
+  styleElement.id = OFH_STORYBOOK_THEME_STYLE_ID;
+  styleElement.textContent = OFH_THEME_STYLES[theme];
+
+  if (!existingElement) {
+    document.head.appendChild(styleElement);
+  }
+}
 
 function DocsNamespacedStory({
   Story,
@@ -28,14 +53,47 @@ function DocsNamespacedStory({
   });
 }
 
+function StorybookThemeDecorator({
+  Story,
+  context,
+}: {
+  Story: Parameters<NonNullable<Preview['decorators']>[number]>[0];
+  context: Parameters<NonNullable<Preview['decorators']>[number]>[1];
+}) {
+  const theme: OFHTheme =
+    context.globals.ofhTheme === 'research' ? 'research' : 'participant';
+
+  React.useLayoutEffect(() => {
+    ensureThemeStylesheet(theme);
+  }, [theme]);
+
+  if (context.viewMode !== 'docs') {
+    return Story();
+  }
+
+  return React.createElement(DocsNamespacedStory, { Story, context });
+}
+
 const preview: Preview = {
+  globalTypes: {
+    ofhTheme: {
+      name: 'OFH theme',
+      description: 'Switch between participant and research theme styles',
+      defaultValue: 'participant',
+      toolbar: {
+        title: 'Theme',
+        icon: 'paintbrush',
+        dynamicTitle: true,
+        items: [
+          { value: 'participant', title: 'Participant' },
+          { value: 'research', title: 'Research' },
+        ],
+      },
+    },
+  },
   decorators: [
     (Story, context) => {
-      if (context.viewMode !== 'docs') {
-        return Story();
-      }
-
-      return React.createElement(DocsNamespacedStory, { Story, context });
+      return React.createElement(StorybookThemeDecorator, { Story, context });
     },
   ],
   parameters: {

--- a/packages/react-components/.storybook/themes/participant.scss
+++ b/packages/react-components/.storybook/themes/participant.scss
@@ -1,0 +1,3 @@
+$ofh-theme-mode: participant;
+
+@import '../../src/styles/main';

--- a/packages/react-components/.storybook/themes/research.scss
+++ b/packages/react-components/.storybook/themes/research.scss
@@ -1,0 +1,3 @@
+$ofh-theme-mode: research;
+
+@import '../../src/styles/main';

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -53,6 +53,7 @@ import {
   ErrorSummary,
   Expander,
   Fieldset,
+  Footer,
   Icon,
   LinkAction,
   LinkIcon,
@@ -128,6 +129,13 @@ function App() {
         <TextInput id="email" label="Email address" type="email" width="three-quarters" />
         <TextInput id="phone" label="Phone number" type="tel" width="two-thirds" />
       </Fieldset>
+      <Footer
+        links={[
+          { href: '#privacy', label: 'Privacy' },
+          { href: 'https://example.com/careers', label: 'Careers', external: true, openInNewWindow: true },
+        ]}
+        smallPrint="© Our Future Health 2026"
+      />
       <TextInput id="name" label="Your name" hint="Enter your full name" inputWidth={20} />
       <Textarea id="notes" label="Additional notes" />
       <Select
@@ -215,6 +223,7 @@ A form input component with toolkit-parity label, hint, error, and width support
 The package also provides:
 
 - `Fieldset`
+- `Footer`
 - `Textarea`
 - `Select`
 - `DateInput`

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -9,7 +9,7 @@ Install the packaged GitHub release artifact:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.11.0/ourfuturehealth-react-components-0.11.0.tgz",
+    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.12.0/ourfuturehealth-react-components-0.12.0.tgz",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   }
@@ -132,7 +132,7 @@ function App() {
       <Footer
         links={[
           { href: '#privacy', label: 'Privacy' },
-          { href: 'https://example.com/careers', label: 'Careers', external: true, openInNewWindow: true },
+          { href: '#careers', label: 'Careers' },
         ]}
         smallPrint="© Our Future Health 2026"
       />

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/react-components",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "type": "module",
   "description": "React component library for OFH Design System",
   "packageManager": "pnpm@10.29.2",

--- a/packages/react-components/src/components/Footer/Footer.stories.tsx
+++ b/packages/react-components/src/components/Footer/Footer.stories.tsx
@@ -1,7 +1,203 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Footer, type FooterProps } from './Footer';
+import {
+  Footer,
+  type FooterLinkItem,
+  type FooterProps,
+  type FooterSocialLinkItem,
+  type FooterSocialPlatform,
+} from './Footer';
 
-const meta: Meta<FooterProps> = {
+type FooterLinkSet =
+  | 'default'
+  | 'minimal'
+  | 'mixed-icons'
+  | 'external-links';
+
+type FooterStoryArgs = FooterProps & {
+  linkSet?: FooterLinkSet;
+  showSupportLinks?: boolean;
+  showSmallPrint?: boolean;
+  showLegalText?: boolean;
+  showSocialLinks?: boolean;
+  socialPlatforms?: FooterSocialPlatform[];
+};
+
+const legalText =
+  'Our Future Health is a company limited by guarantee registered in England and Wales (number 12212468) and a charity registered with the Charity Commission for England and Wales (charity number 1189681) and OSCR, Scottish Charity Regulator (charity number SC050917). Registered office: 2 New Bailey, 6 Stanley Street, Manchester M3 5GS.';
+
+const defaultLinks: FooterLinkItem[] = [
+  {
+    href: '#help',
+    label: 'Help and Support',
+  },
+  {
+    href: '#faq',
+    label: 'Frequently Asked Questions',
+  },
+  {
+    href: '#contact',
+    label: 'Contact Us',
+  },
+  {
+    href: '#accessibility',
+    label: 'Accessibility',
+  },
+  {
+    href: '#privacy',
+    label: 'Privacy',
+  },
+  {
+    href: '#cookies',
+    label: 'Cookies',
+  },
+  {
+    href: '#careers',
+    label: 'Careers',
+  },
+];
+
+const minimalLinks: FooterLinkItem[] = [
+  {
+    href: '#privacy',
+    label: 'Privacy',
+  },
+];
+
+const mixedIconLinks: FooterLinkItem[] = [
+  {
+    href: '#overview',
+    label: 'Back to overview',
+    iconName: 'ChevronLeft',
+    iconPosition: 'left',
+  },
+  {
+    href: '#search',
+    label: 'Search site',
+    iconName: 'Search',
+    iconPosition: 'left',
+  },
+  {
+    href: '#privacy',
+    label: 'Privacy',
+  },
+  {
+    href: 'https://example.com/guidance',
+    label: 'External guidance',
+    external: true,
+    openInNewWindow: true,
+  },
+];
+
+const externalLinks: FooterLinkItem[] = [
+  {
+    href: 'https://example.com/guidance',
+    label: 'Clinical guidance',
+    external: true,
+    openInNewWindow: true,
+  },
+  {
+    href: 'https://example.com/policies',
+    label: 'Privacy policy',
+    external: true,
+    openInNewWindow: true,
+  },
+  {
+    href: 'https://example.com/accessibility',
+    label: 'Accessibility statement',
+    external: true,
+    openInNewWindow: true,
+  },
+];
+
+const socialPlatformOptions: FooterSocialPlatform[] = [
+  'linkedin',
+  'x',
+  'facebook',
+  'youtube',
+  'instagram',
+  'tiktok',
+];
+
+const socialLinkMap: Record<FooterSocialPlatform, FooterSocialLinkItem> = {
+  linkedin: {
+    platform: 'linkedin',
+    href: 'https://www.linkedin.com/company/our-future-health/',
+    openInNewWindow: true,
+  },
+  x: {
+    platform: 'x',
+    href: 'https://x.com/',
+    openInNewWindow: true,
+  },
+  facebook: {
+    platform: 'facebook',
+    href: 'https://facebook.com/',
+    openInNewWindow: true,
+  },
+  youtube: {
+    platform: 'youtube',
+    href: 'https://youtube.com/',
+    openInNewWindow: true,
+  },
+  instagram: {
+    platform: 'instagram',
+    href: 'https://instagram.com/',
+    openInNewWindow: true,
+  },
+  tiktok: {
+    platform: 'tiktok',
+    href: 'https://tiktok.com/',
+    openInNewWindow: true,
+  },
+};
+
+const supportLinkSets: Record<FooterLinkSet, FooterLinkItem[]> = {
+  default: defaultLinks,
+  minimal: minimalLinks,
+  'mixed-icons': mixedIconLinks,
+  'external-links': externalLinks,
+};
+
+const buildSocialLinks = (
+  platforms: FooterSocialPlatform[] = [],
+): FooterSocialLinkItem[] =>
+  platforms.map((platform) => socialLinkMap[platform]);
+
+const friendlyControlNames = [
+  'linkSet',
+  'showSupportLinks',
+  'showSmallPrint',
+  'smallPrint',
+  'showLegalText',
+  'legalText',
+  'showSocialLinks',
+  'socialPlatforms',
+  'socialLabel',
+] satisfies Array<keyof FooterStoryArgs>;
+
+const renderFooterStory = ({
+  linkSet = 'default',
+  showSupportLinks = true,
+  showSmallPrint = true,
+  showLegalText = true,
+  showSocialLinks = true,
+  socialPlatforms = socialPlatformOptions,
+  smallPrint,
+  legalText: legalCopy,
+  socialLabel = 'Follow us',
+  ...args
+}: FooterStoryArgs) => (
+  <Footer
+    {...args}
+    links={showSupportLinks ? supportLinkSets[linkSet] : []}
+    smallPrint={showSmallPrint ? smallPrint : null}
+    legalText={showLegalText ? legalCopy : undefined}
+    socialLabel={socialLabel}
+    socialLinks={showSocialLinks ? buildSocialLinks(socialPlatforms) : []}
+  />
+);
+
+const meta: Meta<FooterStoryArgs> = {
   title: 'Components/Footer',
   component: Footer,
   parameters: {
@@ -9,97 +205,187 @@ const meta: Meta<FooterProps> = {
     docs: {
       description: {
         component:
-          'Footer shows support links, small-print/legal copy, and an optional social section. External footer links can render a right-side launch icon without introducing a generic link abstraction.',
+          'Footer shows support links, optional small-print and legal copy, and an optional social section. Support links are composed from the shared LinkIcon pattern, so the default footer stays text-only while services can opt into left or right icon cues when they are genuinely helpful.',
       },
     },
   },
   tags: ['autodocs'],
   args: {
-    links: [
-      {
-        href: '#help',
-        label: 'Help and Support',
-      },
-      {
-        href: '#faq',
-        label: 'Frequently Asked Questions',
-      },
-      {
-        href: '#contact',
-        label: 'Contact Us',
-      },
-      {
-        href: '#accessibility',
-        label: 'Accessibility',
-      },
-      {
-        href: '#privacy',
-        label: 'Privacy',
-      },
-      {
-        href: '#cookies',
-        label: 'Cookies',
-      },
-      {
-        href: 'https://example.com/careers',
-        label: 'Careers',
-        external: true,
-        openInNewWindow: true,
-      },
-    ],
+    linkSet: 'default',
+    showSupportLinks: true,
+    showSmallPrint: true,
+    showLegalText: true,
+    showSocialLinks: true,
+    socialPlatforms: socialPlatformOptions,
     smallPrint: '© Our Future Health 2026',
-    legalText:
-      'Our Future Health is a company limited by guarantee registered in England and Wales (number 12212468) and a charity registered with the Charity Commission for England and Wales (charity number 1189681) and OSCR, Scottish Charity Regulator (charity number SC050917). Registered office: 2 New Bailey, 6 Stanley Street, Manchester M3 5GS.',
-    socialLinks: [
-      {
-        platform: 'linkedin',
-        href: 'https://www.linkedin.com/company/our-future-health/',
-        openInNewWindow: true,
+    legalText,
+    socialLabel: 'Follow us',
+  },
+  render: renderFooterStory,
+  argTypes: {
+    linkSet: {
+      control: 'select',
+      options: ['default', 'minimal', 'mixed-icons', 'external-links'],
+      description:
+        'Preset used to populate the support links section when it is enabled.',
+    },
+    showSupportLinks: {
+      control: 'boolean',
+      description: 'Shows or hides the support links section.',
+    },
+    links: {
+      control: false,
+      description:
+        'Low-level support links data. In Storybook, prefer the `linkSet` and `showSupportLinks` controls.',
+      table: {
+        category: 'Advanced',
       },
-      {
-        platform: 'x',
-        href: 'https://x.com/',
-        openInNewWindow: true,
+    },
+    smallPrint: {
+      control: 'text',
+      description:
+        'Small-print line shown below the support links. Pass `null` to hide it explicitly.',
+    },
+    showSmallPrint: {
+      control: 'boolean',
+      description: 'Shows or hides the small-print line.',
+    },
+    legalText: {
+      control: 'text',
+      description:
+        'Additional legal copy shown beside the support links on larger breakpoints.',
+    },
+    showLegalText: {
+      control: 'boolean',
+      description: 'Shows or hides the legal copy block.',
+    },
+    socialLabel: {
+      control: 'text',
+      description:
+        'Label shown before the social links on tablet and desktop.',
+    },
+    showSocialLinks: {
+      control: 'boolean',
+      description: 'Shows or hides the social section.',
+    },
+    socialLinks: {
+      control: false,
+      description:
+        'Low-level social links data. In Storybook, prefer the `socialPlatforms` and `showSocialLinks` controls.',
+      table: {
+        category: 'Advanced',
       },
-      {
-        platform: 'facebook',
-        href: 'https://facebook.com/',
-        openInNewWindow: true,
+    },
+    socialPlatforms: {
+      control: 'check',
+      options: socialPlatformOptions,
+      description:
+        'Social icons to include when the social section is enabled.',
+    },
+    classes: {
+      control: false,
+      table: {
+        disable: true,
       },
-      {
-        platform: 'youtube',
-        href: 'https://youtube.com/',
-        openInNewWindow: true,
+    },
+    className: {
+      control: false,
+      table: {
+        disable: true,
       },
-      {
-        platform: 'instagram',
-        href: 'https://instagram.com/',
-        openInNewWindow: true,
+    },
+    ref: {
+      control: false,
+      table: {
+        disable: true,
       },
-      {
-        platform: 'tiktok',
-        href: 'https://tiktok.com/',
-        openInNewWindow: true,
-      },
-    ],
+    },
   },
 };
 
 export default meta;
-type Story = StoryObj<FooterProps>;
+type Story = StoryObj<FooterStoryArgs>;
 
-export const Default: Story = {};
+export const Builder: Story = {
+  parameters: {
+    controls: {
+      include: friendlyControlNames,
+    },
+    docs: {
+      description: {
+        story:
+          'Use this builder to turn footer sections on and off without editing raw nested arrays. The link-set control swaps between text-only links, icon-led footer links, and external-link patterns.',
+      },
+    },
+  },
+  args: {
+    socialPlatforms: ['linkedin', 'x', 'facebook'],
+  },
+};
+
+export const Default: Story = {
+  parameters: {
+    controls: {
+      include: friendlyControlNames,
+    },
+  },
+};
 
 export const Minimal: Story = {
   args: {
-    links: [
-      {
-        href: '#privacy',
-        label: 'Privacy',
+    linkSet: 'minimal',
+    showSupportLinks: true,
+    showSmallPrint: true,
+    showLegalText: false,
+    showSocialLinks: false,
+  },
+  parameters: {
+    controls: {
+      include: friendlyControlNames,
+    },
+  },
+};
+
+export const SupportLinksWithIcons: Story = {
+  args: {
+    linkSet: 'mixed-icons',
+    showSupportLinks: true,
+    showSmallPrint: true,
+    showLegalText: false,
+    showSocialLinks: false,
+  },
+  parameters: {
+    controls: {
+      include: friendlyControlNames,
+    },
+    docs: {
+      description: {
+        story:
+          'The default footer keeps support links text-only, but footer link items can opt into the shared LinkIcon capabilities when a directional or external cue adds meaning.',
       },
-    ],
-    smallPrint: '© Our Future Health 2026',
-    legalText: undefined,
-    socialLinks: [],
+    },
+  },
+};
+
+export const LegalAndSocialOnly: Story = {
+  args: {
+    showSupportLinks: false,
+    showSmallPrint: false,
+    showLegalText: true,
+    showSocialLinks: true,
+    legalText:
+      'Our Future Health is a company limited by guarantee registered in England and Wales (number 12212468).',
+    socialPlatforms: ['linkedin', 'x', 'facebook'],
+  },
+  parameters: {
+    controls: {
+      include: friendlyControlNames,
+    },
+    docs: {
+      description: {
+        story:
+          'This variant hides the support-link list and small-print line, leaving just legal copy plus the social section.',
+      },
+    },
   },
 };

--- a/packages/react-components/src/components/Footer/Footer.stories.tsx
+++ b/packages/react-components/src/components/Footer/Footer.stories.tsx
@@ -1,0 +1,105 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Footer, type FooterProps } from './Footer';
+
+const meta: Meta<FooterProps> = {
+  title: 'Components/Footer',
+  component: Footer,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Footer shows support links, small-print/legal copy, and an optional social section. External footer links can render a right-side launch icon without introducing a generic link abstraction.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    links: [
+      {
+        href: '#help',
+        label: 'Help and Support',
+      },
+      {
+        href: '#faq',
+        label: 'Frequently Asked Questions',
+      },
+      {
+        href: '#contact',
+        label: 'Contact Us',
+      },
+      {
+        href: '#accessibility',
+        label: 'Accessibility',
+      },
+      {
+        href: '#privacy',
+        label: 'Privacy',
+      },
+      {
+        href: '#cookies',
+        label: 'Cookies',
+      },
+      {
+        href: 'https://example.com/careers',
+        label: 'Careers',
+        external: true,
+        openInNewWindow: true,
+      },
+    ],
+    smallPrint: '© Our Future Health 2026',
+    legalText:
+      'Our Future Health is a company limited by guarantee registered in England and Wales (number 12212468) and a charity registered with the Charity Commission for England and Wales (charity number 1189681) and OSCR, Scottish Charity Regulator (charity number SC050917). Registered office: 2 New Bailey, 6 Stanley Street, Manchester M3 5GS.',
+    socialLinks: [
+      {
+        platform: 'linkedin',
+        href: 'https://www.linkedin.com/company/our-future-health/',
+        openInNewWindow: true,
+      },
+      {
+        platform: 'x',
+        href: 'https://x.com/',
+        openInNewWindow: true,
+      },
+      {
+        platform: 'facebook',
+        href: 'https://facebook.com/',
+        openInNewWindow: true,
+      },
+      {
+        platform: 'youtube',
+        href: 'https://youtube.com/',
+        openInNewWindow: true,
+      },
+      {
+        platform: 'instagram',
+        href: 'https://instagram.com/',
+        openInNewWindow: true,
+      },
+      {
+        platform: 'tiktok',
+        href: 'https://tiktok.com/',
+        openInNewWindow: true,
+      },
+    ],
+  },
+};
+
+export default meta;
+type Story = StoryObj<FooterProps>;
+
+export const Default: Story = {};
+
+export const Minimal: Story = {
+  args: {
+    links: [
+      {
+        href: '#privacy',
+        label: 'Privacy',
+      },
+    ],
+    smallPrint: '© Our Future Health 2026',
+    legalText: undefined,
+    socialLinks: [],
+  },
+};

--- a/packages/react-components/src/components/Footer/Footer.stories.tsx
+++ b/packages/react-components/src/components/Footer/Footer.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import {
   Footer,
   type FooterLinkItem,
@@ -151,6 +152,112 @@ const socialLinkMap: Record<FooterSocialPlatform, FooterSocialLinkItem> = {
   },
 };
 
+const defaultFooterSource = `import { Footer } from '@ourfuturehealth/react-components';
+
+const supportLinks = [
+  { href: '#help', label: 'Help and Support' },
+  { href: '#faq', label: 'Frequently Asked Questions' },
+  { href: '#contact', label: 'Contact Us' },
+  { href: '#accessibility', label: 'Accessibility' },
+  { href: '#privacy', label: 'Privacy' },
+  { href: '#cookies', label: 'Cookies' },
+  { href: '#careers', label: 'Careers' },
+];
+
+const socialLinks = [
+  {
+    platform: 'linkedin',
+    href: 'https://www.linkedin.com/company/our-future-health/',
+    openInNewWindow: true,
+  },
+  {
+    platform: 'x',
+    href: 'https://x.com/',
+    openInNewWindow: true,
+  },
+  {
+    platform: 'facebook',
+    href: 'https://facebook.com/',
+    openInNewWindow: true,
+  },
+];
+
+<Footer
+  links={supportLinks}
+  smallPrint="© Our Future Health 2026"
+  legalText="Our Future Health is a company limited by guarantee registered in England and Wales (number 12212468) and a charity registered with the Charity Commission for England and Wales (charity number 1189681) and OSCR, Scottish Charity Regulator (charity number SC050917). Registered office: 2 New Bailey, 6 Stanley Street, Manchester M3 5GS."
+  socialLabel="Follow us"
+  socialLinks={socialLinks}
+/>;
+`;
+
+const minimalFooterSource = `import { Footer } from '@ourfuturehealth/react-components';
+
+const supportLinks = [{ href: '#privacy', label: 'Privacy' }];
+
+<Footer
+  links={supportLinks}
+  smallPrint="© Our Future Health 2026"
+/>;
+`;
+
+const supportLinksWithIconsSource = `import { Footer } from '@ourfuturehealth/react-components';
+
+const supportLinks = [
+  {
+    href: '#overview',
+    label: 'Back to overview',
+    iconName: 'ChevronLeft',
+    iconPosition: 'left',
+  },
+  {
+    href: '#search',
+    label: 'Search site',
+    iconName: 'Search',
+    iconPosition: 'left',
+  },
+  { href: '#privacy', label: 'Privacy' },
+  {
+    href: 'https://example.com/guidance',
+    label: 'External guidance',
+    external: true,
+    openInNewWindow: true,
+  },
+];
+
+<Footer
+  links={supportLinks}
+  smallPrint="© Our Future Health 2026"
+/>;
+`;
+
+const legalAndSocialOnlySource = `import { Footer } from '@ourfuturehealth/react-components';
+
+const socialLinks = [
+  {
+    platform: 'linkedin',
+    href: 'https://www.linkedin.com/company/our-future-health/',
+    openInNewWindow: true,
+  },
+  {
+    platform: 'x',
+    href: 'https://x.com/',
+    openInNewWindow: true,
+  },
+  {
+    platform: 'facebook',
+    href: 'https://facebook.com/',
+    openInNewWindow: true,
+  },
+];
+
+<Footer
+  legalText="Our Future Health is a company limited by guarantee registered in England and Wales (number 12212468)."
+  socialLabel="Follow us"
+  socialLinks={socialLinks}
+/>;
+`;
+
 const supportLinkSets: Record<FooterLinkSet, FooterLinkItem[]> = {
   default: defaultLinks,
   minimal: minimalLinks,
@@ -205,8 +312,52 @@ const meta: Meta<FooterStoryArgs> = {
     docs: {
       description: {
         component:
-          'Footer shows support links, optional small-print and legal copy, and an optional social section. Support links are composed from the shared LinkIcon pattern, so the default footer stays text-only while services can opt into left or right icon cues when they are genuinely helpful.',
+          'Footer shows support links, optional small-print and legal copy, and an optional social section. The real React API is intentionally small: pass `links` for support links, `smallPrint` for the copyright line, `legalText` for the legal copy, `socialLabel` for the social heading, and `socialLinks` for the social icons. Storybook adds helper controls to make the examples easier to explore, but those helpers are not part of `FooterProps`.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Start with the real component props. The footer is composed from
+            support links, optional small-print text, optional legal copy, and
+            optional social links.
+          </p>
+          <p>
+            Use the shared <code>LinkIcon</code> capabilities on support links
+            only when a left or right icon genuinely adds meaning.
+          </p>
+
+          <h2>Component props</h2>
+          <ArgTypes of={Footer} />
+
+          <h2>Storybook helper controls</h2>
+          <p>
+            <code>linkSet</code>, <code>showSupportLinks</code>,{' '}
+            <code>showSmallPrint</code>, <code>showLegalText</code>,{' '}
+            <code>showSocialLinks</code>, <code>socialPlatforms</code>, and the
+            other builder controls are Storybook-only helpers. They are used to
+            explore the footer in Storybook, but they are not part of the
+            React component API.
+          </p>
+
+          <h2>Examples</h2>
+          <Stories />
+
+          <h2>Example source</h2>
+          <p>
+            The snippets below show the rendered examples with the item arrays
+            inlined so the support-link and social-link shapes are easy to
+            copy.
+          </p>
+          <Source code={defaultFooterSource} language="tsx" />
+          <Source code={minimalFooterSource} language="tsx" />
+          <Source code={supportLinksWithIconsSource} language="tsx" />
+          <Source code={legalAndSocialOnlySource} language="tsx" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],
@@ -227,28 +378,39 @@ const meta: Meta<FooterStoryArgs> = {
       control: 'select',
       options: ['default', 'minimal', 'mixed-icons', 'external-links'],
       description:
-        'Preset used to populate the support links section when it is enabled.',
+        'Storybook-only helper used to switch between support-link presets in the Builder story.',
+      table: {
+        category: 'Builder story only',
+      },
     },
     showSupportLinks: {
       control: 'boolean',
-      description: 'Shows or hides the support links section.',
+      description:
+        'Storybook-only helper used to show or hide the support links section in the Builder story.',
+      table: {
+        category: 'Builder story only',
+      },
     },
     links: {
       control: false,
       description:
-        'Low-level support links data. In Storybook, prefer the `linkSet` and `showSupportLinks` controls.',
+        'Support-link data passed to the real React component. Each item can be text-only or use the shared LinkIcon options when needed.',
       table: {
-        category: 'Advanced',
+        category: 'FooterProps',
       },
     },
     smallPrint: {
       control: 'text',
       description:
-        'Small-print line shown below the support links. Pass `null` to hide it explicitly.',
+        'Small-print line shown below the support links. Pass `null` to hide it explicitly when the footer should not show copyright text.',
     },
     showSmallPrint: {
       control: 'boolean',
-      description: 'Shows or hides the small-print line.',
+      description:
+        'Storybook-only helper used to show or hide the small-print line in the Builder story.',
+      table: {
+        category: 'Builder story only',
+      },
     },
     legalText: {
       control: 'text',
@@ -257,7 +419,11 @@ const meta: Meta<FooterStoryArgs> = {
     },
     showLegalText: {
       control: 'boolean',
-      description: 'Shows or hides the legal copy block.',
+      description:
+        'Storybook-only helper used to show or hide the legal copy block in the Builder story.',
+      table: {
+        category: 'Builder story only',
+      },
     },
     socialLabel: {
       control: 'text',
@@ -266,38 +432,50 @@ const meta: Meta<FooterStoryArgs> = {
     },
     showSocialLinks: {
       control: 'boolean',
-      description: 'Shows or hides the social section.',
+      description:
+        'Storybook-only helper used to show or hide the social section in the Builder story.',
+      table: {
+        category: 'Builder story only',
+      },
     },
     socialLinks: {
       control: false,
       description:
-        'Low-level social links data. In Storybook, prefer the `socialPlatforms` and `showSocialLinks` controls.',
+        'Social-link data passed to the real React component.',
       table: {
-        category: 'Advanced',
+        category: 'FooterProps',
       },
     },
     socialPlatforms: {
       control: 'check',
       options: socialPlatformOptions,
       description:
-        'Social icons to include when the social section is enabled.',
+        'Storybook-only helper used to choose which social icons the Builder story should render.',
+      table: {
+        category: 'Builder story only',
+      },
     },
     classes: {
       control: false,
+      description:
+        'Toolkit-parity escape hatch for adding extra classes to the root element. Most React consumers should ignore this and use `className` instead.',
       table: {
-        disable: true,
+        category: 'FooterProps',
       },
     },
     className: {
       control: false,
+      description:
+        'Adds extra classes to the root `<footer>` element. Use this for layout tweaks or integration hooks when you need to target the component from your app.',
       table: {
-        disable: true,
+        category: 'FooterProps',
       },
     },
     ref: {
       control: false,
+      description: 'React ref for the root `<footer>` element.',
       table: {
-        disable: true,
+        category: 'FooterProps',
       },
     },
   },
@@ -324,67 +502,98 @@ export const Builder: Story = {
 };
 
 export const Default: Story = {
+  render: () => (
+    <Footer
+      links={defaultLinks}
+      smallPrint="© Our Future Health 2026"
+      legalText={legalText}
+      socialLabel="Follow us"
+      socialLinks={[
+        socialLinkMap.linkedin,
+        socialLinkMap.x,
+        socialLinkMap.facebook,
+      ]}
+    />
+  ),
   parameters: {
     controls: {
-      include: friendlyControlNames,
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'A realistic default footer example with text-only support links, legal copy, small print, and the social section visible.',
+      },
+      source: {
+        code: defaultFooterSource,
+      },
     },
   },
 };
 
 export const Minimal: Story = {
-  args: {
-    linkSet: 'minimal',
-    showSupportLinks: true,
-    showSmallPrint: true,
-    showLegalText: false,
-    showSocialLinks: false,
-  },
+  render: () => (
+    <Footer links={minimalLinks} smallPrint="© Our Future Health 2026" />
+  ),
   parameters: {
     controls: {
-      include: friendlyControlNames,
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'A compact footer example with just one support link and the small-print line.',
+      },
+      source: {
+        code: minimalFooterSource,
+      },
     },
   },
 };
 
 export const SupportLinksWithIcons: Story = {
-  args: {
-    linkSet: 'mixed-icons',
-    showSupportLinks: true,
-    showSmallPrint: true,
-    showLegalText: false,
-    showSocialLinks: false,
-  },
+  render: () => (
+    <Footer links={mixedIconLinks} smallPrint="© Our Future Health 2026" />
+  ),
   parameters: {
     controls: {
-      include: friendlyControlNames,
+      disable: true,
     },
     docs: {
       description: {
         story:
           'The default footer keeps support links text-only, but footer link items can opt into the shared LinkIcon capabilities when a directional or external cue adds meaning.',
       },
+      source: {
+        code: supportLinksWithIconsSource,
+      },
     },
   },
 };
 
 export const LegalAndSocialOnly: Story = {
-  args: {
-    showSupportLinks: false,
-    showSmallPrint: false,
-    showLegalText: true,
-    showSocialLinks: true,
-    legalText:
-      'Our Future Health is a company limited by guarantee registered in England and Wales (number 12212468).',
-    socialPlatforms: ['linkedin', 'x', 'facebook'],
-  },
+  render: () => (
+    <Footer
+      legalText="Our Future Health is a company limited by guarantee registered in England and Wales (number 12212468)."
+      socialLabel="Follow us"
+      socialLinks={[
+        socialLinkMap.linkedin,
+        socialLinkMap.x,
+        socialLinkMap.facebook,
+      ]}
+    />
+  ),
   parameters: {
     controls: {
-      include: friendlyControlNames,
+      disable: true,
     },
     docs: {
       description: {
         story:
           'This variant hides the support-link list and small-print line, leaving just legal copy plus the social section.',
+      },
+      source: {
+        code: legalAndSocialOnlySource,
       },
     },
   },

--- a/packages/react-components/src/components/Footer/Footer.stories.tsx
+++ b/packages/react-components/src/components/Footer/Footer.stories.tsx
@@ -329,6 +329,7 @@ const meta: Meta<FooterStoryArgs> = {
             Use the shared <code>LinkIcon</code> capabilities on support links
             only when a left or right icon genuinely adds meaning.
           </p>
+          <Source code={defaultFooterSource} language="tsx" />
 
           <h2>Component props</h2>
           <ArgTypes of={Footer} />

--- a/packages/react-components/src/components/Footer/Footer.test.tsx
+++ b/packages/react-components/src/components/Footer/Footer.test.tsx
@@ -2,10 +2,14 @@ import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { axe } from 'vitest-axe';
 import { describe, expect, it } from 'vitest';
-import { Footer } from './Footer';
+import {
+  Footer,
+  type FooterLinkItem,
+  type FooterSocialLinkItem,
+} from './Footer';
 
 describe('Footer', () => {
-  const links = [
+  const links: FooterLinkItem[] = [
     {
       href: '#help',
       label: 'Help and Support',
@@ -16,9 +20,9 @@ describe('Footer', () => {
       external: true,
       openInNewWindow: true,
     },
-  ] as const;
+  ];
 
-  const socialLinks = [
+  const socialLinks: FooterSocialLinkItem[] = [
     {
       platform: 'linkedin',
       href: 'https://www.linkedin.com/company/our-future-health/',
@@ -29,7 +33,7 @@ describe('Footer', () => {
       href: 'https://x.com/',
       openInNewWindow: true,
     },
-  ] as const;
+  ];
 
   it('renders footer links, copy, and social links', () => {
     const { container } = render(
@@ -50,11 +54,13 @@ describe('Footer', () => {
     expect(screen.getByText('© Our Future Health 2026')).toBeInTheDocument();
     expect(screen.getByText('Organisation legal text.')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'LinkedIn' })).toBeInTheDocument();
+    expect(container.querySelector('.ofh-icon--ChevronLeft')).toBeNull();
+    expect(container.querySelector('.ofh-icon--Linkedin')).toBeInTheDocument();
     expect(container.querySelector('.ofh-icon--Launch')).toBeInTheDocument();
   });
 
   it('forwards refs and extra classes to the footer element', () => {
-    const ref = createRef<HTMLFooterElement>();
+    const ref = createRef<HTMLElement>();
 
     render(
       <Footer
@@ -73,6 +79,33 @@ describe('Footer', () => {
 
     expect(screen.queryByText('Follow us')).toBeNull();
     expect(screen.queryByRole('link', { name: 'LinkedIn' })).toBeNull();
+  });
+
+  it('supports custom footer link icons and lets small print be hidden', () => {
+    const { container } = render(
+      <Footer
+        links={[
+          {
+            href: '#overview',
+            label: 'Back to overview',
+            iconName: 'ChevronLeft',
+            iconPosition: 'left',
+          },
+          {
+            href: '#search',
+            label: 'Search site',
+            iconName: 'Search',
+            iconPosition: 'left',
+          },
+        ]}
+        smallPrint={null}
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: 'Back to overview' })).toBeInTheDocument();
+    expect(container.querySelector('.ofh-icon--ChevronLeft')).toBeInTheDocument();
+    expect(container.querySelector('.ofh-icon--Search')).toBeInTheDocument();
+    expect(container.querySelector('.ofh-footer__small-print')).toBeNull();
   });
 
   it('has no accessibility violations', async () => {

--- a/packages/react-components/src/components/Footer/Footer.test.tsx
+++ b/packages/react-components/src/components/Footer/Footer.test.tsx
@@ -108,6 +108,39 @@ describe('Footer', () => {
     expect(container.querySelector('.ofh-footer__small-print')).toBeNull();
   });
 
+  it('preserves caller rel tokens when links open in a new window', () => {
+    render(
+      <Footer
+        links={[
+          {
+            href: 'https://example.com/guidance',
+            label: 'External guidance',
+            external: true,
+            openInNewWindow: true,
+            rel: 'nofollow',
+          },
+        ]}
+        socialLinks={[
+          {
+            platform: 'linkedin',
+            href: 'https://www.linkedin.com/company/our-future-health/',
+            openInNewWindow: true,
+            rel: 'me',
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: 'External guidance' })).toHaveAttribute(
+      'rel',
+      'nofollow noopener noreferrer',
+    );
+    expect(screen.getByRole('link', { name: 'LinkedIn' })).toHaveAttribute(
+      'rel',
+      'me noopener noreferrer',
+    );
+  });
+
   it('has no accessibility violations', async () => {
     const { container } = render(
       <Footer

--- a/packages/react-components/src/components/Footer/Footer.test.tsx
+++ b/packages/react-components/src/components/Footer/Footer.test.tsx
@@ -1,0 +1,92 @@
+import { createRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import { axe } from 'vitest-axe';
+import { describe, expect, it } from 'vitest';
+import { Footer } from './Footer';
+
+describe('Footer', () => {
+  const links = [
+    {
+      href: '#help',
+      label: 'Help and Support',
+    },
+    {
+      href: 'https://example.com/careers',
+      label: 'Careers',
+      external: true,
+      openInNewWindow: true,
+    },
+  ] as const;
+
+  const socialLinks = [
+    {
+      platform: 'linkedin',
+      href: 'https://www.linkedin.com/company/our-future-health/',
+      openInNewWindow: true,
+    },
+    {
+      platform: 'x',
+      href: 'https://x.com/',
+      openInNewWindow: true,
+    },
+  ] as const;
+
+  it('renders footer links, copy, and social links', () => {
+    const { container } = render(
+      <Footer
+        links={links}
+        smallPrint="© Our Future Health 2026"
+        legalText="Organisation legal text."
+        socialLinks={socialLinks}
+      />,
+    );
+
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Help and Support' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Careers' })).toHaveAttribute(
+      'target',
+      '_blank',
+    );
+    expect(screen.getByText('© Our Future Health 2026')).toBeInTheDocument();
+    expect(screen.getByText('Organisation legal text.')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'LinkedIn' })).toBeInTheDocument();
+    expect(container.querySelector('.ofh-icon--Launch')).toBeInTheDocument();
+  });
+
+  it('forwards refs and extra classes to the footer element', () => {
+    const ref = createRef<HTMLFooterElement>();
+
+    render(
+      <Footer
+        ref={ref}
+        className="custom-footer"
+        links={links}
+      />,
+    );
+
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+    expect(ref.current).toHaveClass('ofh-footer', 'custom-footer');
+  });
+
+  it('omits the social section when no social links are provided', () => {
+    render(<Footer links={links} />);
+
+    expect(screen.queryByText('Follow us')).toBeNull();
+    expect(screen.queryByRole('link', { name: 'LinkedIn' })).toBeNull();
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <Footer
+        links={links}
+        smallPrint="© Our Future Health 2026"
+        legalText="Organisation legal text."
+        socialLinks={socialLinks}
+      />,
+    );
+
+    const results = await axe(container);
+
+    expect(results.violations).toHaveLength(0);
+  });
+});

--- a/packages/react-components/src/components/Footer/Footer.tsx
+++ b/packages/react-components/src/components/Footer/Footer.tsx
@@ -1,12 +1,26 @@
 import React from 'react';
 import { joinClasses } from '../../internal/ofhUtils';
 import { Icon } from '../Icon';
+import { LinkIcon, type LinkIconProps } from '../LinkIcon';
+
+type FooterLinkIconProps = Pick<
+  LinkIconProps,
+  | 'iconColor'
+  | 'iconName'
+  | 'iconPosition'
+  | 'leftIconName'
+  | 'rightIconName'
+  | 'showIconLeft'
+  | 'showIconRight'
+  | 'size'
+>;
 
 export interface FooterLinkItem
   extends Omit<
     React.AnchorHTMLAttributes<HTMLAnchorElement>,
     'children' | 'className' | 'href' | 'ref'
-  > {
+  >,
+    FooterLinkIconProps {
   href: string;
   label: React.ReactNode;
   external?: boolean;
@@ -40,7 +54,7 @@ export interface FooterProps
   socialLabel?: React.ReactNode;
   socialLinks?: FooterSocialLinkItem[];
   classes?: string;
-  ref?: React.Ref<HTMLFooterElement>;
+  ref?: React.Ref<HTMLElement>;
 }
 
 const socialIcons: Record<
@@ -52,8 +66,8 @@ const socialIcons: Record<
   }
 > = {
   linkedin: {
-    defaultIcon: 'LinkedIn',
-    hoverIcon: 'LinkedInHover',
+    defaultIcon: 'Linkedin',
+    hoverIcon: 'LinkedinHover',
     label: 'LinkedIn',
   },
   x: {
@@ -88,32 +102,54 @@ const renderFooterLink = (link: FooterLinkItem, index: number) => {
     href,
     label,
     external = false,
+    iconColor,
+    iconName,
+    iconPosition,
+    leftIconName,
     openInNewWindow = false,
     rel,
+    rightIconName,
+    showIconLeft,
+    showIconRight,
+    size,
     target,
     ...props
   } = link;
+  const usesCustomLinkIconDisplay =
+    iconPosition !== undefined ||
+    iconName !== undefined ||
+    leftIconName !== undefined ||
+    rightIconName !== undefined ||
+    showIconLeft !== undefined ||
+    showIconRight !== undefined;
+  const resolvedIconPosition = iconPosition ?? (external ? 'right' : 'left');
   const resolvedRel = openInNewWindow ? 'noopener noreferrer' : rel;
+  const resolvedShowIconLeft =
+    showIconLeft ?? (usesCustomLinkIconDisplay ? undefined : false);
+  const resolvedShowIconRight =
+    showIconRight ?? (usesCustomLinkIconDisplay ? undefined : external);
   const resolvedTarget = openInNewWindow ? '_blank' : target;
 
   return (
     <li className="ofh-footer__links-item" key={`footer-link-${index}`}>
-      <a
+      <LinkIcon
         {...props}
-        className="ofh-footer__link"
+        className="ofh-footer__link-component"
         href={href}
+        iconColor={iconColor}
+        iconName={iconName}
+        iconPosition={resolvedIconPosition}
+        leftIconName={leftIconName}
         rel={resolvedRel}
+        openInNewWindow={openInNewWindow}
+        rightIconName={rightIconName}
+        showIconLeft={resolvedShowIconLeft}
+        showIconRight={resolvedShowIconRight}
+        size={size}
         target={resolvedTarget}
       >
-        <span className="ofh-footer__link-text">{label}</span>
-        {external ? (
-          <Icon
-            name="Launch"
-            size={16}
-            className="ofh-footer__link-icon"
-          />
-        ) : null}
-      </a>
+        {label}
+      </LinkIcon>
     </li>
   );
 };
@@ -169,7 +205,7 @@ const renderSocialLink = (link: FooterSocialLinkItem, index: number) => {
 
 export const Footer = ({
   links = [],
-  smallPrint = '© Crown copyright',
+  smallPrint,
   legalText,
   socialLabel = 'Follow us',
   socialLinks = [],
@@ -178,47 +214,57 @@ export const Footer = ({
   ref,
   role = 'contentinfo',
   ...props
-}: FooterProps) => (
-  <footer
-    {...props}
-    ref={ref}
-    role={role}
-    className={joinClasses('ofh-footer', classes, className)}
-  >
-    <div className="ofh-footer__main">
-      <div className="ofh-width-container">
-        <div className="ofh-footer__main-inner">
-          <div className="ofh-footer__meta">
-            {links.length ? (
-              <>
-                <h2 className="ofh-u-visually-hidden">Support links</h2>
-                <ul className="ofh-footer__links">
-                  {links.map(renderFooterLink)}
-                </ul>
-              </>
-            ) : null}
-            <p className="ofh-footer__small-print">{smallPrint}</p>
-          </div>
-          {legalText ? (
-            <p className="ofh-footer__legal">{legalText}</p>
-          ) : null}
-        </div>
-      </div>
-    </div>
+}: FooterProps) => {
+  const resolvedSmallPrint =
+    smallPrint === undefined ? '© Crown copyright' : smallPrint;
+  const hasMeta = links.length > 0 || Boolean(resolvedSmallPrint);
 
-    {socialLinks.length ? (
-      <div className="ofh-footer__social">
+  return (
+    <footer
+      {...props}
+      ref={ref}
+      role={role}
+      className={joinClasses('ofh-footer', classes, className)}
+    >
+      <div className="ofh-footer__main">
         <div className="ofh-width-container">
-          <div className="ofh-footer__social-inner">
-            <p className="ofh-footer__social-title">{socialLabel}</p>
-            <ul className="ofh-footer__social-list">
-              {socialLinks.map(renderSocialLink)}
-            </ul>
+          <div className="ofh-footer__main-inner">
+            {hasMeta ? (
+              <div className="ofh-footer__meta">
+                {links.length ? (
+                  <>
+                    <h2 className="ofh-u-visually-hidden">Support links</h2>
+                    <ul className="ofh-footer__links">
+                      {links.map(renderFooterLink)}
+                    </ul>
+                  </>
+                ) : null}
+                {resolvedSmallPrint ? (
+                  <p className="ofh-footer__small-print">{resolvedSmallPrint}</p>
+                ) : null}
+              </div>
+            ) : null}
+            {legalText ? (
+              <p className="ofh-footer__legal">{legalText}</p>
+            ) : null}
           </div>
         </div>
       </div>
-    ) : null}
-  </footer>
-);
+
+      {socialLinks.length ? (
+        <div className="ofh-footer__social">
+          <div className="ofh-width-container">
+            <div className="ofh-footer__social-inner">
+              <p className="ofh-footer__social-title">{socialLabel}</p>
+              <ul className="ofh-footer__social-list">
+                {socialLinks.map(renderSocialLink)}
+              </ul>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </footer>
+  );
+};
 
 Footer.displayName = 'Footer';

--- a/packages/react-components/src/components/Footer/Footer.tsx
+++ b/packages/react-components/src/components/Footer/Footer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { mergeRelTokens } from '../../internal/mergeRelTokens';
 import { joinClasses } from '../../internal/ofhUtils';
 import { Icon } from '../Icon';
 import { LinkIcon, type LinkIconProps } from '../LinkIcon';
@@ -123,12 +124,10 @@ const renderFooterLink = (link: FooterLinkItem, index: number) => {
     showIconLeft !== undefined ||
     showIconRight !== undefined;
   const resolvedIconPosition = iconPosition ?? (external ? 'right' : 'left');
-  const resolvedRel = openInNewWindow ? 'noopener noreferrer' : rel;
   const resolvedShowIconLeft =
     showIconLeft ?? (usesCustomLinkIconDisplay ? undefined : false);
   const resolvedShowIconRight =
     showIconRight ?? (usesCustomLinkIconDisplay ? undefined : external);
-  const resolvedTarget = openInNewWindow ? '_blank' : target;
 
   return (
     <li className="ofh-footer__links-item" key={`footer-link-${index}`}>
@@ -140,13 +139,13 @@ const renderFooterLink = (link: FooterLinkItem, index: number) => {
         iconName={iconName}
         iconPosition={resolvedIconPosition}
         leftIconName={leftIconName}
-        rel={resolvedRel}
+        rel={rel}
         openInNewWindow={openInNewWindow}
         rightIconName={rightIconName}
         showIconLeft={resolvedShowIconLeft}
         showIconRight={resolvedShowIconRight}
         size={size}
-        target={resolvedTarget}
+        target={target}
       >
         {label}
       </LinkIcon>
@@ -165,7 +164,7 @@ const renderSocialLink = (link: FooterSocialLinkItem, index: number) => {
     ...props
   } = link;
   const iconNames = socialIcons[platform];
-  const resolvedRel = openInNewWindow ? 'noopener noreferrer' : rel;
+  const resolvedRel = mergeRelTokens(rel, openInNewWindow);
   const resolvedTarget = openInNewWindow ? '_blank' : target;
 
   return (

--- a/packages/react-components/src/components/Footer/Footer.tsx
+++ b/packages/react-components/src/components/Footer/Footer.tsx
@@ -1,0 +1,224 @@
+import React from 'react';
+import { joinClasses } from '../../internal/ofhUtils';
+import { Icon } from '../Icon';
+
+export interface FooterLinkItem
+  extends Omit<
+    React.AnchorHTMLAttributes<HTMLAnchorElement>,
+    'children' | 'className' | 'href' | 'ref'
+  > {
+  href: string;
+  label: React.ReactNode;
+  external?: boolean;
+  openInNewWindow?: boolean;
+}
+
+export type FooterSocialPlatform =
+  | 'linkedin'
+  | 'x'
+  | 'facebook'
+  | 'youtube'
+  | 'instagram'
+  | 'tiktok';
+
+export interface FooterSocialLinkItem
+  extends Omit<
+    React.AnchorHTMLAttributes<HTMLAnchorElement>,
+    'children' | 'className' | 'href' | 'ref'
+  > {
+  href: string;
+  label?: string;
+  openInNewWindow?: boolean;
+  platform: FooterSocialPlatform;
+}
+
+export interface FooterProps
+  extends Omit<React.ComponentPropsWithoutRef<'footer'>, 'children' | 'ref'> {
+  links?: FooterLinkItem[];
+  smallPrint?: React.ReactNode;
+  legalText?: React.ReactNode;
+  socialLabel?: React.ReactNode;
+  socialLinks?: FooterSocialLinkItem[];
+  classes?: string;
+  ref?: React.Ref<HTMLFooterElement>;
+}
+
+const socialIcons: Record<
+  FooterSocialPlatform,
+  {
+    defaultIcon: string;
+    hoverIcon: string;
+    label: string;
+  }
+> = {
+  linkedin: {
+    defaultIcon: 'LinkedIn',
+    hoverIcon: 'LinkedInHover',
+    label: 'LinkedIn',
+  },
+  x: {
+    defaultIcon: 'X',
+    hoverIcon: 'XHover',
+    label: 'X',
+  },
+  facebook: {
+    defaultIcon: 'Facebook',
+    hoverIcon: 'FacebookHover',
+    label: 'Facebook',
+  },
+  youtube: {
+    defaultIcon: 'Youtube',
+    hoverIcon: 'YoutubeHover',
+    label: 'YouTube',
+  },
+  instagram: {
+    defaultIcon: 'Instagram',
+    hoverIcon: 'InstagramHover',
+    label: 'Instagram',
+  },
+  tiktok: {
+    defaultIcon: 'Tiktok',
+    hoverIcon: 'TiktokHover',
+    label: 'TikTok',
+  },
+};
+
+const renderFooterLink = (link: FooterLinkItem, index: number) => {
+  const {
+    href,
+    label,
+    external = false,
+    openInNewWindow = false,
+    rel,
+    target,
+    ...props
+  } = link;
+  const resolvedRel = openInNewWindow ? 'noopener noreferrer' : rel;
+  const resolvedTarget = openInNewWindow ? '_blank' : target;
+
+  return (
+    <li className="ofh-footer__links-item" key={`footer-link-${index}`}>
+      <a
+        {...props}
+        className="ofh-footer__link"
+        href={href}
+        rel={resolvedRel}
+        target={resolvedTarget}
+      >
+        <span className="ofh-footer__link-text">{label}</span>
+        {external ? (
+          <Icon
+            name="Launch"
+            size={16}
+            className="ofh-footer__link-icon"
+          />
+        ) : null}
+      </a>
+    </li>
+  );
+};
+
+const renderSocialLink = (link: FooterSocialLinkItem, index: number) => {
+  const {
+    href,
+    label,
+    openInNewWindow = false,
+    platform,
+    rel,
+    target,
+    ...props
+  } = link;
+  const iconNames = socialIcons[platform];
+  const resolvedRel = openInNewWindow ? 'noopener noreferrer' : rel;
+  const resolvedTarget = openInNewWindow ? '_blank' : target;
+
+  return (
+    <li className="ofh-footer__social-item" key={`footer-social-${platform}-${index}`}>
+      <a
+        {...props}
+        className="ofh-footer__social-link"
+        href={href}
+        rel={resolvedRel}
+        target={resolvedTarget}
+      >
+        <span
+          className="ofh-footer__social-icon ofh-footer__social-icon--default"
+          aria-hidden="true"
+        >
+          <Icon
+            name={iconNames.defaultIcon}
+            size={32}
+            className="ofh-footer__social-icon-svg"
+          />
+        </span>
+        <span
+          className="ofh-footer__social-icon ofh-footer__social-icon--hover"
+          aria-hidden="true"
+        >
+          <Icon
+            name={iconNames.hoverIcon}
+            size={32}
+            className="ofh-footer__social-icon-svg"
+          />
+        </span>
+        <span className="ofh-u-visually-hidden">{label ?? iconNames.label}</span>
+      </a>
+    </li>
+  );
+};
+
+export const Footer = ({
+  links = [],
+  smallPrint = '© Crown copyright',
+  legalText,
+  socialLabel = 'Follow us',
+  socialLinks = [],
+  classes = '',
+  className = '',
+  ref,
+  role = 'contentinfo',
+  ...props
+}: FooterProps) => (
+  <footer
+    {...props}
+    ref={ref}
+    role={role}
+    className={joinClasses('ofh-footer', classes, className)}
+  >
+    <div className="ofh-footer__main">
+      <div className="ofh-width-container">
+        <div className="ofh-footer__main-inner">
+          <div className="ofh-footer__meta">
+            {links.length ? (
+              <>
+                <h2 className="ofh-u-visually-hidden">Support links</h2>
+                <ul className="ofh-footer__links">
+                  {links.map(renderFooterLink)}
+                </ul>
+              </>
+            ) : null}
+            <p className="ofh-footer__small-print">{smallPrint}</p>
+          </div>
+          {legalText ? (
+            <p className="ofh-footer__legal">{legalText}</p>
+          ) : null}
+        </div>
+      </div>
+    </div>
+
+    {socialLinks.length ? (
+      <div className="ofh-footer__social">
+        <div className="ofh-width-container">
+          <div className="ofh-footer__social-inner">
+            <p className="ofh-footer__social-title">{socialLabel}</p>
+            <ul className="ofh-footer__social-list">
+              {socialLinks.map(renderSocialLink)}
+            </ul>
+          </div>
+        </div>
+      </div>
+    ) : null}
+  </footer>
+);
+
+Footer.displayName = 'Footer';

--- a/packages/react-components/src/components/Footer/index.ts
+++ b/packages/react-components/src/components/Footer/index.ts
@@ -1,0 +1,7 @@
+export { Footer } from './Footer';
+export type {
+  FooterLinkItem,
+  FooterProps,
+  FooterSocialLinkItem,
+  FooterSocialPlatform,
+} from './Footer';

--- a/packages/react-components/src/components/LinkIcon/LinkIcon.test.tsx
+++ b/packages/react-components/src/components/LinkIcon/LinkIcon.test.tsx
@@ -7,9 +7,11 @@ import { LinkIcon } from './LinkIcon';
 
 describe('LinkIcon', () => {
   it('renders the default left icon pattern', () => {
-    const { container } = render(<LinkIcon href="#back">Go back</LinkIcon>);
+    const { container } = render(
+      <LinkIcon href="#overview">Back to overview</LinkIcon>,
+    );
 
-    const link = screen.getByRole('link', { name: /go back/i });
+    const link = screen.getByRole('link', { name: /back to overview/i });
     const icon = container.querySelector('svg');
     const wrapper = container.firstElementChild;
 
@@ -24,12 +26,12 @@ describe('LinkIcon', () => {
 
   it('renders the right icon pattern with the launch icon by default', () => {
     const { container } = render(
-      <LinkIcon href="https://example.com" iconPosition="right">
-        Open external service
+      <LinkIcon href="https://example.com/guidance" iconPosition="right">
+        External guidance
       </LinkIcon>,
     );
 
-    const link = screen.getByRole('link', { name: /open external service/i });
+    const link = screen.getByRole('link', { name: /external guidance/i });
     const children = Array.from(link.children);
     const wrapper = container.firstElementChild;
 
@@ -41,8 +43,8 @@ describe('LinkIcon', () => {
 
   it('supports medium size and explicit icon names', () => {
     const { container } = render(
-      <LinkIcon href="#back" iconName="ChevronLeft" size="medium">
-        Go back
+      <LinkIcon href="#search" iconName="Search" size="medium">
+        Search site
       </LinkIcon>,
     );
 
@@ -56,7 +58,7 @@ describe('LinkIcon', () => {
   it('supports icon-only colour overrides', () => {
     const { container } = render(
       <LinkIcon href="#search" iconName="Search" iconColor="#005eb8">
-        Search results
+        Search site
       </LinkIcon>,
     );
 
@@ -65,17 +67,22 @@ describe('LinkIcon', () => {
     expect(icon).toHaveStyle({ color: 'rgb(0, 94, 184)' });
   });
 
-  it('opens in a new window when requested', () => {
+  it('preserves caller rel tokens when opening in a new window', () => {
     render(
-      <LinkIcon href="https://example.com" openInNewWindow>
-        Open external service
+      <LinkIcon
+        href="https://example.com/guidance"
+        iconPosition="right"
+        openInNewWindow
+        rel="nofollow"
+      >
+        External guidance
       </LinkIcon>,
     );
 
-    const link = screen.getByRole('link', { name: /open external service/i });
+    const link = screen.getByRole('link', { name: /external guidance/i });
 
     expect(link).toHaveAttribute('target', '_blank');
-    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(link).toHaveAttribute('rel', 'nofollow noopener noreferrer');
   });
 
   it('handles clicks', async () => {
@@ -83,8 +90,8 @@ describe('LinkIcon', () => {
     const user = userEvent.setup();
 
     render(
-      <LinkIcon href="#back" onClick={onClick}>
-        Go back
+      <LinkIcon href="#overview" onClick={onClick}>
+        Back to overview
       </LinkIcon>,
     );
 
@@ -97,8 +104,8 @@ describe('LinkIcon', () => {
     const ref = createRef<HTMLAnchorElement>();
 
     render(
-      <LinkIcon ref={ref} href="#back">
-        Go back
+      <LinkIcon ref={ref} href="#overview">
+        Back to overview
       </LinkIcon>,
     );
 
@@ -106,7 +113,9 @@ describe('LinkIcon', () => {
   });
 
   it('has no accessibility violations', async () => {
-    const { container } = render(<LinkIcon href="#back">Go back</LinkIcon>);
+    const { container } = render(
+      <LinkIcon href="#overview">Back to overview</LinkIcon>,
+    );
 
     const results = await axe(container);
 

--- a/packages/react-components/src/components/LinkIcon/LinkIcon.tsx
+++ b/packages/react-components/src/components/LinkIcon/LinkIcon.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { IconProps } from '../Icon';
 import { Icon } from '../Icon';
+import { mergeRelTokens } from '../../internal/mergeRelTokens';
 import { joinClassNames } from '../_internal/joinClassNames';
 
 export type LinkIconSize = 'small' | 'medium';
@@ -65,7 +66,7 @@ export const LinkIcon = ({
     `ofh-link-icon--icon-${iconPosition}`,
     className,
   );
-  const resolvedRel = openInNewWindow ? 'noopener noreferrer' : rel;
+  const resolvedRel = mergeRelTokens(rel, openInNewWindow);
   const resolvedTarget = openInNewWindow ? '_blank' : target;
 
   return (

--- a/packages/react-components/src/components/LinkIcon/LinkIcon.tsx
+++ b/packages/react-components/src/components/LinkIcon/LinkIcon.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import type { IconProps } from '../Icon';
 import { Icon } from '../Icon';
 import { joinClassNames } from '../_internal/joinClassNames';
 
 export type LinkIconSize = 'small' | 'medium';
 export type LinkIconIconPosition = 'left' | 'right';
 
-const defaultIconNames: Record<LinkIconIconPosition, string> = {
+const defaultIconNames: Record<LinkIconIconPosition, IconProps['name']> = {
   left: 'ChevronLeft',
   right: 'Launch',
 };
@@ -16,18 +17,19 @@ const iconSizes: Record<LinkIconSize, 16 | 24> = {
 };
 
 export interface LinkIconProps
-  extends Omit<
-    React.AnchorHTMLAttributes<HTMLAnchorElement>,
-    'children' | 'ref'
-  > {
+  extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'children' | 'ref'> {
   children: React.ReactNode;
   href: string;
   iconColor?: string;
-  iconName?: string;
+  iconName?: IconProps['name'];
   iconPosition?: LinkIconIconPosition;
+  leftIconName?: IconProps['name'];
   openInNewWindow?: boolean;
-  size?: LinkIconSize;
   ref?: React.Ref<HTMLAnchorElement>;
+  rightIconName?: IconProps['name'];
+  showIconLeft?: boolean;
+  showIconRight?: boolean;
+  size?: LinkIconSize;
 }
 
 export const LinkIcon = ({
@@ -36,15 +38,26 @@ export const LinkIcon = ({
   iconColor,
   iconName,
   iconPosition = 'left',
+  leftIconName,
   openInNewWindow = false,
   size = 'small',
   className = '',
   ref,
   rel,
+  rightIconName,
+  showIconLeft,
+  showIconRight,
   target,
   ...props
 }: LinkIconProps) => {
-  const resolvedIconName = iconName ?? defaultIconNames[iconPosition];
+  const resolvedShowIconLeft = showIconLeft ?? iconPosition === 'left';
+  const resolvedShowIconRight = showIconRight ?? iconPosition === 'right';
+  const resolvedLeftIconName =
+    leftIconName ??
+    (iconPosition === 'left' && iconName ? iconName : defaultIconNames.left);
+  const resolvedRightIconName =
+    rightIconName ??
+    (iconPosition === 'right' && iconName ? iconName : defaultIconNames.right);
   const resolvedIconSize = iconSizes[size];
   const rootClassName = joinClassNames(
     'ofh-link-icon',
@@ -65,18 +78,18 @@ export const LinkIcon = ({
         rel={resolvedRel}
         target={resolvedTarget}
       >
-        {iconPosition === 'left' ? (
+        {resolvedShowIconLeft ? (
           <Icon
-            name={resolvedIconName}
+            name={resolvedLeftIconName}
             size={resolvedIconSize}
             className="ofh-link-icon__icon"
             color={iconColor}
           />
         ) : null}
         <span className="ofh-link-icon__text">{children}</span>
-        {iconPosition === 'right' ? (
+        {resolvedShowIconRight ? (
           <Icon
-            name={resolvedIconName}
+            name={resolvedRightIconName}
             size={resolvedIconSize}
             className="ofh-link-icon__icon"
             color={iconColor}

--- a/packages/react-components/src/components/LinkIcon/index.ts
+++ b/packages/react-components/src/components/LinkIcon/index.ts
@@ -1,2 +1,6 @@
 export { LinkIcon } from './LinkIcon';
-export type { LinkIconIconPosition, LinkIconProps, LinkIconSize } from './LinkIcon';
+export type {
+  LinkIconIconPosition,
+  LinkIconProps,
+  LinkIconSize,
+} from './LinkIcon';

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -43,6 +43,14 @@ export type { DetailsProps } from './components/Details';
 export { Expander } from './components/Expander';
 export type { ExpanderProps } from './components/Expander';
 
+export { Footer } from './components/Footer';
+export type {
+  FooterLinkItem,
+  FooterProps,
+  FooterSocialLinkItem,
+  FooterSocialPlatform,
+} from './components/Footer';
+
 export { Textarea } from './components/Textarea';
 export type { TextareaProps } from './components/Textarea';
 

--- a/packages/react-components/src/internal/mergeRelTokens.ts
+++ b/packages/react-components/src/internal/mergeRelTokens.ts
@@ -1,0 +1,14 @@
+export function mergeRelTokens(
+  rel: string | undefined,
+  openInNewWindow: boolean,
+): string | undefined {
+  if (!openInNewWindow) {
+    return rel;
+  }
+
+  const relTokens = new Set((rel ?? '').split(/\s+/).filter(Boolean));
+  relTokens.add('noopener');
+  relTokens.add('noreferrer');
+
+  return Array.from(relTokens).join(' ');
+}

--- a/packages/site/views/design-system/components/footer/default/index.njk
+++ b/packages/site/views/design-system/components/footer/default/index.njk
@@ -27,10 +27,8 @@
       "label": "Cookies"
     },
     {
-      "url": "https://example.com/careers",
-      "label": "Careers",
-      "external": true,
-      "openInNewWindow": true
+      "url": "#careers",
+      "label": "Careers"
     }
   ],
   "smallPrint": "&copy; Our Future Health 2026",

--- a/packages/site/views/design-system/components/footer/default/index.njk
+++ b/packages/site/views/design-system/components/footer/default/index.njk
@@ -3,24 +3,68 @@
 {{ footer({
   "links": [
     {
-      "URL": "#",
-      "label": "Accessibility statement"
+      "url": "#help",
+      "label": "Help and Support"
     },
     {
-      "URL": "#",
-      "label": "Contact us"
+      "url": "#faq",
+      "label": "Frequently Asked Questions"
     },
     {
-      "URL": "#",
+      "url": "#contact",
+      "label": "Contact Us"
+    },
+    {
+      "url": "#accessibility",
+      "label": "Accessibility"
+    },
+    {
+      "url": "#privacy",
+      "label": "Privacy"
+    },
+    {
+      "url": "#cookies",
       "label": "Cookies"
     },
     {
-      "URL": "#",
-      "label": "Privacy policy"
+      "url": "https://example.com/careers",
+      "label": "Careers",
+      "external": true,
+      "openInNewWindow": true
+    }
+  ],
+  "smallPrint": "&copy; Our Future Health 2026",
+  "legalText": "Our Future Health is a company limited by guarantee registered in England and Wales (number 12212468) and a charity registered with the Charity Commission for England and Wales (charity number 1189681) and OSCR, Scottish Charity Regulator (charity number SC050917). Registered office: 2 New Bailey, 6 Stanley Street, Manchester M3 5GS.",
+  "socialLinks": [
+    {
+      "platform": "linkedin",
+      "href": "https://www.linkedin.com/company/our-future-health/",
+      "openInNewWindow": true
     },
     {
-      "URL": "#",
-      "label": "Terms and conditions"
+      "platform": "x",
+      "href": "https://x.com/",
+      "openInNewWindow": true
+    },
+    {
+      "platform": "facebook",
+      "href": "https://facebook.com/",
+      "openInNewWindow": true
+    },
+    {
+      "platform": "youtube",
+      "href": "https://youtube.com/",
+      "openInNewWindow": true
+    },
+    {
+      "platform": "instagram",
+      "href": "https://instagram.com/",
+      "openInNewWindow": true
+    },
+    {
+      "platform": "tiktok",
+      "href": "https://tiktok.com/",
+      "openInNewWindow": true
     }
   ]
-})}}
+}) }}

--- a/packages/site/views/design-system/components/footer/index.njk
+++ b/packages/site/views/design-system/components/footer/index.njk
@@ -1,10 +1,10 @@
 {% set pageTitle = "Footer" %}
 {% set pageSection = "Design system" %}
 {% set subSection = "Components" %}
-{% set pageDescription = "Use the footer to show users they are on an NHS service and to help them find links they expect at the bottom of our pages." %}
+{% set pageDescription = "Use the footer to show service support links, legal information, and optional social links at the bottom of a page." %}
 {% set theme = "Navigation" %}
-{% set dateUpdated = "May 2020" %}
-{% set backlog_issue_id = "15" %}
+{% set dateUpdated = "April 2026" %}
+{% set backlog_issue_id = "337" %}
 
 {% extends "app-layout.njk" %}
 
@@ -24,16 +24,8 @@
   <p>Use the footer at the bottom of every page of your service.</p>
 
   <h2 id="how-to-use-the-footer">How to use the footer</h2>
-
-  <p>Add links to meta information about your service, such as:
-  <ul>
-    <li>accessibility</li>
-    <li>contact details</li>
-    <li>cookies</li>
-    <li>privacy policy</li>
-    <li>terms and conditions</li>
-  </ul>
-
-  <p>Avoid adding lots of links. Keep them to a minimum.</p>
+  <p>Add only the links users expect to find in the footer, such as support, contact, privacy, and accessibility information.</p>
+  <p>Use the small-print and legal text areas for concise organisation details. If you need to point to an external destination, use the optional right-side launch icon.</p>
+  <p>Only include the social section when those channels are part of the service experience and are actively maintained.</p>
 
 {% endblock %}

--- a/packages/site/views/design-system/components/footer/index.njk
+++ b/packages/site/views/design-system/components/footer/index.njk
@@ -28,4 +28,13 @@
   <p>Use the small-print and legal text areas for concise organisation details. If you need to point to an external destination, use the optional right-side launch icon.</p>
   <p>Only include the social section when those channels are part of the service experience and are actively maintained.</p>
 
+  <h3 id="minimal-footer">Minimal footer</h3>
+  <p>If your service only needs a small set of support links, you can use the simpler footer without legal copy or social links.</p>
+
+  {{ designExample({
+    group: "components",
+    item: "footer",
+    type: "minimal"
+  }) }}
+
 {% endblock %}

--- a/packages/site/views/design-system/components/footer/index.njk
+++ b/packages/site/views/design-system/components/footer/index.njk
@@ -25,8 +25,17 @@
 
   <h2 id="how-to-use-the-footer">How to use the footer</h2>
   <p>Add only the links users expect to find in the footer, such as support, contact, privacy, and accessibility information.</p>
-  <p>Use the small-print and legal text areas for concise organisation details. If you need to point to an external destination, use the optional right-side launch icon.</p>
+  <p>Use the small-print and legal text areas for concise organisation details. The default footer keeps support links text-only, but you can opt into shared link icons when a directional or external cue helps users understand where a link leads.</p>
   <p>Only include the social section when those channels are part of the service experience and are actively maintained.</p>
+
+  <h3 id="footer-links-with-icons">Footer links with icons</h3>
+  <p>Use link icons sparingly in the footer. They can help when you need to distinguish between text-only support links, back-navigation, and links that open external guidance.</p>
+
+  {{ designExample({
+    group: "components",
+    item: "footer",
+    type: "link-icons"
+  }) }}
 
   <h3 id="minimal-footer">Minimal footer</h3>
   <p>If your service only needs a small set of support links, you can use the simpler footer without legal copy or social links.</p>
@@ -35,6 +44,15 @@
     group: "components",
     item: "footer",
     type: "minimal"
+  }) }}
+
+  <h3 id="legal-and-social-footer">Footer with legal and social sections only</h3>
+  <p>Use this variant when the service needs organisation details and social channels, but does not need a support-link list or a separate small-print line.</p>
+
+  {{ designExample({
+    group: "components",
+    item: "footer",
+    type: "legal-and-social"
   }) }}
 
 {% endblock %}

--- a/packages/site/views/design-system/components/footer/legal-and-social/index.njk
+++ b/packages/site/views/design-system/components/footer/legal-and-social/index.njk
@@ -1,0 +1,23 @@
+{% from 'footer/macro.njk' import footer %}
+
+{{ footer({
+  "smallPrint": "",
+  "legalText": "Our Future Health is a company limited by guarantee registered in England and Wales (number 12212468).",
+  "socialLinks": [
+    {
+      "platform": "linkedin",
+      "href": "https://www.linkedin.com/company/our-future-health/",
+      "openInNewWindow": true
+    },
+    {
+      "platform": "x",
+      "href": "https://x.com/",
+      "openInNewWindow": true
+    },
+    {
+      "platform": "facebook",
+      "href": "https://facebook.com/",
+      "openInNewWindow": true
+    }
+  ]
+}) }}

--- a/packages/site/views/design-system/components/footer/link-icons/index.njk
+++ b/packages/site/views/design-system/components/footer/link-icons/index.njk
@@ -1,0 +1,29 @@
+{% from 'footer/macro.njk' import footer %}
+
+{{ footer({
+  "links": [
+    {
+      "url": "#overview",
+      "label": "Back to overview",
+      "iconName": "ChevronLeft",
+      "iconPosition": "left"
+    },
+    {
+      "url": "#search",
+      "label": "Search site",
+      "iconName": "Search",
+      "iconPosition": "left"
+    },
+    {
+      "url": "#privacy",
+      "label": "Privacy"
+    },
+    {
+      "url": "https://example.com/guidance",
+      "label": "External guidance",
+      "external": true,
+      "openInNewWindow": true
+    }
+  ],
+  "smallPrint": "&copy; Our Future Health 2026"
+}) }}

--- a/packages/site/views/design-system/components/footer/macro-options.json
+++ b/packages/site/views/design-system/components/footer/macro-options.json
@@ -4,27 +4,89 @@
       "name": "links",
       "type": "array",
       "required": false,
-      "description": "Contains an array of footer link items.",
+      "description": "Array of footer link items.",
       "params": [
         {
           "name": "url",
           "type": "string",
           "required": false,
-          "description": "Href attribute for the footer link item."
+          "description": "Href for the footer link item. The legacy `URL` key is also supported."
         },
         {
           "name": "label",
           "type": "string",
           "required": true,
-          "description": "The label of for the footer link item."
+          "description": "Visible label for the footer link item."
+        },
+        {
+          "name": "external",
+          "type": "boolean",
+          "required": false,
+          "description": "Adds a right-side launch icon for external links."
+        },
+        {
+          "name": "openInNewWindow",
+          "type": "boolean",
+          "required": false,
+          "description": "Opens the link in a new window and adds `rel=\"noopener noreferrer\"`."
         }
       ]
+    },
+    {
+      "name": "smallPrint",
+      "type": "string",
+      "required": false,
+      "description": "Small-print line shown below the support links."
     },
     {
       "name": "copyright",
       "type": "string",
       "required": false,
-      "description": "Optional text for the copyright notice in the footer."
+      "description": "Backward-compatible alias for `smallPrint`."
+    },
+    {
+      "name": "legalText",
+      "type": "string",
+      "required": false,
+      "description": "Additional legal copy shown below the small-print line."
+    },
+    {
+      "name": "socialLabel",
+      "type": "string",
+      "required": false,
+      "description": "Optional label shown before the social links. Defaults to `Follow us`."
+    },
+    {
+      "name": "socialLinks",
+      "type": "array",
+      "required": false,
+      "description": "Array of social link items.",
+      "params": [
+        {
+          "name": "platform",
+          "type": "string",
+          "required": true,
+          "description": "One of `linkedin`, `x`, `facebook`, `youtube`, `instagram`, or `tiktok`."
+        },
+        {
+          "name": "href",
+          "type": "string",
+          "required": true,
+          "description": "Href for the social link."
+        },
+        {
+          "name": "label",
+          "type": "string",
+          "required": false,
+          "description": "Accessible label override for the social link."
+        },
+        {
+          "name": "openInNewWindow",
+          "type": "boolean",
+          "required": false,
+          "description": "Opens the social link in a new window."
+        }
+      ]
     },
     {
       "name": "classes",

--- a/packages/site/views/design-system/components/footer/macro-options.json
+++ b/packages/site/views/design-system/components/footer/macro-options.json
@@ -25,6 +25,54 @@
           "description": "Adds a right-side launch icon for external links."
         },
         {
+          "name": "iconName",
+          "type": "string",
+          "required": false,
+          "description": "Optional shared icon name for the footer link. Defaults to `ChevronLeft` for left icons and `Launch` for right icons."
+        },
+        {
+          "name": "iconPosition",
+          "type": "string",
+          "required": false,
+          "description": "Optional icon placement for the footer link. Use `left` or `right`."
+        },
+        {
+          "name": "iconLeftName",
+          "type": "string",
+          "required": false,
+          "description": "Optional explicit icon name for the left side of the footer link."
+        },
+        {
+          "name": "iconRightName",
+          "type": "string",
+          "required": false,
+          "description": "Optional explicit icon name for the right side of the footer link."
+        },
+        {
+          "name": "showIconLeft",
+          "type": "boolean",
+          "required": false,
+          "description": "Forces the left icon on or off for the footer link."
+        },
+        {
+          "name": "showIconRight",
+          "type": "boolean",
+          "required": false,
+          "description": "Forces the right icon on or off for the footer link."
+        },
+        {
+          "name": "iconColor",
+          "type": "string",
+          "required": false,
+          "description": "Optional icon-only colour override for the footer link."
+        },
+        {
+          "name": "size",
+          "type": "string",
+          "required": false,
+          "description": "Optional icon/text size for the footer link. Use `small` or `medium`."
+        },
+        {
           "name": "openInNewWindow",
           "type": "boolean",
           "required": false,
@@ -36,7 +84,7 @@
       "name": "smallPrint",
       "type": "string",
       "required": false,
-      "description": "Small-print line shown below the support links."
+      "description": "Small-print line shown below the support links. Set it to an empty string or `null` to hide it."
     },
     {
       "name": "copyright",

--- a/packages/site/views/design-system/components/footer/minimal/index.njk
+++ b/packages/site/views/design-system/components/footer/minimal/index.njk
@@ -1,0 +1,11 @@
+{% from 'footer/macro.njk' import footer %}
+
+{{ footer({
+  "links": [
+    {
+      "url": "#privacy",
+      "label": "Privacy"
+    }
+  ],
+  "smallPrint": "&copy; Our Future Health 2026"
+}) }}

--- a/packages/site/views/examples/components/footer/index.njk
+++ b/packages/site/views/examples/components/footer/index.njk
@@ -32,10 +32,8 @@
         "label": "Cookies"
       },
       {
-        "url": "https://example.com/careers",
-        "label": "Careers",
-        "external": true,
-        "openInNewWindow": true
+        "url": "#careers",
+        "label": "Careers"
       }
     ],
     "smallPrint": "&copy; Our Future Health 2026",

--- a/packages/site/views/examples/components/footer/index.njk
+++ b/packages/site/views/examples/components/footer/index.njk
@@ -8,26 +8,70 @@
   {{ footer({
     "links": [
       {
-        "URL": "#",
-        "label": "Accessibility statement"
+        "url": "#help",
+        "label": "Help and Support"
       },
       {
-        "URL": "#",
-        "label": "Contact us"
+        "url": "#faq",
+        "label": "Frequently Asked Questions"
       },
       {
-        "URL": "#",
+        "url": "#contact",
+        "label": "Contact Us"
+      },
+      {
+        "url": "#accessibility",
+        "label": "Accessibility"
+      },
+      {
+        "url": "#privacy",
+        "label": "Privacy"
+      },
+      {
+        "url": "#cookies",
         "label": "Cookies"
       },
       {
-        "URL": "#",
-        "label": "Privacy policy"
+        "url": "https://example.com/careers",
+        "label": "Careers",
+        "external": true,
+        "openInNewWindow": true
+      }
+    ],
+    "smallPrint": "&copy; Our Future Health 2026",
+    "legalText": "Our Future Health is a company limited by guarantee registered in England and Wales (number 12212468) and a charity registered with the Charity Commission for England and Wales (charity number 1189681) and OSCR, Scottish Charity Regulator (charity number SC050917). Registered office: 2 New Bailey, 6 Stanley Street, Manchester M3 5GS.",
+    "socialLinks": [
+      {
+        "platform": "linkedin",
+        "href": "https://www.linkedin.com/company/our-future-health/",
+        "openInNewWindow": true
       },
       {
-        "URL": "#",
-        "label": "Terms and conditions"
+        "platform": "x",
+        "href": "https://x.com/",
+        "openInNewWindow": true
+      },
+      {
+        "platform": "facebook",
+        "href": "https://facebook.com/",
+        "openInNewWindow": true
+      },
+      {
+        "platform": "youtube",
+        "href": "https://youtube.com/",
+        "openInNewWindow": true
+      },
+      {
+        "platform": "instagram",
+        "href": "https://instagram.com/",
+        "openInNewWindow": true
+      },
+      {
+        "platform": "tiktok",
+        "href": "https://tiktok.com/",
+        "openInNewWindow": true
       }
     ]
-  })}}
+  }) }}
 
 {% endblock %}

--- a/packages/toolkit/components/footer/README.md
+++ b/packages/toolkit/components/footer/README.md
@@ -2,75 +2,112 @@
 
 ## Guidance
 
+Use the footer to show service support links, concise organisation details, and optional social links at the bottom of a page.
+
 Find out more about the footer component and when to use it in the [design system docs website](https://designsystem.ourfuturehealth.org.uk/design-system/components/footer).
 
-## Quick start examples
-
-### Footer
+## Quick start example
 
 [Preview the footer component](https://ourfuturehealth.github.io/design-system-toolkit/components/footer/index.html)
 
-#### HTML markup
+### HTML markup
 
 ```html
 <footer role="contentinfo">
   <div class="ofh-footer" id="ofh-footer">
-    <div class="ofh-width-container">
-      <h2 class="ofh-u-visually-hidden">Support links</h2>
-      <ul class="ofh-footer__list">
-        <li class="ofh-footer__list-item"><a class="ofh-footer__list-item-link" href="#">Accessibility statement</a></li>
-        <li class="ofh-footer__list-item"><a class="ofh-footer__list-item-link" href="#">Contact us</a></li>
-        <li class="ofh-footer__list-item"><a class="ofh-footer__list-item-link" href="#">Cookies</a></li>
-        <li class="ofh-footer__list-item"><a class="ofh-footer__list-item-link" href="#">Privacy policy</a></li>
-        <li class="ofh-footer__list-item"><a class="ofh-footer__list-item-link" href="#">Terms and conditions</a></li>
-      </ul>
-      <p class="ofh-footer__copyright">&copy; Crown copyright</p>
+    <div class="ofh-footer__main">
+      <div class="ofh-width-container">
+        <div class="ofh-footer__main-inner">
+          <div class="ofh-footer__meta">
+            <h2 class="ofh-u-visually-hidden">Support links</h2>
+            <ul class="ofh-footer__links">
+              <li class="ofh-footer__links-item">
+                <a class="ofh-footer__link" href="#">Help and Support</a>
+              </li>
+              <li class="ofh-footer__links-item">
+                <a class="ofh-footer__link" href="#">
+                  Careers
+                  <svg class="ofh-icon ofh-icon--16 ofh-icon--Launch ofh-footer__link-icon" aria-hidden="true" focusable="false">
+                    ...
+                  </svg>
+                </a>
+              </li>
+            </ul>
+            <p class="ofh-footer__small-print">&copy; Our Future Health 2026</p>
+          </div>
+          <p class="ofh-footer__legal">Organisation legal text.</p>
+        </div>
+      </div>
+    </div>
+    <div class="ofh-footer__social">
+      <div class="ofh-width-container">
+        <div class="ofh-footer__social-inner">
+          <p class="ofh-footer__social-title">Follow us</p>
+          <ul class="ofh-footer__social-list">
+            <li class="ofh-footer__social-item">
+              <a class="ofh-footer__social-link" href="#">
+                ...
+                <span class="ofh-u-visually-hidden">LinkedIn</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
     </div>
   </div>
 </footer>
 ```
 
-#### Nunjucks macro
+### Nunjucks macro
 
-```
+```njk
 {% from 'components/footer/macro.njk' import footer %}
 
 {{ footer({
   "links": [
     {
-      "URL": "#",
-      "label": "Accessibility statement"
+      "url": "#help",
+      "label": "Help and Support"
     },
     {
-      "URL": "#",
-      "label": "Contact us"
-    },
+      "url": "https://example.com/careers",
+      "label": "Careers",
+      "external": true,
+      "openInNewWindow": true
+    }
+  ],
+  "smallPrint": "&copy; Our Future Health 2026",
+  "legalText": "Organisation legal text.",
+  "socialLinks": [
     {
-      "URL": "#",
-      "label": "Cookies"
-    },
-    {
-      "URL": "#",
-      "label": "Privacy policy"
-    },
-    {
-      "URL": "#",
-      "label": "Terms and conditions"
+      "platform": "linkedin",
+      "href": "https://www.linkedin.com/company/our-future-health/",
+      "openInNewWindow": true
     }
   ]
-})}}
+}) }}
 ```
+
 ### Nunjucks arguments
 
-The footer Nunjucks macro takes the following arguments:
-
-| Name                         | Type     | Required  | Description  |
-| -----------------------------|----------|-----------|--------------|
-| **links**             | array    | No        | Array of primary navigation items for use in the footer. |
-| **links.[].url**      | string   | No        | The href of a primary navigation item in the footer. |
-| **links.[].label**    | string   | No        | The label of a primary navigation item in the footer. |
-| **classes**           | string   | No        | Optional additional classes to add to the footer container. Separate each class with a space. |
-| **attributes**        | object   | No        | Any extra HTML attributes (for example data attributes) to add to the footer container. |
-| **copyright**        | string   | No        | The label for the copyright notice in the footer. |
-
-If you are using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `html` can be a [security risk](https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting). Read more about this in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).
+| Name | Type | Required | Description |
+| ---- | ---- | ---- | ---- |
+| `links` | array | No | Array of footer link items. |
+| `links[].url` | string | No | Href for the footer link item. The legacy `URL` key is still supported for compatibility. |
+| `links[].label` | string | Yes | Visible label for the footer link item. |
+| `links[].external` | boolean | No | Adds a right-side launch icon for external links. |
+| `links[].openInNewWindow` | boolean | No | Opens the link in a new window and adds `rel=\"noopener noreferrer\"`. |
+| `links[].attributes` | object | No | Extra HTML attributes for the footer link item. |
+| `smallPrint` | string | No | Small-print line shown under the support links. |
+| `copyright` | string | No | Backward-compatible alias for `smallPrint`. |
+| `legalText` | string | No | Additional legal copy shown below the small-print line. |
+| `legalHtml` | string | No | Trusted HTML alternative for the legal copy. |
+| `socialLabel` | string | No | Label shown before the social links on tablet and desktop. Defaults to `Follow us`. |
+| `socialLinks` | array | No | Array of social link items. |
+| `socialLinks[].platform` | string | Yes | One of `linkedin`, `x`, `facebook`, `youtube`, `instagram`, or `tiktok`. |
+| `socialLinks[].href` | string | Yes | Href for the social link. |
+| `socialLinks[].label` | string | No | Accessible label override for the social link. |
+| `socialLinks[].openInNewWindow` | boolean | No | Opens the social link in a new window. |
+| `socialLinks[].attributes` | object | No | Extra HTML attributes for the social link. |
+| `classes` | string | No | Optional additional classes to add to the footer container. |
+| `attributes` | object | No | Extra HTML attributes for the footer container. |

--- a/packages/toolkit/components/footer/README.md
+++ b/packages/toolkit/components/footer/README.md
@@ -22,15 +22,21 @@ Find out more about the footer component and when to use it in the [design syste
             <h2 class="ofh-u-visually-hidden">Support links</h2>
             <ul class="ofh-footer__links">
               <li class="ofh-footer__links-item">
-                <a class="ofh-footer__link" href="#">Help and Support</a>
+                <div class="ofh-link-icon ofh-link-icon--small ofh-link-icon--icon-left ofh-footer__link-component">
+                  <a class="ofh-link-icon__link" href="#">
+                    <span class="ofh-link-icon__text">Help and Support</span>
+                  </a>
+                </div>
               </li>
               <li class="ofh-footer__links-item">
-                <a class="ofh-footer__link" href="#">
-                  Careers
-                  <svg class="ofh-icon ofh-icon--16 ofh-icon--Launch ofh-footer__link-icon" aria-hidden="true" focusable="false">
-                    ...
-                  </svg>
-                </a>
+                <div class="ofh-link-icon ofh-link-icon--small ofh-link-icon--icon-right ofh-footer__link-component">
+                  <a class="ofh-link-icon__link" href="#">
+                    <span class="ofh-link-icon__text">External guidance</span>
+                    <svg class="ofh-icon ofh-icon--16 ofh-icon--Launch ofh-link-icon__icon" aria-hidden="true" focusable="false">
+                      ...
+                    </svg>
+                  </a>
+                </div>
               </li>
             </ul>
             <p class="ofh-footer__small-print">&copy; Our Future Health 2026</p>
@@ -70,8 +76,8 @@ Find out more about the footer component and when to use it in the [design syste
       "label": "Help and Support"
     },
     {
-      "url": "https://example.com/careers",
-      "label": "Careers",
+      "url": "https://example.com/guidance",
+      "label": "External guidance",
       "external": true,
       "openInNewWindow": true
     }
@@ -96,9 +102,17 @@ Find out more about the footer component and when to use it in the [design syste
 | `links[].url` | string | No | Href for the footer link item. The legacy `URL` key is still supported for compatibility. |
 | `links[].label` | string | Yes | Visible label for the footer link item. |
 | `links[].external` | boolean | No | Adds a right-side launch icon for external links. |
+| `links[].iconName` | string | No | Optional shared icon name for the footer link. Defaults to `ChevronLeft` for left icons and `Launch` for right icons. |
+| `links[].iconPosition` | string | No | Optional icon placement for the footer link. Use `left` or `right`. |
+| `links[].iconLeftName` | string | No | Optional explicit icon name for the left side of the footer link. |
+| `links[].iconRightName` | string | No | Optional explicit icon name for the right side of the footer link. |
+| `links[].showIconLeft` | boolean | No | Forces the left icon on or off for the footer link. |
+| `links[].showIconRight` | boolean | No | Forces the right icon on or off for the footer link. |
+| `links[].iconColor` | string | No | Optional icon-only colour override for the footer link. |
+| `links[].size` | string | No | Optional icon/text size for the footer link. Use `small` or `medium`. |
 | `links[].openInNewWindow` | boolean | No | Opens the link in a new window and adds `rel=\"noopener noreferrer\"`. |
 | `links[].attributes` | object | No | Extra HTML attributes for the footer link item. |
-| `smallPrint` | string | No | Small-print line shown under the support links. |
+| `smallPrint` | string | No | Small-print line shown under the support links. Set it to an empty string or `null` to hide it. |
 | `copyright` | string | No | Backward-compatible alias for `smallPrint`. |
 | `legalText` | string | No | Additional legal copy shown below the small-print line. |
 | `legalHtml` | string | No | Trusted HTML alternative for the legal copy. |

--- a/packages/toolkit/components/footer/_footer.scss
+++ b/packages/toolkit/components/footer/_footer.scss
@@ -10,8 +10,8 @@
 
 .ofh-footer__main {
   background-color: $ofh-color-background-tertiary;
-  padding-bottom: $ofh-size-32;
-  padding-top: $ofh-size-32;
+
+  @include ofh-responsive-padding(32, 'vertical');
 }
 
 .ofh-footer__main-inner {
@@ -19,13 +19,15 @@
 
   display: flex;
   flex-direction: column;
-  gap: $ofh-size-32;
+
+  @include ofh-responsive-gap-y(32);
 }
 
 .ofh-footer__meta {
   display: flex;
   flex-direction: column;
-  gap: $ofh-size-16;
+
+  @include ofh-responsive-gap-y(16);
 }
 
 .ofh-footer__links,
@@ -38,7 +40,9 @@
 .ofh-footer__links {
   display: flex;
   flex-wrap: wrap;
-  gap: $ofh-size-16 $ofh-size-32;
+  row-gap: $ofh-size-16;
+
+  @include ofh-responsive-gap-x(32);
 }
 
 .ofh-footer__link {
@@ -81,8 +85,8 @@
 
 .ofh-footer__social {
   background-color: $ofh-color-background-secondary;
-  padding-bottom: $ofh-size-32;
-  padding-top: $ofh-size-32;
+
+  @include ofh-responsive-padding(32, 'vertical');
 }
 
 .ofh-footer__social-inner {

--- a/packages/toolkit/components/footer/_footer.scss
+++ b/packages/toolkit/components/footer/_footer.scss
@@ -5,7 +5,7 @@
 .ofh-footer {
   @include print-hide();
 
-  border-top: $ofh-size-4 solid $ofh-color-brand-yellow-3-main;
+  border-top: $ofh-size-4 solid $ofh-color-border-accent-2;
 }
 
 .ofh-footer__main {

--- a/packages/toolkit/components/footer/_footer.scss
+++ b/packages/toolkit/components/footer/_footer.scss
@@ -3,70 +3,143 @@
    ========================================================================== */
 
 .ofh-footer {
-  @include clearfix();
   @include print-hide();
-  @include ofh-responsive-padding(24, bottom);
-  @include ofh-responsive-padding(24, top);
-  @include ofh-font('paragraph-sm');
 
-  background-color: $ofh-color-greyscale-5;
   border-top: $ofh-size-4 solid $ofh-color-brand-yellow-3-main;
 }
 
-.footer-text {
-  float: left;
-
-  p {
-    @include ofh-font('paragraph-sm');
-
-    margin: 0;
-  }
+.ofh-footer__main {
+  background-color: $ofh-color-background-tertiary;
+  padding-bottom: $ofh-size-32;
+  padding-top: $ofh-size-32;
 }
 
-.ofh-footer__list {
-  @include ofh-responsive-padding(16, bottom);
-
-  list-style-type: none;
-  margin: 0;
-  padding-left: $ofh-size-0;
-
-  @include mq($from: desktop) {
-    float: left;
-    padding-bottom: 0;
-    width: 75%;
-  }
-}
-
-.ofh-footer__list-item {
+.ofh-footer__main-inner {
   @include ofh-font('paragraph-sm');
 
-  @include mq($from: desktop) {
-    float: left;
-    margin-right: $ofh-size-32;
-  }
+  display: flex;
+  flex-direction: column;
+  gap: $ofh-size-32;
 }
 
-.ofh-footer__list-item-link {
-  color: $ofh-color-brand-blue-navy-3-main;
+.ofh-footer__meta {
+  display: flex;
+  flex-direction: column;
+  gap: $ofh-size-16;
+}
+
+.ofh-footer__links,
+.ofh-footer__social-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ofh-footer__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $ofh-size-16 $ofh-size-32;
+}
+
+.ofh-footer__link {
+  @include ofh-typography-responsive('paragraph-sm');
+
+  align-items: center;
+  color: $ofh-color-foreground-brand-blue-navy;
+  display: inline-flex;
+  gap: $ofh-size-4;
+  text-decoration: underline;
 
   &:visited {
-    color: $ofh-color-brand-blue-navy-3-main;
+    color: $ofh-color-foreground-brand-blue-navy;
   }
 
   &:hover {
-    color: $ofh-color-foreground-primary;
+    color: $ofh-color-foreground-link-hover;
+    text-decoration: none;
+  }
+
+  &:focus {
+    outline: $ofh-stroke-weight-4 solid $ofh-color-border-feedback-focus;
+    outline-offset: $ofh-stroke-weight-4;
+    text-decoration: none;
   }
 }
 
-.ofh-footer__copyright {
-  @include ofh-font('paragraph-sm');
+.ofh-footer__link-icon {
+  color: currentColor;
+  flex: 0 0 auto;
+}
 
-  color: $ofh-color-greyscale-black;
+.ofh-footer__small-print,
+.ofh-footer__legal {
+  @include ofh-typography-responsive('paragraph-sm');
+
+  color: $ofh-color-foreground-secondary;
+  margin-bottom: 0;
+}
+
+.ofh-footer__social {
+  background-color: $ofh-color-background-secondary;
+  padding-bottom: $ofh-size-32;
+  padding-top: $ofh-size-32;
+}
+
+.ofh-footer__social-inner {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: $ofh-size-16;
+}
+
+.ofh-footer__social-title {
+  @include ofh-typography-responsive('heading-xs');
+
+  color: $ofh-color-foreground-brand-blue-navy;
   margin-bottom: 0;
 
-  @include mq($from: desktop) {
-    float: right;
-    text-align: right;
-    width: 25%;
+  @include mq($until: tablet) {
+    display: none;
   }
+}
+
+.ofh-footer__social-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $ofh-size-16;
+}
+
+.ofh-footer__social-link {
+  border-radius: 10000px;
+  display: inline-flex;
+  line-height: 0;
+  position: relative;
+  text-decoration: none;
+
+  &:focus {
+    outline: $ofh-stroke-weight-4 solid $ofh-color-border-feedback-focus;
+    outline-offset: $ofh-stroke-weight-4;
+  }
+
+  &:hover {
+    .ofh-footer__social-icon--default {
+      display: none;
+    }
+
+    .ofh-footer__social-icon--hover {
+      display: inline-flex;
+    }
+  }
+}
+
+.ofh-footer__social-icon {
+  display: inline-flex;
+}
+
+.ofh-footer__social-icon--hover {
+  display: none;
+}
+
+.ofh-footer__social-icon-svg {
+  display: block;
 }

--- a/packages/toolkit/components/footer/_footer.scss
+++ b/packages/toolkit/components/footer/_footer.scss
@@ -38,6 +38,7 @@
 }
 
 .ofh-footer__links {
+  align-items: center;
   display: flex;
   flex-wrap: wrap;
   row-gap: $ofh-size-16;
@@ -45,13 +46,20 @@
   @include ofh-responsive-gap-x(32);
 }
 
-.ofh-footer__link {
-  @include ofh-typography-responsive('paragraph-sm');
-
+.ofh-footer__link-component {
   align-items: center;
+  display: flex;
+  margin-bottom: 0;
+}
+
+.ofh-footer__links-item {
+  align-items: center;
+  display: flex;
+  margin-bottom: 0;
+}
+
+.ofh-footer__link-component .ofh-link-icon__link {
   color: $ofh-color-foreground-brand-blue-navy;
-  display: inline-flex;
-  gap: $ofh-size-4;
   text-decoration: underline;
 
   &:visited {
@@ -64,15 +72,9 @@
   }
 
   &:focus {
-    outline: $ofh-stroke-weight-4 solid $ofh-color-border-feedback-focus;
-    outline-offset: $ofh-stroke-weight-4;
+    color: $ofh-color-foreground-link-active;
     text-decoration: none;
   }
-}
-
-.ofh-footer__link-icon {
-  color: currentColor;
-  flex: 0 0 auto;
 }
 
 .ofh-footer__small-print,
@@ -92,7 +94,6 @@
 .ofh-footer__social-inner {
   align-items: center;
   display: flex;
-  flex-wrap: wrap;
   gap: $ofh-size-16;
 }
 
@@ -108,12 +109,18 @@
 }
 
 .ofh-footer__social-list {
+  align-items: center;
   display: flex;
-  flex-wrap: wrap;
   gap: $ofh-size-16;
 }
 
+.ofh-footer__social-item {
+  display: flex;
+  margin-bottom: 0;
+}
+
 .ofh-footer__social-link {
+  align-items: center;
   border-radius: 10000px;
   display: inline-flex;
   line-height: 0;

--- a/packages/toolkit/components/footer/template.njk
+++ b/packages/toolkit/components/footer/template.njk
@@ -1,16 +1,27 @@
 {% from '../icon/macro.njk' import icon %}
+{% from '../link-icon/macro.njk' import linkIcon %}
 
 {%- macro _footerLink(item) -%}
   {% set href = item.url if item.url else item.URL %}
-  <a class="ofh-footer__link"
-    href="{{ href if href else '#' }}"
-    {%- if item.openInNewWindow %} target="_blank" rel="noopener noreferrer"{% endif %}
-    {%- if item.attributes %}{% for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}{% endif %}>
-    <span class="ofh-footer__link-text">{{ item.label }}</span>
-    {%- if item.external %}
-      {{ icon({ "name": "Launch", "size": 16, "classes": "ofh-footer__link-icon" }) }}
-    {%- endif %}
-  </a>
+  {% set usesCustomLinkIconDisplay = item.iconPosition is defined or item.iconName is defined or item.iconLeftName is defined or item.iconRightName is defined or item.showIconLeft is defined or item.showIconRight is defined %}
+  {% set resolvedIconPosition = item.iconPosition if item.iconPosition else ('right' if item.external else 'left') %}
+  {% set resolvedShowIconLeft = item.showIconLeft if item.showIconLeft is defined else (true if usesCustomLinkIconDisplay and resolvedIconPosition == 'left' else false) %}
+  {% set resolvedShowIconRight = item.showIconRight if item.showIconRight is defined else (true if usesCustomLinkIconDisplay and resolvedIconPosition == 'right' else (true if item.external else false)) %}
+  {{ linkIcon({
+    "href": href if href else '#',
+    "text": item.label,
+    "iconColor": item.iconColor,
+    "iconName": item.iconName,
+    "iconPosition": resolvedIconPosition,
+    "iconLeftName": item.iconLeftName,
+    "iconRightName": item.iconRightName,
+    "showIconLeft": resolvedShowIconLeft,
+    "showIconRight": resolvedShowIconRight,
+    "size": item.size if item.size else 'small',
+    "openInNewWindow": true if item.openInNewWindow else false,
+    "classes": "ofh-footer__link-component",
+    "attributes": item.attributes
+  }) }}
 {%- endmacro -%}
 
 {%- macro _socialIcon(item, platform) -%}
@@ -19,8 +30,8 @@
   {% set label = item.label if item.label else platform %}
 
   {%- if platform == 'linkedin' -%}
-    {% set iconName = 'LinkedIn' %}
-    {% set hoverIconName = 'LinkedInHover' %}
+    {% set iconName = 'Linkedin' %}
+    {% set hoverIconName = 'LinkedinHover' %}
     {% set label = item.label if item.label else 'LinkedIn' %}
   {%- elif platform == 'x' -%}
     {% set iconName = 'X' %}
@@ -58,7 +69,13 @@
   </a>
 {%- endmacro -%}
 
-{% set smallPrint = params.smallPrint if params.smallPrint else (params.copyright if params.copyright else '&copy; Crown copyright') %}
+{% if params.smallPrint is defined %}
+  {% set smallPrint = params.smallPrint %}
+{% elif params.copyright is defined %}
+  {% set smallPrint = params.copyright %}
+{% else %}
+  {% set smallPrint = '&copy; Crown copyright' %}
+{% endif %}
 {% set socialLabel = params.socialLabel if params.socialLabel else 'Follow us' %}
 
 <footer role="contentinfo">
@@ -67,17 +84,21 @@
     <div class="ofh-footer__main">
       <div class="ofh-width-container">
         <div class="ofh-footer__main-inner">
-          <div class="ofh-footer__meta">
-            {% if params.links %}
-              <h2 class="ofh-u-visually-hidden">Support links</h2>
-              <ul class="ofh-footer__links">
-                {%- for item in params.links %}
-                  <li class="ofh-footer__links-item">{{ _footerLink(item) | trim }}</li>
-                {%- endfor %}
-              </ul>
-            {% endif %}
-            <p class="ofh-footer__small-print">{{ smallPrint | safe }}</p>
-          </div>
+          {% if params.links or smallPrint %}
+            <div class="ofh-footer__meta">
+              {% if params.links %}
+                <h2 class="ofh-u-visually-hidden">Support links</h2>
+                <ul class="ofh-footer__links">
+                  {%- for item in params.links %}
+                    <li class="ofh-footer__links-item">{{ _footerLink(item) | trim }}</li>
+                  {%- endfor %}
+                </ul>
+              {% endif %}
+              {% if smallPrint %}
+                <p class="ofh-footer__small-print">{{ smallPrint | safe }}</p>
+              {% endif %}
+            </div>
+          {% endif %}
           {% if params.legalHtml or params.legalText %}
             <p class="ofh-footer__legal">{{ params.legalHtml | safe if params.legalHtml else params.legalText }}</p>
           {% endif %}

--- a/packages/toolkit/components/footer/template.njk
+++ b/packages/toolkit/components/footer/template.njk
@@ -1,5 +1,6 @@
 {% from '../icon/macro.njk' import icon %}
 {% from '../link-icon/macro.njk' import linkIcon %}
+{% set supportedSocialPlatforms = ['linkedin', 'x', 'facebook', 'youtube', 'instagram', 'tiktok'] %}
 
 {%- macro _footerLink(item) -%}
   {% set href = item.url if item.url else item.URL %}
@@ -114,7 +115,9 @@
             <ul class="ofh-footer__social-list">
               {%- for item in params.socialLinks %}
                 {% set platform = item.platform | lower %}
-                <li class="ofh-footer__social-item">{{ _socialIcon(item, platform) | trim }}</li>
+                {%- if platform in supportedSocialPlatforms %}
+                  <li class="ofh-footer__social-item">{{ _socialIcon(item, platform) | trim }}</li>
+                {%- endif %}
               {%- endfor %}
             </ul>
           </div>

--- a/packages/toolkit/components/footer/template.njk
+++ b/packages/toolkit/components/footer/template.njk
@@ -1,17 +1,104 @@
+{% from '../icon/macro.njk' import icon %}
+
+{%- macro _footerLink(item) -%}
+  {% set href = item.url if item.url else item.URL %}
+  <a class="ofh-footer__link"
+    href="{{ href if href else '#' }}"
+    {%- if item.openInNewWindow %} target="_blank" rel="noopener noreferrer"{% endif %}
+    {%- if item.attributes %}{% for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}{% endif %}>
+    <span class="ofh-footer__link-text">{{ item.label }}</span>
+    {%- if item.external %}
+      {{ icon({ "name": "Launch", "size": 16, "classes": "ofh-footer__link-icon" }) }}
+    {%- endif %}
+  </a>
+{%- endmacro -%}
+
+{%- macro _socialIcon(item, platform) -%}
+  {% set iconName = '' %}
+  {% set hoverIconName = '' %}
+  {% set label = item.label if item.label else platform %}
+
+  {%- if platform == 'linkedin' -%}
+    {% set iconName = 'LinkedIn' %}
+    {% set hoverIconName = 'LinkedInHover' %}
+    {% set label = item.label if item.label else 'LinkedIn' %}
+  {%- elif platform == 'x' -%}
+    {% set iconName = 'X' %}
+    {% set hoverIconName = 'XHover' %}
+    {% set label = item.label if item.label else 'X' %}
+  {%- elif platform == 'facebook' -%}
+    {% set iconName = 'Facebook' %}
+    {% set hoverIconName = 'FacebookHover' %}
+    {% set label = item.label if item.label else 'Facebook' %}
+  {%- elif platform == 'youtube' -%}
+    {% set iconName = 'Youtube' %}
+    {% set hoverIconName = 'YoutubeHover' %}
+    {% set label = item.label if item.label else 'YouTube' %}
+  {%- elif platform == 'instagram' -%}
+    {% set iconName = 'Instagram' %}
+    {% set hoverIconName = 'InstagramHover' %}
+    {% set label = item.label if item.label else 'Instagram' %}
+  {%- elif platform == 'tiktok' -%}
+    {% set iconName = 'Tiktok' %}
+    {% set hoverIconName = 'TiktokHover' %}
+    {% set label = item.label if item.label else 'TikTok' %}
+  {%- endif -%}
+
+  <a class="ofh-footer__social-link"
+    href="{{ item.href if item.href else '#' }}"
+    {%- if item.openInNewWindow %} target="_blank" rel="noopener noreferrer"{% endif %}
+    {%- if item.attributes %}{% for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}{% endif %}>
+    <span class="ofh-footer__social-icon ofh-footer__social-icon--default" aria-hidden="true">
+      {{ icon({ "name": iconName, "size": 32, "classes": "ofh-footer__social-icon-svg" }) }}
+    </span>
+    <span class="ofh-footer__social-icon ofh-footer__social-icon--hover" aria-hidden="true">
+      {{ icon({ "name": hoverIconName, "size": 32, "classes": "ofh-footer__social-icon-svg" }) }}
+    </span>
+    <span class="ofh-u-visually-hidden">{{ label }}</span>
+  </a>
+{%- endmacro -%}
+
+{% set smallPrint = params.smallPrint if params.smallPrint else (params.copyright if params.copyright else '&copy; Crown copyright') %}
+{% set socialLabel = params.socialLabel if params.socialLabel else 'Follow us' %}
+
 <footer role="contentinfo">
-  <div class="ofh-footer
-    {%- if params.classes %} {{ params.classes }}{% endif %}" id="ofh-footer"
+  <div class="ofh-footer{%- if params.classes %} {{ params.classes }}{% endif %}" id="ofh-footer"
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
-    <div class="ofh-width-container">
-      {%- if params.links %}
-      <h2 class="ofh-u-visually-hidden">Support links</h2>
-      <ul class="ofh-footer__list">
-        {%- for item in params.links %}
-        <li class="ofh-footer__list-item"><a class="ofh-footer__list-item-link" href="{{ item.URL }}">{{ item.label }}</a></li>
-        {%- endfor %}
-      </ul>
-      {% endif %}
-      <p class="ofh-footer__copyright">{% if params.copyright %}{{ params.copyright | safe }}{% else %}&copy; Crown copyright{% endif %}</p>
+    <div class="ofh-footer__main">
+      <div class="ofh-width-container">
+        <div class="ofh-footer__main-inner">
+          <div class="ofh-footer__meta">
+            {% if params.links %}
+              <h2 class="ofh-u-visually-hidden">Support links</h2>
+              <ul class="ofh-footer__links">
+                {%- for item in params.links %}
+                  <li class="ofh-footer__links-item">{{ _footerLink(item) | trim }}</li>
+                {%- endfor %}
+              </ul>
+            {% endif %}
+            <p class="ofh-footer__small-print">{{ smallPrint | safe }}</p>
+          </div>
+          {% if params.legalHtml or params.legalText %}
+            <p class="ofh-footer__legal">{{ params.legalHtml | safe if params.legalHtml else params.legalText }}</p>
+          {% endif %}
+        </div>
+      </div>
     </div>
+
+    {% if params.socialLinks %}
+      <div class="ofh-footer__social">
+        <div class="ofh-width-container">
+          <div class="ofh-footer__social-inner">
+            <p class="ofh-footer__social-title">{{ socialLabel }}</p>
+            <ul class="ofh-footer__social-list">
+              {%- for item in params.socialLinks %}
+                {% set platform = item.platform | lower %}
+                <li class="ofh-footer__social-item">{{ _socialIcon(item, platform) | trim }}</li>
+              {%- endfor %}
+            </ul>
+          </div>
+        </div>
+      </div>
+    {% endif %}
   </div>
 </footer>

--- a/packages/toolkit/components/link-icon/_link-icon.scss
+++ b/packages/toolkit/components/link-icon/_link-icon.scss
@@ -1,14 +1,12 @@
 /* ==========================================================================
-   COMPONENTS/ #LINK-ICON
+   COMPONENTS / #LINK-ICON
    ========================================================================== */
 
-.ofh-link-icon,
-.ofh-back-link {
+.ofh-link-icon {
   @include ofh-responsive-margin(16, 'bottom');
 }
 
-.ofh-link-icon__link,
-.ofh-back-link__link {
+.ofh-link-icon__link {
   @include ofh-typography-responsive('paragraph-sm');
 
   align-items: center;
@@ -38,8 +36,7 @@
   white-space: normal;
 }
 
-.ofh-link-icon__icon,
-.ofh-back-link__icon {
+.ofh-link-icon__icon {
   color: currentColor;
   flex: none;
 }
@@ -67,8 +64,7 @@
 }
 
 @include mq($media-type: print) {
-  .ofh-link-icon__link,
-  .ofh-back-link__link {
+  .ofh-link-icon__link {
     color: $ofh-color-foreground-primary;
 
     &:visited {

--- a/packages/toolkit/components/link-icon/template.njk
+++ b/packages/toolkit/components/link-icon/template.njk
@@ -1,9 +1,12 @@
 {% from '../icon/macro.njk' import icon %}
 
-{% set iconPosition = params.iconPosition if params.iconPosition else 'left' %}
-{% set iconName = params.iconName if params.iconName else ('Launch' if iconPosition == 'right' else 'ChevronLeft') %}
-{% set iconColor = params.iconColor if params.iconColor else '' %}
 {% set size = params.size if params.size else 'small' %}
+{% set iconPosition = params.iconPosition if params.iconPosition else 'left' %}
+{% set showIconLeft = params.showIconLeft if params.showIconLeft is defined else (iconPosition == 'left') %}
+{% set showIconRight = params.showIconRight if params.showIconRight is defined else (iconPosition == 'right') %}
+{% set leftIconName = params.iconLeftName if params.iconLeftName else (params.iconName if params.iconName and iconPosition == 'left' else 'ChevronLeft') %}
+{% set rightIconName = params.iconRightName if params.iconRightName else (params.iconName if params.iconName and iconPosition == 'right' else 'Launch') %}
+{% set iconColor = params.iconColor if params.iconColor else '' %}
 {% set iconSize = 24 if size == 'medium' else 16 %}
 {% set textContent = params.html if params.html else (params.text if params.text else '') %}
 
@@ -12,12 +15,12 @@
     href="{% if params.href %}{{ params.href }}{% else %}#{% endif %}"
     {%- if params.openInNewWindow %} target="_blank" rel="noopener noreferrer"{% endif %}
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
-    {%- if iconPosition == 'left' %}
-      {{ icon({ "name": iconName, "size": iconSize, "color": iconColor, "classes": "ofh-link-icon__icon" }) }}
+    {%- if showIconLeft %}
+      {{ icon({ "name": leftIconName, "size": iconSize, "color": iconColor, "classes": "ofh-link-icon__icon" }) }}
     {%- endif %}
     <span class="ofh-link-icon__text">{{ params.html | safe if params.html else textContent }}</span>
-    {%- if iconPosition == 'right' %}
-      {{ icon({ "name": iconName, "size": iconSize, "color": iconColor, "classes": "ofh-link-icon__icon" }) }}
+    {%- if showIconRight %}
+      {{ icon({ "name": rightIconName, "size": iconSize, "color": iconColor, "classes": "ofh-link-icon__icon" }) }}
     {%- endif %}
   </a>
 </div>

--- a/packages/toolkit/components/link-icon/template.njk
+++ b/packages/toolkit/components/link-icon/template.njk
@@ -9,12 +9,13 @@
 {% set iconColor = params.iconColor if params.iconColor else '' %}
 {% set iconSize = 24 if size == 'medium' else 16 %}
 {% set textContent = params.html if params.html else (params.text if params.text else '') %}
+{% set reservedAttributes = ['href', 'target', 'rel', 'class'] %}
 
 <div class="ofh-link-icon ofh-link-icon--{{ size }} ofh-link-icon--icon-{{ iconPosition }}{%- if params.classes %} {{ params.classes }}{% endif %}">
   <a class="ofh-link-icon__link"
     href="{% if params.href %}{{ params.href }}{% else %}#{% endif %}"
     {%- if params.openInNewWindow %} target="_blank" rel="noopener noreferrer"{% endif %}
-    {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+    {%- for attribute, value in params.attributes %}{% if attribute not in reservedAttributes %} {{ attribute }}="{{ value }}"{% endif %}{% endfor %}>
     {%- if showIconLeft %}
       {{ icon({ "name": leftIconName, "size": iconSize, "color": iconColor, "classes": "ofh-link-icon__icon" }) }}
     {%- endif %}

--- a/packages/toolkit/ofh.scss
+++ b/packages/toolkit/ofh.scss
@@ -27,6 +27,7 @@
 @import 'components/inset-text/inset-text';
 @import 'components/link-icon/link-icon';
 @import 'components/label/label';
+@import 'components/link-icon/link-icon';
 @import 'components/pagination/pagination';
 @import 'components/radios/radios';
 @import 'components/select/select';

--- a/packages/toolkit/ofh.scss
+++ b/packages/toolkit/ofh.scss
@@ -27,7 +27,6 @@
 @import 'components/inset-text/inset-text';
 @import 'components/link-icon/link-icon';
 @import 'components/label/label';
-@import 'components/link-icon/link-icon';
 @import 'components/pagination/pagination';
 @import 'components/radios/radios';
 @import 'components/select/select';

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/toolkit",
-  "version": "4.12.1",
+  "version": "4.13.0",
   "description": "Our Future Health design system toolkit contains the code you need to start building user interfaces for Our Future Health websites and services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
This PR delivers **DSE-337 footer refresh** across toolkit, React, the docs site, and Storybook.

It aligns the footer with the current Figma structure and responsive behaviour, replaces bespoke footer support-link markup with the shared `LinkIcon` composition, and brings the docs and Storybook examples into clearer parity for review and consumer usage. It also adds Storybook theme switching so theme-sensitive footer behaviour can be reviewed properly, and fixes the footer accent border to follow theme tokens in both Participant and Research.

Ticket: DSE-337

## Release scope
- `@ourfuturehealth/toolkit` -> `4.13.0`
- `@ourfuturehealth/react-components` -> `0.12.0`
- updates release metadata in `CHANGELOG.md`, `UPGRADING.md`, `docs/release-versioning-strategy.md`, `docs/consuming-react-components.md`, and `packages/react-components/README.md`
- carries forward the corrected `react-v0.8.0` / `react-v0.9.0` release history so the docs stay consistent after rebasing onto current `main`

## Breaking Changes
- None.

## Key Changes
- refreshes the toolkit footer structure, social row alignment, and responsive spacing to match the current Figma component more closely
- composes footer support links from the shared `LinkIcon` component in both toolkit and React instead of maintaining footer-specific link implementations
- adds and aligns docs/Storybook coverage for `Minimal`, `SupportLinksWithIcons`, and `LegalAndSocialOnly`
- simplifies footer Storybook stories so the non-builder variants use curated, demo-friendly controls instead of raw nested object controls
- adds a Storybook toolbar switch for `Participant` and `Research` themes so theme-sensitive component behaviour can be validated during review
- fixes the footer top accent border to use the theme accent token rather than a hardcoded participant yellow
- preserves caller `rel` tokens for new-window footer links while still adding `noopener noreferrer`
- guards unsupported toolkit social-link platforms and filters reserved attributes in shared `link-icon` rendering
- allows footer small print to be explicitly hidden while preserving the existing default when omitted

## Validation
- `npm test`
- `pnpm lint`
- `pnpm build`
- `pnpm docs:release-contract`
- `pnpm smoke:release-artifacts`
- `pnpm --filter=@ourfuturehealth/react-components build:storybook`
- `pnpm --filter=site build:eleventy`
- manual QA on docs footer examples
- manual QA on Storybook footer stories
- responsive checks at `1200px`, `768px`, and `500px`
- theme checks in both `Participant` and `Research`

## Reviewer Focus
- footer support links now flow through the shared `LinkIcon` composition in both toolkit and React
- docs site and Storybook should now teach the same footer variants and icon-link behaviour
- Storybook theme switching and the footer top accent border should now behave correctly in both Participant and Research
- release metadata should line up on `toolkit-v4.13.0` / `react-v0.12.0`
