### PR TITLE
DSE-336 :: Pagination update FE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ### 2026-04-20
 
+#### @ourfuturehealth/toolkit 4.14.0 (`toolkit-v4.14.0`)
+
+##### Changed
+
+- Refreshed the toolkit `pagination` component to the current design-system treatment, including 4px arrow spacing, the boxed focus style, and state coloring that keeps the title and arrow in the brand color while the page label carries the link-state change
+- Changed pagination links to hug their content instead of owning 50% click zones, while keeping the existing responsive outer margin pending broader design confirmation
+- Expanded the pagination docs page and examples to cover default, previous-only, and next-only sequence edges
+
+#### @ourfuturehealth/react-components 0.13.0 (`react-v0.13.0`)
+
+##### Added
+
+- First public React `Pagination` component with toolkit-parity previous/next link structure and support for previous-only and next-only variants
+- Storybook coverage and unit/accessibility tests for the React pagination component
+
+##### Changed
+
+- Aligned the React pagination arrows, focus treatment, and state coloring with the refreshed toolkit component and current design spec
+
 #### @ourfuturehealth/toolkit 4.13.0 (`toolkit-v4.13.0`)
 
 ##### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ## Monorepo Package Releases (`toolkit-v*`, `react-v*`)
 
-### 2026-04-20
+### 2026-04-28
 
 #### @ourfuturehealth/toolkit 4.14.0 (`toolkit-v4.14.0`)
 
@@ -26,6 +26,8 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 ##### Changed
 
 - Aligned the React pagination arrows, focus treatment, and state coloring with the refreshed toolkit component and current design spec
+
+### 2026-04-20
 
 #### @ourfuturehealth/toolkit 4.13.0 (`toolkit-v4.13.0`)
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,6 +8,7 @@ This guide provides detailed migration instructions for upgrading between versio
 
 | Version                                                 | Date          | Breaking Changes      | Migration Complexity                  |
 | ------------------------------------------------------- | ------------- | --------------------- | ------------------------------------- |
+| [v4.14.0 / React v0.13.0](#upgrading-to-v4140--react-v0130) | April 2026    | No breaking changes | 🟢 Low - adopt the public React pagination if needed |
 | [v4.13.0 / React v0.12.0](#upgrading-to-v4130--react-v0120) | April 2026    | No breaking changes | 🟢 Low - adopt the public React footer if needed |
 | [v4.12.0 / React v0.11.0](#upgrading-to-v4120--react-v0110) | April 2026    | No breaking changes | 🟢 Low - adopt the public React summary list if needed |
 | [v4.11.0 / React v0.10.0](#upgrading-to-v4110--react-v0100) | April 2026    | No breaking changes | 🟢 Low - adopt the public React details family if needed |
@@ -21,6 +22,64 @@ This guide provides detailed migration instructions for upgrading between versio
 | [v4.3.0 / React v0.2.0](#upgrading-to-v430--react-v020) | March 2026    | Button variant naming      | 🟡 Medium - Find/replace required        |
 | [v4.1.0](#upgrading-to-v410)                            | February 2026 | Spacing scale indices      | 🟡 Medium - Index updates required       |
 | [v4.0.0](#upgrading-to-v400-monorepo-restructure)       | 2025          | Monorepo restructure       | 🔴 High - Installation & paths change    |
+
+---
+
+## Upgrading to v4.14.0 / React v0.13.0
+
+**Released:** April 2026
+**Affected packages:**
+
+- `@ourfuturehealth/toolkit` v4.14.0+
+- `@ourfuturehealth/react-components` v0.13.0+
+
+### Breaking Changes
+
+None.
+
+### Release Overview
+
+This release refreshes the toolkit `pagination` component to the current design-system treatment and introduces the first public React `Pagination` component.
+
+- Toolkit consumers now get boxed pagination focus states, corrected state coloring, and content-hugging previous/next hit areas instead of 50/50 click zones.
+- Toolkit docs now show the start and end of a sequence explicitly through `previous-only` and `next-only` examples.
+- React consumers can now adopt the public `Pagination` component instead of carrying local previous/next page navigation markup.
+
+### Migration Steps
+
+1. Adopt the public React `Pagination` component where you need toolkit-parity previous/next page navigation in React.
+2. Re-run visual QA if you have local pagination overrides, because the link hit area now hugs the content instead of filling half of the row.
+3. For sequence endpoints, omit the unavailable side rather than rendering placeholder markup.
+
+#### React example
+
+**New in `react-v0.13.0`:**
+
+```tsx
+import { Pagination } from '@ourfuturehealth/react-components';
+```
+
+#### Toolkit example
+
+**Before:**
+
+```njk
+<nav class="app-pagination" aria-label="Pagination">
+  <a href="/previous">Previous page</a>
+  <a href="/next">Next page</a>
+</nav>
+```
+
+**After (`toolkit-v4.14.0`):**
+
+```njk
+{{ pagination({
+  "previousUrl": "/section/treatments",
+  "previousPage": "Treatments",
+  "nextUrl": "/section/symptoms",
+  "nextPage": "Symptoms"
+}) }}
+```
 
 ---
 

--- a/docs/consuming-react-components.md
+++ b/docs/consuming-react-components.md
@@ -57,7 +57,7 @@ Import components and styles in your React application:
 
 ```tsx
 import React from 'react';
-import { Button, TextInput } from '@ourfuturehealth/react-components';
+import { Button, Pagination, TextInput } from '@ourfuturehealth/react-components';
 import '@ourfuturehealth/react-components/styles/participant';
 
 function App() {
@@ -69,6 +69,12 @@ function App() {
         hint="Enter your full name"
         inputWidth={20}
         onChange={(e) => console.log(e.target.value)}
+      />
+      <Pagination
+        previousUrl="/section/treatments"
+        previousPage="Treatments"
+        nextUrl="/section/symptoms"
+        nextPage="Symptoms"
       />
       <Button onClick={() => console.log('Clicked')}>Submit</Button>
     </div>
@@ -139,6 +145,7 @@ The React components package currently provides the following components:
 - `Card` - Content presentation cards for summaries, status, and next steps
 - `CardCallout` - Feedback-style callout cards for informational, warning, success, and error messages
 - `CardDoDont` - Positive and negative recommendation lists
+- `Pagination` - Previous/next page navigation for a small related sequence
 
 For complete component documentation and live examples, run Storybook locally from this repository:
 

--- a/docs/release-versioning-strategy.md
+++ b/docs/release-versioning-strategy.md
@@ -31,8 +31,8 @@ For consumer migration instructions, use [Upgrading Guide](../UPGRADING.md).
 
 | Package                             | Canonical tag pattern | Example tag      |
 | ----------------------------------- | --------------------- | ---------------- |
-| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.13.0` |
-| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.12.0`   |
+| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.14.0` |
+| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.13.0`   |
 
 The release workflow still accepts legacy toolkit tags in the `v*` format for backward compatibility, but new toolkit releases should use `toolkit-v*`.
 
@@ -60,7 +60,7 @@ Consumers must install the package release tarball:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/toolkit": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/toolkit-v4.13.0/ourfuturehealth-toolkit-4.13.0.tgz"
+    "@ourfuturehealth/toolkit": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/toolkit-v4.14.0/ourfuturehealth-toolkit-4.14.0.tgz"
   }
 }
 ```
@@ -70,7 +70,7 @@ React consumers follow the same contract:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.12.0/ourfuturehealth-react-components-0.12.0.tgz"
+    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.13.0/ourfuturehealth-react-components-0.13.0.tgz"
   }
 }
 ```
@@ -137,6 +137,8 @@ This table is a visual aid for pre-monorepo versus post-monorepo releases.
 | 28    | `react-v0.11.0`   | N/A            | `0.11.0`      | Monorepo       | Released               |
 | 29    | `toolkit-v4.13.0` | `4.13.0`       | N/A           | Monorepo       | Released               |
 | 30    | `react-v0.12.0`   | N/A            | `0.12.0`      | Monorepo       | Released               |
+| 31    | `toolkit-v4.14.0` | `4.14.0`       | N/A           | Monorepo       | Released               |
+| 32    | `react-v0.13.0`   | N/A            | `0.13.0`      | Monorepo       | Released               |
 
 ## References
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -9,7 +9,7 @@ Install the packaged GitHub release artifact:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.12.0/ourfuturehealth-react-components-0.12.0.tgz",
+    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.13.0/ourfuturehealth-react-components-0.13.0.tgz",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   }
@@ -55,6 +55,7 @@ import {
   Fieldset,
   Footer,
   Icon,
+  Pagination,
   LinkAction,
   LinkIcon,
   LinkSkip,
@@ -118,6 +119,12 @@ function App() {
       <SummaryList rows={summaryRows} />
       <Tag variant="brand">Beta</Tag>
       <Button variant="contained">Click me</Button>
+      <Pagination
+        previousUrl="/section/treatments"
+        previousPage="Treatments"
+        nextUrl="/section/symptoms"
+        nextPage="Symptoms"
+      />
       <Icon name="Search" size={24} />
       <LinkAction href="/services/minor-injuries">Find a minor injuries unit</LinkAction>
       <LinkIcon href="/previous-step">Go back</LinkIcon>
@@ -232,6 +239,7 @@ The package also provides:
 - `Checkboxes`
 - `Radios`
 - `Icon`
+- `Pagination`
 - `SummaryList`
 
 ### ErrorSummary

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/react-components",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "description": "React component library for OFH Design System",
   "packageManager": "pnpm@10.29.2",

--- a/packages/react-components/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/react-components/src/components/Pagination/Pagination.stories.tsx
@@ -1,5 +1,32 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import { Pagination, type PaginationProps } from './Pagination';
+
+const defaultPaginationSource = `import { Pagination } from '@ourfuturehealth/react-components';
+
+<Pagination
+  previousUrl="/section/treatments"
+  previousPage="Treatments"
+  nextUrl="/section/symptoms"
+  nextPage="Symptoms"
+/>;
+`;
+
+const previousOnlyPaginationSource = `import { Pagination } from '@ourfuturehealth/react-components';
+
+<Pagination
+  previousUrl="/section/treatments"
+  previousPage="Treatments"
+/>;
+`;
+
+const nextOnlyPaginationSource = `import { Pagination } from '@ourfuturehealth/react-components';
+
+<Pagination
+  nextUrl="/section/symptoms"
+  nextPage="Symptoms"
+/>;
+`;
 
 const meta: Meta<PaginationProps> = {
   title: 'Components/Pagination',
@@ -9,8 +36,32 @@ const meta: Meta<PaginationProps> = {
     docs: {
       description: {
         component:
-          'Pagination shows previous and next page links for a small set of related pages. The toolkit styling keeps the page title and action text on separate lines, uses the shared React `Icon` base for the arrows, and applies the 4px focus outline gap from the design spec.',
+          'Pagination shows previous and next page links for a small set of related pages. Pass `previousUrl` and `previousPage` for the previous link, `nextUrl` and `nextPage` for the next link, and leave either pair out when you only need one side. The toolkit styling keeps the page title and action text on separate lines, uses the shared React `Icon` base for the arrows, and applies the 4px focus outline gap from the design spec.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Pagination is a very small API. Give it the previous and next page
+            label plus URL pairs, or provide just one side when you only need a
+            previous-only or next-only navigation pattern.
+          </p>
+
+          <h2>Component props</h2>
+          <ArgTypes of={Pagination} />
+
+          <h2>Examples</h2>
+          <Stories />
+
+          <h2>Example source</h2>
+          <Source code={defaultPaginationSource} language="tsx" />
+          <Source code={previousOnlyPaginationSource} language="tsx" />
+          <Source code={nextOnlyPaginationSource} language="tsx" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],
@@ -65,14 +116,57 @@ const meta: Meta<PaginationProps> = {
 export default meta;
 type Story = StoryObj<PaginationProps>;
 
-export const Default: Story = {};
+export const Builder: Story = {
+  parameters: {
+    controls: {
+      include: ['previousUrl', 'previousPage', 'nextUrl', 'nextPage'],
+    },
+  },
+};
+
+export const Default: Story = {
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      source: {
+        code: defaultPaginationSource,
+      },
+      description: {
+        story:
+          'A realistic default pagination example with both previous and next links visible.',
+      },
+    },
+  },
+};
 
 export const PreviousOnly: Story = {
   render: () => (
     <Pagination previousUrl="/section/treatments" previousPage="Treatments" />
   ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      source: {
+        code: previousOnlyPaginationSource,
+      },
+    },
+  },
 };
 
 export const NextOnly: Story = {
   render: () => <Pagination nextUrl="/section/symptoms" nextPage="Symptoms" />,
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      source: {
+        code: nextOnlyPaginationSource,
+      },
+    },
+  },
 };

--- a/packages/react-components/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/react-components/src/components/Pagination/Pagination.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Pagination, type PaginationProps } from './Pagination';
+
+const meta: Meta<PaginationProps> = {
+  title: 'Components/Pagination',
+  component: Pagination,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Pagination shows previous and next page links for a small set of related pages. The toolkit styling keeps the page title and action text on separate lines, uses the shared React `Icon` base for the arrows, and applies the 4px focus outline gap from the design spec.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    previousUrl: {
+      control: 'text',
+      description: 'Href for the previous-page link.',
+    },
+    previousPage: {
+      control: 'text',
+      description: 'Label for the previous-page destination.',
+    },
+    nextUrl: {
+      control: 'text',
+      description: 'Href for the next-page link.',
+    },
+    nextPage: {
+      control: 'text',
+      description: 'Label for the next-page destination.',
+    },
+    classes: {
+      control: false,
+      description:
+        'Toolkit-parity alias for extra root classes. Prefer `className` in React-first usage.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+    className: {
+      control: false,
+      description: 'Adds extra classes to the root `<nav>` element.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+    ref: {
+      control: false,
+      description: 'React ref for the root `<nav>` element.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+  },
+  args: {
+    previousUrl: '/section/treatments',
+    previousPage: 'Treatments',
+    nextUrl: '/section/symptoms',
+    nextPage: 'Symptoms',
+  },
+};
+
+export default meta;
+type Story = StoryObj<PaginationProps>;
+
+export const Default: Story = {};
+
+export const PreviousOnly: Story = {
+  render: () => (
+    <Pagination previousUrl="/section/treatments" previousPage="Treatments" />
+  ),
+};
+
+export const NextOnly: Story = {
+  render: () => <Pagination nextUrl="/section/symptoms" nextPage="Symptoms" />,
+};
+
+export const AllVariants: Story = {
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
+  render: () => (
+    <div style={{ display: 'grid', gap: '1.5rem', maxWidth: '32rem' }}>
+      <Pagination
+        previousUrl="/section/treatments"
+        previousPage="Treatments"
+        nextUrl="/section/symptoms"
+        nextPage="Symptoms"
+      />
+      <Pagination previousUrl="/section/treatments" previousPage="Treatments" />
+      <Pagination nextUrl="/section/symptoms" nextPage="Symptoms" />
+    </div>
+  ),
+};

--- a/packages/react-components/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/react-components/src/components/Pagination/Pagination.stories.tsx
@@ -49,6 +49,7 @@ const meta: Meta<PaginationProps> = {
             label plus URL pairs, or provide just one side when you only need a
             previous-only or next-only navigation pattern.
           </p>
+          <Source code={defaultPaginationSource} language="tsx" />
 
           <h2>Component props</h2>
           <ArgTypes of={Pagination} />

--- a/packages/react-components/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/react-components/src/components/Pagination/Pagination.stories.tsx
@@ -76,23 +76,3 @@ export const PreviousOnly: Story = {
 export const NextOnly: Story = {
   render: () => <Pagination nextUrl="/section/symptoms" nextPage="Symptoms" />,
 };
-
-export const AllVariants: Story = {
-  parameters: {
-    controls: {
-      disable: true,
-    },
-  },
-  render: () => (
-    <div style={{ display: 'grid', gap: '1.5rem', maxWidth: '32rem' }}>
-      <Pagination
-        previousUrl="/section/treatments"
-        previousPage="Treatments"
-        nextUrl="/section/symptoms"
-        nextPage="Symptoms"
-      />
-      <Pagination previousUrl="/section/treatments" previousPage="Treatments" />
-      <Pagination nextUrl="/section/symptoms" nextPage="Symptoms" />
-    </div>
-  ),
-};

--- a/packages/react-components/src/components/Pagination/Pagination.test.tsx
+++ b/packages/react-components/src/components/Pagination/Pagination.test.tsx
@@ -1,0 +1,76 @@
+import { createRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import { axe } from 'vitest-axe';
+import { describe, expect, it } from 'vitest';
+import { Pagination } from './Pagination';
+
+describe('Pagination', () => {
+  it('renders both pagination links with the expected labels and icons', () => {
+    const { container } = render(
+      <Pagination
+        previousUrl="/section/treatments"
+        previousPage="Treatments"
+        nextUrl="/section/symptoms"
+        nextPage="Symptoms"
+      />,
+    );
+
+    expect(
+      screen.getByRole('navigation', { name: 'Pagination' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /previous.*treatments/i })).toHaveAttribute(
+      'href',
+      '/section/treatments',
+    );
+    expect(screen.getByRole('link', { name: /next.*symptoms/i })).toHaveAttribute(
+      'href',
+      '/section/symptoms',
+    );
+    expect(container.querySelectorAll('.ofh-icon--West')).toHaveLength(1);
+    expect(container.querySelectorAll('.ofh-icon--East')).toHaveLength(1);
+  });
+
+  it('renders only the previous link when next props are missing', () => {
+    render(<Pagination previousUrl="/section/treatments" previousPage="Treatments" />);
+
+    expect(screen.getByRole('link', { name: /previous.*treatments/i })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /next.*symptoms/i })).toBeNull();
+  });
+
+  it('renders only the next link when previous props are missing', () => {
+    render(<Pagination nextUrl="/section/symptoms" nextPage="Symptoms" />);
+
+    expect(screen.getByRole('link', { name: /next.*symptoms/i })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /previous.*treatments/i })).toBeNull();
+  });
+
+  it('applies custom classes and forwards ref to the nav element', () => {
+    const ref = createRef<HTMLElement>();
+
+    render(
+      <Pagination
+        ref={ref}
+        className="custom-class"
+        previousUrl="/section/treatments"
+        previousPage="Treatments"
+      />,
+    );
+
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+    expect(ref.current).toHaveClass('ofh-pagination', 'custom-class');
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <Pagination
+        previousUrl="/section/treatments"
+        previousPage="Treatments"
+        nextUrl="/section/symptoms"
+        nextPage="Symptoms"
+      />,
+    );
+
+    const results = await axe(container);
+    expect(results.violations).toHaveLength(0);
+  });
+});

--- a/packages/react-components/src/components/Pagination/Pagination.test.tsx
+++ b/packages/react-components/src/components/Pagination/Pagination.test.tsx
@@ -26,8 +26,8 @@ describe('Pagination', () => {
       'href',
       '/section/symptoms',
     );
-    expect(container.querySelectorAll('.ofh-icon--West')).toHaveLength(1);
-    expect(container.querySelectorAll('.ofh-icon--East')).toHaveLength(1);
+    expect(container.querySelectorAll('.ofh-icon--ArrowLeft')).toHaveLength(1);
+    expect(container.querySelectorAll('.ofh-icon--ArrowRight')).toHaveLength(1);
   });
 
   it('renders only the previous link when next props are missing', () => {

--- a/packages/react-components/src/components/Pagination/Pagination.tsx
+++ b/packages/react-components/src/components/Pagination/Pagination.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { joinClasses } from '../../internal/ofhUtils';
+import { Icon } from '../Icon';
+
+export interface PaginationProps
+  extends Omit<React.ComponentPropsWithoutRef<'nav'>, 'children' | 'ref'> {
+  previousUrl?: string;
+  previousPage?: React.ReactNode;
+  nextUrl?: string;
+  nextPage?: React.ReactNode;
+  classes?: string;
+  ref?: React.Ref<HTMLElement>;
+}
+
+type PaginationLinkProps = {
+  direction: 'previous' | 'next';
+  url: string;
+  page: React.ReactNode;
+};
+
+const renderPaginationLink = ({
+  direction,
+  url,
+  page,
+}: PaginationLinkProps) => {
+  const isPrevious = direction === 'previous';
+
+  return (
+    <li
+      className={
+        isPrevious
+          ? 'ofh-pagination-item--previous'
+          : 'ofh-pagination-item--next'
+      }
+    >
+      <a
+        className={joinClasses(
+          'ofh-pagination__link',
+          isPrevious ? 'ofh-pagination__link--prev' : 'ofh-pagination__link--next',
+        )}
+        href={url}
+      >
+        <span className="ofh-pagination__title">
+          {isPrevious ? 'Previous' : 'Next'}
+        </span>
+        <span className="ofh-u-visually-hidden">:</span>
+        <span className="ofh-pagination__page">{page}</span>
+        <Icon
+          name={isPrevious ? 'West' : 'East'}
+          size={32}
+          className="ofh-pagination__icon"
+        />
+      </a>
+    </li>
+  );
+};
+
+export const Pagination = ({
+  previousUrl,
+  previousPage,
+  nextUrl,
+  nextPage,
+  classes = '',
+  className = '',
+  ref,
+  role = 'navigation',
+  ...props
+}: PaginationProps) => {
+  const { 'aria-label': ariaLabel = 'Pagination' } = props;
+
+  return (
+    <nav
+      {...props}
+      ref={ref}
+      role={role}
+      aria-label={ariaLabel}
+      className={joinClasses('ofh-pagination', classes, className)}
+    >
+      <ul className="ofh-list ofh-pagination__list">
+        {previousUrl && previousPage
+          ? renderPaginationLink({
+              direction: 'previous',
+              url: previousUrl,
+              page: previousPage,
+            })
+          : null}
+        {nextUrl && nextPage
+          ? renderPaginationLink({
+              direction: 'next',
+              url: nextUrl,
+              page: nextPage,
+            })
+          : null}
+      </ul>
+    </nav>
+  );
+};
+
+Pagination.displayName = 'Pagination';

--- a/packages/react-components/src/components/Pagination/Pagination.tsx
+++ b/packages/react-components/src/components/Pagination/Pagination.tsx
@@ -46,7 +46,7 @@ const renderPaginationLink = ({
         <span className="ofh-u-visually-hidden">:</span>
         <span className="ofh-pagination__page">{page}</span>
         <Icon
-          name={isPrevious ? 'West' : 'East'}
+          name={isPrevious ? 'ArrowLeft' : 'ArrowRight'}
           size={32}
           className="ofh-pagination__icon"
         />

--- a/packages/react-components/src/components/Pagination/index.ts
+++ b/packages/react-components/src/components/Pagination/index.ts
@@ -1,0 +1,2 @@
+export { Pagination } from './Pagination';
+export type { PaginationProps } from './Pagination';

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -91,6 +91,9 @@ export type { CardCalloutProps } from './components/CardCallout';
 export { CardDoDont } from './components/CardDoDont';
 export type { CardDoDontItem, CardDoDontProps } from './components/CardDoDont';
 
+export { Pagination } from './components/Pagination';
+export type { PaginationProps } from './components/Pagination';
+
 export { Tag } from './components/Tag';
 export type { TagProps, TagVariant } from './components/Tag';
 

--- a/packages/site/tests/fixtures/pagination/default.njk
+++ b/packages/site/tests/fixtures/pagination/default.njk
@@ -1,0 +1,8 @@
+{% from 'pagination/macro.njk' import pagination %}
+
+{{ pagination({
+  "previousUrl": "/section/treatments",
+  "previousPage": "Treatments",
+  "nextUrl": "/section/symptoms",
+  "nextPage": "Symptoms"
+}) }}

--- a/packages/site/tests/fixtures/pagination/next-only.njk
+++ b/packages/site/tests/fixtures/pagination/next-only.njk
@@ -1,0 +1,6 @@
+{% from 'pagination/macro.njk' import pagination %}
+
+{{ pagination({
+  "nextUrl": "/section/symptoms",
+  "nextPage": "Symptoms"
+}) }}

--- a/packages/site/tests/fixtures/pagination/previous-only.njk
+++ b/packages/site/tests/fixtures/pagination/previous-only.njk
@@ -1,0 +1,6 @@
+{% from 'pagination/macro.njk' import pagination %}
+
+{{ pagination({
+  "previousUrl": "/section/treatments",
+  "previousPage": "Treatments"
+}) }}

--- a/packages/site/views/design-system/components/pagination/index.njk
+++ b/packages/site/views/design-system/components/pagination/index.njk
@@ -3,7 +3,7 @@
 {% set subSection = "Components" %}
 {% set pageDescription = "Use pagination to allow users to navigate between related pages, for example about a single condition." %}
 {% set theme = "Navigation" %}
-{% set dateUpdated = "February 2019" %}
+{% set dateUpdated = "April 2026" %}
 {% set backlog_issue_id = "27" %}
 
 {% extends "app-layout.njk" %}
@@ -35,6 +35,21 @@
   <h2>How to use pagination</h2>
   <p>Use a <a href="/design-system/components/contents-list">contents list</a> at the top of the page together with pagination at the bottom of each page.</p>
   <p>Use the word "Previous" with an arrow left and a link to the previous page. Use the word Next" with an arrow right and a link to the next page. Use the same page titles as in the contents list.</p>
+
+  <h3 id="start-and-end-of-a-sequence">Start and end of a sequence</h3>
+  <p>On the first page of a sequence you may only need a next link. On the last page you may only need a previous link.</p>
+
+  {{ designExample({
+    group: "components",
+    item: "pagination",
+    type: "previous-only"
+  }) }}
+
+  {{ designExample({
+    group: "components",
+    item: "pagination",
+    type: "next-only"
+  }) }}
 
   <h3>Accessibility</h3>
   <p class="rich-text">The pagination components are surrounded by a <code>&lt;nav&gt;</code> element to show that they are navigation links. This element has an <code>aria-label</code> attribute with the value <code>Pagination</code>. Screen readers that support this attribute will read this.</p>

--- a/packages/site/views/design-system/components/pagination/index.njk
+++ b/packages/site/views/design-system/components/pagination/index.njk
@@ -34,7 +34,7 @@
 
   <h2>How to use pagination</h2>
   <p>Use a <a href="/design-system/components/contents-list">contents list</a> at the top of the page together with pagination at the bottom of each page.</p>
-  <p>Use the word "Previous" with an arrow left and a link to the previous page. Use the word Next" with an arrow right and a link to the next page. Use the same page titles as in the contents list.</p>
+  <p>Use the word "Previous" with an arrow left and a link to the previous page. Use the word "Next" with an arrow right and a link to the next page. Use the same page titles as in the contents list.</p>
 
   <h3 id="start-and-end-of-a-sequence">Start and end of a sequence</h3>
   <p>On the first page of a sequence you may only need a next link. On the last page you may only need a previous link.</p>

--- a/packages/site/views/design-system/components/pagination/index.njk
+++ b/packages/site/views/design-system/components/pagination/index.njk
@@ -38,8 +38,7 @@
 
   <h3>Accessibility</h3>
   <p class="rich-text">The pagination components are surrounded by a <code>&lt;nav&gt;</code> element to show that they are navigation links. This element has an <code>aria-label</code> attribute with the value <code>Pagination</code>. Screen readers that support this attribute will read this.</p>
-  <p class="rich-text">There is also a visually hidden heading title <code>pagination</code> which will be read by screen readers as a heading to the links. </p>
-  <p class="rich-text">If the link describes the current page that you are on, then it has the <code>aria-current="page"</code> value to indicate to screen readers that this is the case.</p>
+  <p class="rich-text">The page labels are announced directly, so there is no separate visually hidden heading in the component markup.</p>
 
   <h2>Research</h2>
   <p>We tested pagination in grouped information pages in 3 labs in summer 2018. We haven't tested it in forms.</p>

--- a/packages/site/views/design-system/components/pagination/next-only/index.njk
+++ b/packages/site/views/design-system/components/pagination/next-only/index.njk
@@ -1,0 +1,6 @@
+{% from 'pagination/macro.njk' import pagination %}
+
+{{ pagination({
+  "nextUrl": "#",
+  "nextPage": "Symptoms"
+}) }}

--- a/packages/site/views/design-system/components/pagination/previous-only/index.njk
+++ b/packages/site/views/design-system/components/pagination/previous-only/index.njk
@@ -1,0 +1,6 @@
+{% from 'pagination/macro.njk' import pagination %}
+
+{{ pagination({
+  "previousUrl": "#",
+  "previousPage": "Treatments"
+}) }}

--- a/packages/toolkit/components/pagination/README.md
+++ b/packages/toolkit/components/pagination/README.md
@@ -3,6 +3,8 @@
 ## Guidance
 
 > Icon migration: this component now renders icons using `components/icon/macro.njk` and the Material SVG sprite.
+>
+> The pagination link uses a 4px icon gap and a 4px focus outline offset to match the current design spec.
 
 
 Find out more about the pagination component and when to use it in the [design system docs website](https://designsystem.ourfuturehealth.org.uk/design-system/components/pagination).
@@ -23,8 +25,8 @@ Find out more about the pagination component and when to use it in the [design s
         <span class="ofh-pagination__title">Previous</span>
         <span class="ofh-u-visually-hidden">:</span>
         <span class="ofh-pagination__page">Treatments</span>
-        <svg class="ofh-icon ofh-icon__arrow-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M4.1 12.3l2.7 3c.2.2.5.2.7 0 .1-.1.1-.2.1-.3v-2h11c.6 0 1-.4 1-1s-.4-1-1-1h-11V9c0-.2-.1-.4-.3-.5h-.2c-.1 0-.3.1-.4.2l-2.7 3c0 .2 0 .4.1.6z"></path>
+        <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--West ofh-pagination__icon" aria-hidden="true" focusable="false" width="32" height="32">
+          <use href="/assets/icons/icon-sprite.svg#ofh-icon-West"></use>
         </svg>
       </a>
     </li>
@@ -33,8 +35,8 @@ Find out more about the pagination component and when to use it in the [design s
         <span class="ofh-pagination__title">Next</span>
         <span class="ofh-u-visually-hidden">:</span>
         <span class="ofh-pagination__page">Symptoms</span>
-        <svg class="ofh-icon ofh-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
+        <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--East ofh-pagination__icon" aria-hidden="true" focusable="false" width="32" height="32">
+          <use href="/assets/icons/icon-sprite.svg#ofh-icon-East"></use>
         </svg>
       </a>
     </li>
@@ -69,8 +71,8 @@ Find out more about the pagination component and when to use it in the [design s
         <span class="ofh-pagination__title">Next</span>
         <span class="ofh-u-visually-hidden">:</span>
         <span class="ofh-pagination__page">Symptoms</span>
-        <svg class="ofh-icon ofh-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
+        <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--East ofh-pagination__icon" aria-hidden="true" focusable="false" width="32" height="32">
+          <use href="/assets/icons/icon-sprite.svg#ofh-icon-East"></use>
         </svg>
       </a>
     </li>
@@ -104,8 +106,8 @@ Find out more about the pagination component and when to use it in the [design s
         <span class="ofh-pagination__title">Previous</span>
         <span class="ofh-u-visually-hidden">:</span>
         <span class="ofh-pagination__page">Treatments</span>
-        <svg class="ofh-icon ofh-icon__arrow-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M4.1 12.3l2.7 3c.2.2.5.2.7 0 .1-.1.1-.2.1-.3v-2h11c.6 0 1-.4 1-1s-.4-1-1-1h-11V9c0-.2-.1-.4-.3-.5h-.2.1 0-.3.1-.4.2l-2.7 3c0 .2 0 .4.1.6z"></path>
+        <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--West ofh-pagination__icon" aria-hidden="true" focusable="false" width="32" height="32">
+          <use href="/assets/icons/icon-sprite.svg#ofh-icon-West"></use>
         </svg>
       </a>
     </li>

--- a/packages/toolkit/components/pagination/README.md
+++ b/packages/toolkit/components/pagination/README.md
@@ -25,8 +25,8 @@ Find out more about the pagination component and when to use it in the [design s
         <span class="ofh-pagination__title">Previous</span>
         <span class="ofh-u-visually-hidden">:</span>
         <span class="ofh-pagination__page">Treatments</span>
-        <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--West ofh-pagination__icon" aria-hidden="true" focusable="false" width="32" height="32">
-          <use href="/assets/icons/icon-sprite.svg#ofh-icon-West"></use>
+        <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--ArrowLeft ofh-pagination__icon" aria-hidden="true" focusable="false" width="32" height="32">
+          <use href="/assets/icons/icon-sprite.svg#ofh-icon-ArrowLeft"></use>
         </svg>
       </a>
     </li>
@@ -35,8 +35,8 @@ Find out more about the pagination component and when to use it in the [design s
         <span class="ofh-pagination__title">Next</span>
         <span class="ofh-u-visually-hidden">:</span>
         <span class="ofh-pagination__page">Symptoms</span>
-        <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--East ofh-pagination__icon" aria-hidden="true" focusable="false" width="32" height="32">
-          <use href="/assets/icons/icon-sprite.svg#ofh-icon-East"></use>
+        <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--ArrowRight ofh-pagination__icon" aria-hidden="true" focusable="false" width="32" height="32">
+          <use href="/assets/icons/icon-sprite.svg#ofh-icon-ArrowRight"></use>
         </svg>
       </a>
     </li>
@@ -71,8 +71,8 @@ Find out more about the pagination component and when to use it in the [design s
         <span class="ofh-pagination__title">Next</span>
         <span class="ofh-u-visually-hidden">:</span>
         <span class="ofh-pagination__page">Symptoms</span>
-        <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--East ofh-pagination__icon" aria-hidden="true" focusable="false" width="32" height="32">
-          <use href="/assets/icons/icon-sprite.svg#ofh-icon-East"></use>
+        <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--ArrowRight ofh-pagination__icon" aria-hidden="true" focusable="false" width="32" height="32">
+          <use href="/assets/icons/icon-sprite.svg#ofh-icon-ArrowRight"></use>
         </svg>
       </a>
     </li>
@@ -106,8 +106,8 @@ Find out more about the pagination component and when to use it in the [design s
         <span class="ofh-pagination__title">Previous</span>
         <span class="ofh-u-visually-hidden">:</span>
         <span class="ofh-pagination__page">Treatments</span>
-        <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--West ofh-pagination__icon" aria-hidden="true" focusable="false" width="32" height="32">
-          <use href="/assets/icons/icon-sprite.svg#ofh-icon-West"></use>
+        <svg class="ofh-icon ofh-icon--material ofh-icon--32 ofh-icon--ArrowLeft ofh-pagination__icon" aria-hidden="true" focusable="false" width="32" height="32">
+          <use href="/assets/icons/icon-sprite.svg#ofh-icon-ArrowLeft"></use>
         </svg>
       </a>
     </li>

--- a/packages/toolkit/components/pagination/_pagination.scss
+++ b/packages/toolkit/components/pagination/_pagination.scss
@@ -15,13 +15,17 @@
 }
 
 .ofh-pagination__list {
-  @include clearfix();
+  display: flex;
+  width: 100%;
+
+  > li {
+    margin-bottom: 0;
+  }
 }
 
 .ofh-pagination-item--previous {
-  float: left;
+  flex: 0 0 auto;
   text-align: left;
-  width: 50%;
 
   .ofh-icon {
     left: -4px;
@@ -33,9 +37,9 @@
 }
 
 .ofh-pagination-item--next {
-  float: right;
+  flex: 0 0 auto;
+  margin-left: auto;
   text-align: right;
-  width: 50%;
 
   .ofh-icon {
     right: -4px;
@@ -48,10 +52,9 @@
 
 .ofh-pagination__link {
   color: $ofh-color-foreground-brand-blue-navy;
-  display: block;
+  display: inline-block;
   position: relative;
   text-decoration: none;
-  width: 100%;
 
   @include mq($media-type: print) {
     color: $ofh-color-foreground-primary;

--- a/packages/toolkit/components/pagination/_pagination.scss
+++ b/packages/toolkit/components/pagination/_pagination.scss
@@ -51,7 +51,7 @@
 }
 
 .ofh-pagination__link {
-  color: $ofh-color-foreground-brand-blue-navy;
+  color: $ofh-color-foreground-link-default;
   display: inline-block;
   position: relative;
   text-decoration: none;
@@ -61,6 +61,7 @@
   }
 
   .ofh-icon {
+    color: $ofh-color-brand-blue-navy-3-main;
     position: absolute;
     top: 0;
 
@@ -71,8 +72,9 @@
   }
 
   &:hover {
+    color: $ofh-color-foreground-link-hover;
+
     .ofh-pagination__page {
-      color: $ofh-color-foreground-link-hover;
       text-decoration: none;
     }
   }
@@ -80,36 +82,35 @@
   &:focus {
     @include ofh-focused-button;
 
+    color: $ofh-color-foreground-link-active;
+
     .ofh-pagination__page {
-      color: $ofh-color-foreground-link-active;
       text-decoration: none;
     }
   }
 
   &:visited {
-    .ofh-pagination__page {
-      color: $ofh-color-foreground-link-visited;
-    }
+    color: $ofh-color-foreground-link-visited;
 
     &:hover {
+      color: $ofh-color-foreground-link-hover;
+
       .ofh-pagination__page {
-        color: $ofh-color-foreground-link-hover;
         text-decoration: none;
       }
     }
 
     &:focus {
+      color: $ofh-color-foreground-link-active;
+
       .ofh-pagination__page {
-        color: $ofh-color-foreground-link-active;
         text-decoration: none;
       }
     }
   }
 
   &:active {
-    .ofh-pagination__page {
-      color: $ofh-color-foreground-link-active;
-    }
+    color: $ofh-color-foreground-link-active;
   }
 }
 
@@ -129,7 +130,7 @@
 .ofh-pagination__page {
   @include ofh-typography-responsive('paragraph-sm');
 
-  color: $ofh-color-foreground-link-default;
+  color: inherit;
   display: block;
   text-decoration: underline;
 }

--- a/packages/toolkit/components/pagination/_pagination.scss
+++ b/packages/toolkit/components/pagination/_pagination.scss
@@ -24,7 +24,7 @@
   width: 50%;
 
   .ofh-icon {
-    left: -6px;
+    left: -4px;
   }
 
   .ofh-pagination__title {
@@ -38,7 +38,7 @@
   width: 50%;
 
   .ofh-icon {
-    right: -6px;
+    right: -4px;
   }
 
   .ofh-pagination__title {
@@ -47,6 +47,7 @@
 }
 
 .ofh-pagination__link {
+  color: $ofh-color-foreground-brand-blue-navy;
   display: block;
   position: relative;
   text-decoration: none;
@@ -58,7 +59,7 @@
 
   .ofh-icon {
     position: absolute;
-    top: -2px;
+    top: 0;
 
     @include mq($media-type: print) {
       color: $ofh-color-foreground-primary;
@@ -67,53 +68,44 @@
   }
 
   &:hover {
-    color: $ofh-color-foreground-link-hover;
-
-    .ofh-icon {
-      color: $ofh-color-foreground-link-hover;
-      fill: $ofh-color-foreground-link-hover;
-    }
-
     .ofh-pagination__page {
+      color: $ofh-color-foreground-link-hover;
       text-decoration: none;
     }
   }
 
   &:focus {
-    @include ofh-focused-text;
+    @include ofh-focused-button;
 
     .ofh-pagination__page {
+      color: $ofh-color-foreground-link-active;
       text-decoration: none;
-    }
-
-    &:visited,
-    &:hover,
-    &:active {
-      .ofh-icon {
-        color: $ofh-color-foreground-brand-blue-navy;
-        fill: $ofh-color-foreground-brand-blue-navy;
-      }
     }
   }
 
   &:visited {
-    .ofh-icon {
+    .ofh-pagination__page {
       color: $ofh-color-foreground-link-visited;
-      fill: $ofh-color-foreground-link-visited;
     }
 
     &:hover {
-      .ofh-icon {
+      .ofh-pagination__page {
         color: $ofh-color-foreground-link-hover;
-        fill: $ofh-color-foreground-link-hover;
+        text-decoration: none;
       }
     }
 
     &:focus {
-      .ofh-icon {
-        color: $ofh-color-foreground-brand-blue-navy;
-        fill: $ofh-color-foreground-brand-blue-navy;
+      .ofh-pagination__page {
+        color: $ofh-color-foreground-link-active;
+        text-decoration: none;
       }
+    }
+  }
+
+  &:active {
+    .ofh-pagination__page {
+      color: $ofh-color-foreground-link-active;
     }
   }
 }
@@ -134,6 +126,7 @@
 .ofh-pagination__page {
   @include ofh-typography-responsive('paragraph-sm');
 
+  color: $ofh-color-foreground-link-default;
   display: block;
   text-decoration: underline;
 }

--- a/packages/toolkit/components/pagination/pagination.test.js
+++ b/packages/toolkit/components/pagination/pagination.test.js
@@ -1,0 +1,43 @@
+const { getHTMLCode } = require('../../../site/views/_data/helpers');
+
+const renderFixture = (fixturePath) => {
+  document.body.innerHTML = getHTMLCode(fixturePath);
+  return document.querySelector('.ofh-pagination');
+};
+
+describe('Our Future Health pagination macro', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders both pagination links with updated icon names and labels', () => {
+    const pagination = renderFixture('tests/fixtures/pagination/default.njk');
+    const links = pagination.querySelectorAll('.ofh-pagination__link');
+    const icons = pagination.querySelectorAll('.ofh-icon');
+
+    expect(pagination).not.toBeNull();
+    expect(pagination.getAttribute('role')).toBe('navigation');
+    expect(pagination.getAttribute('aria-label')).toBe('Pagination');
+    expect(links).toHaveLength(2);
+    expect(links[0].classList.contains('ofh-pagination__link--prev')).toBe(true);
+    expect(links[1].classList.contains('ofh-pagination__link--next')).toBe(true);
+    expect(icons[0].classList.contains('ofh-icon--West')).toBe(true);
+    expect(icons[1].classList.contains('ofh-icon--East')).toBe(true);
+  });
+
+  it('renders the previous-only variant without the next link', () => {
+    const pagination = renderFixture('tests/fixtures/pagination/previous-only.njk');
+
+    expect(pagination.querySelectorAll('.ofh-pagination__link')).toHaveLength(1);
+    expect(pagination.querySelector('.ofh-pagination__link--prev')).not.toBeNull();
+    expect(pagination.querySelector('.ofh-pagination__link--next')).toBeNull();
+  });
+
+  it('renders the next-only variant without the previous link', () => {
+    const pagination = renderFixture('tests/fixtures/pagination/next-only.njk');
+
+    expect(pagination.querySelectorAll('.ofh-pagination__link')).toHaveLength(1);
+    expect(pagination.querySelector('.ofh-pagination__link--next')).not.toBeNull();
+    expect(pagination.querySelector('.ofh-pagination__link--prev')).toBeNull();
+  });
+});

--- a/packages/toolkit/components/pagination/pagination.test.js
+++ b/packages/toolkit/components/pagination/pagination.test.js
@@ -21,8 +21,8 @@ describe('Our Future Health pagination macro', () => {
     expect(links).toHaveLength(2);
     expect(links[0].classList.contains('ofh-pagination__link--prev')).toBe(true);
     expect(links[1].classList.contains('ofh-pagination__link--next')).toBe(true);
-    expect(icons[0].classList.contains('ofh-icon--West')).toBe(true);
-    expect(icons[1].classList.contains('ofh-icon--East')).toBe(true);
+    expect(icons[0].classList.contains('ofh-icon--ArrowLeft')).toBe(true);
+    expect(icons[1].classList.contains('ofh-icon--ArrowRight')).toBe(true);
   });
 
   it('renders the previous-only variant without the next link', () => {

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/toolkit",
-  "version": "4.13.0",
+  "version": "4.14.0",
   "description": "Our Future Health design system toolkit contains the code you need to start building user interfaces for Our Future Health websites and services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
This PR delivers **DSE-336 pagination refresh** across toolkit, React, the docs site, and Storybook.

It aligns pagination with the current Figma interaction treatment, introduces the first public React `Pagination` component, improves docs/Storybook parity for sequence-edge examples, and tightens the pagination hit area so previous/next links hug their content rather than occupying 50/50 click zones.

Ticket: DSE-336

## Release scope
- `@ourfuturehealth/toolkit` -> `4.14.0`
- `@ourfuturehealth/react-components` -> `0.13.0`
- updates release metadata in `CHANGELOG.md`, `UPGRADING.md`, `docs/release-versioning-strategy.md`, `docs/consuming-react-components.md`, and `packages/react-components/README.md`

## Breaking Changes
- None.

## Key Changes
- refreshes the toolkit `pagination` component to match the current design treatment more closely, including 4px arrow spacing, boxed focus styling, and corrected state coloring
- changes pagination links to hug their content instead of using large 50/50 clickable halves, while keeping the existing responsive outer margin unchanged for now pending designer confirmation
- adds the first public React `Pagination` component with default, previous-only, and next-only support
- updates the pagination Storybook docs page so it teaches the real React API more clearly, including a copyable usage snippet in the main usage section
- keeps `Default` as a realistic fixed example, `Builder` as the interactive surface, and `PreviousOnly` / `NextOnly` as fixed showcase examples
- adds Storybook coverage and unit/accessibility coverage for the new React pagination component
- expands the docs site to cover the start and end of a sequence through explicit `previous-only` and `next-only` examples
- updates pagination icon usage to the current `ArrowLeft` / `ArrowRight` naming on the rebased branch

## Validation
- `npm test`
- `pnpm lint`
- `pnpm build`
- `pnpm docs:release-contract`
- `pnpm smoke:release-artifacts`
- `pnpm --filter=@ourfuturehealth/react-components build:storybook`
- manual QA on docs pagination examples
- manual QA on Storybook pagination stories
- responsive checks at `1200px`, `768px`, and `500px`

## Reviewer Focus
- previous/next links should now hug their content and leave the middle space non-clickable
- hover/focus/visited treatment should keep the title and arrow in brand navy while the page label carries the state color
- Storybook should now teach the component using the newer docs/default/builder/showcase pattern
- the existing responsive outer margin on `.ofh-pagination` was intentionally left unchanged pending design confirmation
- release metadata should line up on `toolkit-v4.14.0` / `react-v0.13.0`
