### PR TITLE
Docs :: Storybook story pattern uplift FE

### DIFF
--- a/docs/prompts/component-pr-readiness-template-prompt.md
+++ b/docs/prompts/component-pr-readiness-template-prompt.md
@@ -61,12 +61,15 @@ Workflow I want you to follow:
    - confirm deprecated compatibility paths exist only where intended
    - confirm toolkit vs React consumer expectations are documented clearly
    - confirm Storybook controls policy and prop docs are still coherent after any late changes
+   - confirm the Storybook surface still follows the intended `Docs` / `Default` / `Builder` / showcase shape, or explain clearly why a component needs a different pattern
+   - confirm the Docs page still teaches the real React API rather than a mixture of real props and story-only helper args
    - confirm no interactive single-component stories are still relying on raw JSON controls for stable nested props when clearer story-specific controls would be more usable
    - confirm no story is exposing controls for values the component visibly ignores or overrides
    - do a final token conformance pass for every public surface changed in this review unit, even if the ticket was not framed as a token migration
    - verify typography, spacing, icon sizing, and state-color tokens against the Figma token map used during implementation
    - do not treat inherited global styles as acceptable by default; confirm whether any inherited `a`, `p`, `ul`, `li`, `h*`, or body styles are intentional
    - if the rendered result only matches Figma because of accidental inheritance, treat that as a merge-readiness failure and fix it
+   - confirm copyable example snippets still show meaningful structured-prop shapes instead of hiding them behind undeclared variables
    - if the component was touched by a spacing/typography token migration, do a final spot-check for same-number static-token substitutions where Figma expected responsive tokens
    - do a final spot-check for accidental semantic-element inheritance (`p`, `ul`, `li`, `h*`, `a`) that may have reintroduced wrong spacing or typography
    - confirm release/version metadata is internally consistent for every affected releasable package:

--- a/docs/prompts/component-update-template-prompt.md
+++ b/docs/prompts/component-update-template-prompt.md
@@ -557,6 +557,10 @@ it('should be keyboard accessible', async () => {
 - ✅ Auto-generated prop table (via TypeScript)
 - ✅ Story controls that are ergonomic and honest about what the component actually supports
 - ✅ Example coverage that is intentionally compared against the docs site so one surface does not become much richer than the other
+- ✅ A Docs page that teaches the actual React API in plain language
+- ✅ A realistic `Default` story
+- ✅ A `Builder` story when interactive stakeholder-friendly controls add value
+- ✅ Showcase stories that are intentionally non-interactive when they exist to demonstrate fixed examples or states
 
 **Story Pattern:**
 
@@ -592,17 +596,34 @@ const meta: Meta<typeof {ComponentName}> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// Individual variant stories
+// Realistic default story
 export const Default: Story = {
-  args: { variant: 'default' },
+  args: {
+    // realistic props
+  },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
 };
 
-export const Variant1: Story = {
-  args: { variant: 'variant1' },
+// Builder story for stakeholder-friendly interaction
+export const Builder: Story = {
+  args: {
+    // friendly story-only args and realistic defaults
+  },
+  parameters: {
+    controls: {
+      include: [
+        // only the friendly Builder args and any genuinely simple real props
+      ],
+    },
+  },
 };
 
-// Demo stories
-export const AllVariants: Story = {
+// Showcase stories
+export const VariantShowcase: Story = {
   render: () => (
     <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
       <{ComponentName} variant="variant1">Variant 1</{ComponentName}>
@@ -610,27 +631,9 @@ export const AllVariants: Story = {
       <{ComponentName} variant="variant3">Variant 3</{ComponentName}>
     </div>
   ),
-};
-
-export const InForm: Story = {
-  render: () => (
-    <form onSubmit={(e) => e.preventDefault()}>
-      {/* Real-world usage example */}
-    </form>
-  ),
-};
-
-export const KeyboardNavigation: Story = {
-  render: () => (
-    <div>
-      {/* Demo keyboard interaction patterns */}
-    </div>
-  ),
   parameters: {
-    docs: {
-      description: {
-        story: 'Press Tab to focus, Enter/Space to activate.',
-      },
+    controls: {
+      disable: true,
     },
   },
 };
@@ -648,14 +651,22 @@ Review the component's user-facing documentation surfaces and make sure they exp
   - `interactive single-component example`
   - `showcase/comparison story`
   - `behavior/demo story`
+- Prefer this teaching shape unless there is a strong reason not to:
+  - `Docs` page teaches the real React API and how to consume the component
+  - `Default` story shows a realistic example
+  - `Builder` story is the main interactive controls surface when interactive controls add value
+  - other stories are fixed showcase examples with controls disabled
 - Controls rule:
-  - keep controls enabled for `interactive single-component example` stories where the controls map cleanly to the rendered output
+  - keep controls enabled for the `Builder` story or another true `interactive single-component example` story where the controls map cleanly to the rendered output
   - disable controls for `showcase/comparison` or `behavior/demo` stories when controls would be misleading or do not control the rendered output meaningfully
 - For structured or nested props, do not default to raw JSON editing when a clearer control model is available
   - examples: `tag`, `icon`, `dismissButton`, `actionLink`, `metadataItems`
   - when the story only needs a stable subset of that object shape, add story-only args such as `tagText`, `tagVariant`, `iconName`, `iconSize`, `actionHref`, or similar and map them to the real prop in `render`
   - hide the raw object control for that story when the story-only controls are the intended interaction path
   - only keep raw object editing visible when the JSON shape itself is what consumers need to learn
+- Do not let story-only helper args masquerade as real component props on the Docs page
+  - if you add `taskSet`, `showHints`, `linkSet`, `socialPlatforms`, or similar story-only helper args, make it explicit that they are Storybook-only and not part of the React API
+  - the Docs page should make it easy for a consumer to distinguish real component props from story-only helpers at a glance
 - Use the most specific control type available for constrained values
   - `select`, `radio`, `boolean`, `text`, or `number` instead of generic object editors whenever the value set is finite or easy to model
 - Do not expose controls for prop fields that the component visually ignores or overrides
@@ -683,6 +694,11 @@ Review the component's user-facing documentation surfaces and make sure they exp
   - `headingClasses` or similar styling hooks
   - `classes`, `className`, `attributes`, and `ref`
 - Mark advanced or integration-focused props clearly in Storybook where appropriate
+- The Docs page must be developer-friendly, not just type-friendly
+  - a React consumer should be able to tell what each prop does, when to use it, and what shape to pass without needing to infer it from TypeScript alone
+  - if the auto-generated prop table is too raw or misleading, add a custom docs page, usage example, or item-shape example to teach the API clearly
+- If an example story passes a variable such as `items={defaultItems}`, make sure the copyable source still teaches the variable shape
+  - either inline the structure in the source snippet or include the variable declaration in the shown snippet so the consumer can see what to pass
 
 **Cross-surface consistency review (MANDATORY):**
 
@@ -716,9 +732,12 @@ Review the component's user-facing documentation surfaces and make sure they exp
 **Output required before moving to QA:**
 
 - Confirm that each story has an intentional controls policy
+- Confirm that the Storybook surface follows the intended `Docs` / `Default` / `Builder` / showcase split, or explain clearly why a component needs a different shape
 - Confirm that structured props are not exposed as raw JSON when a clearer story-specific control model would be more usable
 - Confirm that no story exposes controls for values the component visibly ignores or overrides
 - Confirm that prop descriptions are written in plain language, not just implementation language
+- Confirm that the Docs page teaches the actual React API rather than a mixture of real props and story-only helper args
+- Confirm that copyable example source shows meaningful prop shapes instead of hiding them behind undeclared variables
 - Confirm that Storybook docs, site docs, macro options, and README describe the same API consistently
 - Confirm that Storybook and docs-site examples are on the same teaching level and that any important example gap has been closed in one direction or the other
 
@@ -746,10 +765,13 @@ Before moving to the validation prompt, answer these checks explicitly:
 
 - [ ] Are any Storybook controls misleading for any story?
 - [ ] Does every story have an intentional controls policy?
+- [ ] Does the Storybook surface follow the intended `Docs` / `Default` / `Builder` / showcase pattern, or is there a good reason it does not?
 - [ ] Are any nested or structured props still exposed as raw JSON even though the story could offer clearer text/select/boolean controls instead?
 - [ ] Do any story controls expose values that the component visually ignores or overrides?
+- [ ] Can a consumer clearly distinguish real React props from story-only helper args on the Docs page?
 - [ ] Are `heading`, `headingLevel`, and any HTML-overrides explained clearly where relevant?
 - [ ] Are advanced props such as `classes`, `className`, `attributes`, and `ref` clearly described as advanced/integration props where appropriate?
+- [ ] Do copyable example snippets show the meaningful shape of any structured props instead of hiding them behind undeclared variables?
 - [ ] Do Storybook docs, site docs, macro options, and README describe the same API consistently?
 - [ ] Are showcase/demo stories clearly non-interactive where appropriate?
 - [ ] Do Storybook and docs-site examples cover the same important usage patterns, states, and props?

--- a/docs/prompts/component-validation-qa-template-prompt.md
+++ b/docs/prompts/component-validation-qa-template-prompt.md
@@ -75,8 +75,11 @@ Important constraints:
 - If docs/examples are missing what is needed to validate behavior, improve them too.
 - Treat Storybook ↔ docs-site example gaps as implementation misses when one surface teaches materially less than the other.
 - Treat misleading Storybook controls or vague prop documentation as implementation misses to be fixed before QA is considered complete.
+- Treat Storybook docs pages that mix story-only helper args into the real React API as implementation misses to be fixed before QA is considered complete.
+- Treat Storybook surfaces that do not clearly separate `Docs`, `Default`, `Builder`, and fixed showcase stories as implementation misses unless there is a strong reason for a different shape.
 - Treat raw JSON controls for stable nested props as implementation misses when the story could reasonably offer clearer text/select/boolean controls instead.
 - Treat controls for values the component visibly ignores or overrides as implementation misses to be fixed before QA is considered complete.
+- Treat copyable example snippets that hide structured prop shapes behind undeclared variables as implementation misses when that makes the API harder to follow.
 - Treat responsive token mismatches or accidental inherited element styles (`p`, `ul`, `li`, `h*`, `a`) as implementation misses to be fixed before QA is considered complete.
 - Treat missing explicit component-level typography, spacing, or state-color tokens as implementation misses when the current appearance only works because of inherited global styles.
 - Treat spacing or typography contributed by reused shared primitives or layout objects (`label`, `hint`, `error-message`, `fieldset`, `form-group`, list wrappers, etc.) as implementation misses when they make the rendered output diverge from Figma.
@@ -86,6 +89,11 @@ Important constraints:
 - If implementation used a temporary internal adapter because a dependency was missing, call that out clearly during QA and include the affected surfaces in the validation script.
 - Do not use vague instructions like "looks shorter" or "feels closer to Figma" when the expected result can be stated precisely.
 - Do not describe spacing or typography only by numeric values when token identity matters; say whether the implementation should be using a responsive helper or a static token.
+- When validating Storybook docs, check that the Docs page teaches the real React API in plain language:
+  - what the actual props are
+  - what they do
+  - what shape they take
+  - which controls are Storybook-only helpers rather than real component props
 - For each QA step, prefer this structure:
   - what changed
   - what exact values or behaviors should now be visible
@@ -105,6 +113,7 @@ Output style I want from you:
 - Give me exact URLs for QA.
 - Drive the QA one step at a time.
 - Make each QA step specific enough that a reviewer can validate it without guessing what "good" looks like.
+- Treat Storybook docs usability as part of the QA target, not a separate follow-up.
 - When something fails, explain it plainly and fix it before moving on.
 - Keep the summary concise and useful for handing off into merge-readiness work.
 ```

--- a/packages/react-components/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/react-components/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -1,9 +1,91 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Autocomplete } from './Autocomplete';
+import { Autocomplete, type AutocompleteProps } from './Autocomplete';
 
-const options = ['England', 'Scotland', 'Wales', 'Northern Ireland'];
+type AutocompleteOptionSet = 'countries' | 'cities' | 'empty';
 
-const meta: Meta<typeof Autocomplete> = {
+type AutocompleteStoryArgs = AutocompleteProps & {
+  optionSet?: AutocompleteOptionSet;
+};
+
+const countriesOptions = ['England', 'Scotland', 'Wales', 'Northern Ireland'];
+
+const citiesOptions = [
+  'London',
+  'Manchester',
+  'Birmingham',
+  'Leeds',
+  'Liverpool',
+];
+
+const optionSets: Record<AutocompleteOptionSet, string[]> = {
+  countries: countriesOptions,
+  cities: citiesOptions,
+  empty: [],
+};
+
+const defaultStoryCode = `import { Autocomplete } from '@ourfuturehealth/react-components';
+
+const countriesOptions = ['England', 'Scotland', 'Wales', 'Northern Ireland'];
+
+<Autocomplete
+  hint="Start typing to filter the list."
+  label="Country"
+  name="country"
+  options={countriesOptions}
+/>;
+`;
+
+const withErrorStoryCode = `import { Autocomplete } from '@ourfuturehealth/react-components';
+
+const countriesOptions = ['England', 'Scotland', 'Wales', 'Northern Ireland'];
+
+<Autocomplete
+  errorMessage="Select a country from the list or enter a new one."
+  hint="Start typing to filter the list."
+  label="Country"
+  name="country"
+  options={countriesOptions}
+/>;
+`;
+
+const fixedWidthStoryCode = `import { Autocomplete } from '@ourfuturehealth/react-components';
+
+const countriesOptions = ['England', 'Scotland', 'Wales', 'Northern Ireland'];
+
+<Autocomplete
+  hint="Start typing to filter the list."
+  inputWidth={20}
+  label="Country"
+  name="country"
+  options={countriesOptions}
+/>;
+`;
+
+const customNoResultsStoryCode = `import { Autocomplete } from '@ourfuturehealth/react-components';
+
+const countriesOptions = ['England', 'Scotland', 'Wales', 'Northern Ireland'];
+
+<Autocomplete
+  hint="Start typing to filter the list."
+  label="Country"
+  name="country"
+  noResultsText="No matching countries. Enter a new country instead."
+  options={countriesOptions}
+/>;
+`;
+
+const renderAutocompleteStory = ({
+  optionSet,
+  options = countriesOptions,
+  ...args
+}: AutocompleteStoryArgs) => {
+  const resolvedOptions =
+    optionSet === undefined ? options : optionSets[optionSet];
+
+  return <Autocomplete {...args} options={resolvedOptions} />;
+};
+
+const meta: Meta<AutocompleteStoryArgs> = {
   title: 'Components/Input/Autocomplete',
   component: Autocomplete,
   parameters: {
@@ -12,7 +94,7 @@ const meta: Meta<typeof Autocomplete> = {
     docs: {
       description: {
         component:
-          'An input with inline suggestions that reuses the toolkit autocomplete classes, shared input-family label treatment, and suggestions list styling. The component manages the suggestion menu internally and supports both controlled and uncontrolled input values.',
+          'Use Autocomplete for a text field that suggests matches while the user types. The React API stays small: pass a label, an array of suggestion strings, and the usual form-field props such as hint, error message, width, and `defaultValue` or `value` when you need them. Use the `Builder` story to explore the component with friendly preset controls, and use the other stories as fixed examples.',
       },
     },
   },
@@ -20,7 +102,7 @@ const meta: Meta<typeof Autocomplete> = {
   args: {
     label: 'Country',
     name: 'country',
-    options,
+    options: countriesOptions,
   },
   argTypes: {
     label: {
@@ -29,28 +111,41 @@ const meta: Meta<typeof Autocomplete> = {
     },
     hint: {
       control: 'text',
-      description: 'Optional supporting text shown below the label and above any error message.',
+      description:
+        'Optional supporting text shown below the label and above any error message.',
     },
     errorMessage: {
       control: 'text',
-      description: 'Validation message shown above the input. When present, the input is marked invalid and linked with `aria-describedby`.',
+      description:
+        'Validation message shown above the input. When present, the input is marked invalid and linked with `aria-describedby`.',
     },
     name: {
       control: 'text',
       description: 'HTML name submitted with the form.',
     },
     options: {
-      control: 'object',
-      description: 'Plain-text options used to build the suggestions list. Edit this as a simple array of strings.',
+      control: false,
+      description:
+        'Suggestion strings used to build the autocomplete menu. Pass a plain array of labels, for example country names or common answers.',
       table: {
         type: {
           summary: 'string[]',
         },
       },
     },
+    optionSet: {
+      control: 'select',
+      options: ['countries', 'cities', 'empty'],
+      description:
+        'Storybook-only helper for the Builder story. Switches between preset suggestion lists without editing the real `options` array.',
+      table: {
+        disable: true,
+      },
+    },
     noResultsText: {
       control: 'text',
-      description: 'Override for the no-results message shown when the query matches no suggestions.',
+      description:
+        'Override for the no-results message shown when the query matches no suggestions.',
     },
     width: {
       control: 'select',
@@ -62,16 +157,24 @@ const meta: Meta<typeof Autocomplete> = {
         'one-third',
         'one-quarter',
       ],
-      description: 'Responsive width utility for the autocomplete field, including its suggestions dropdown.',
+      description:
+        'Responsive width utility for the autocomplete field, including its suggestions dropdown.',
     },
     inputWidth: {
       control: 'select',
       options: [2, 3, 4, 5, 10, 20, 30],
-      description: 'Fixed character-width modifier that helps signal the expected answer length and also constrains the suggestions dropdown width.',
+      description:
+        'Fixed character-width modifier that helps signal the expected answer length and also constrains the suggestions dropdown width.',
     },
     describedBy: {
       control: 'text',
-      description: 'Additional element IDs to append to the component-generated `aria-describedby` value.',
+      description:
+        'Additional element IDs to append to the component-generated `aria-describedby` value.',
+    },
+    isPageHeading: {
+      control: 'boolean',
+      description:
+        'Wrap the label in an `h1` when this question is also the page heading.',
     },
     onOptionSelect: {
       control: false,
@@ -133,12 +236,73 @@ export const Default: Story = {
   args: {
     hint: 'Start typing to filter the list.',
   },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'A realistic autocomplete example with a small set of country suggestions.',
+      },
+      source: {
+        code: defaultStoryCode,
+      },
+    },
+  },
+};
+
+export const Builder: Story = {
+  args: {
+    hint: 'Start typing to filter the list.',
+    label: 'Country',
+    name: 'country',
+    optionSet: 'countries',
+    options: countriesOptions,
+  },
+  render: renderAutocompleteStory,
+  parameters: {
+    controls: {
+      include: [
+        'label',
+        'hint',
+        'errorMessage',
+        'name',
+        'optionSet',
+        'noResultsText',
+        'width',
+        'inputWidth',
+        'describedBy',
+        'isPageHeading',
+      ],
+    },
+    docs: {
+      description: {
+        story:
+          'Use the friendly controls here to explore the component with preset suggestion lists and the most useful visible props.',
+      },
+    },
+  },
 };
 
 export const WithError: Story = {
   args: {
     errorMessage: 'Select a country from the list or enter a new one.',
     hint: 'Start typing to filter the list.',
+  },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'Shows how the component presents a validation message above the input.',
+      },
+      source: {
+        code: withErrorStoryCode,
+      },
+    },
   },
 };
 
@@ -147,11 +311,39 @@ export const FixedWidth: Story = {
     hint: 'Start typing to filter the list.',
     inputWidth: 20,
   },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'Shows the fixed character-width modifier that signals the expected answer length.',
+      },
+      source: {
+        code: fixedWidthStoryCode,
+      },
+    },
+  },
 };
 
 export const CustomNoResultsText: Story = {
   args: {
     hint: 'Start typing to filter the list.',
     noResultsText: 'No matching countries. Enter a new country instead.',
+  },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'Shows how to override the empty-results message when you need service-specific wording.',
+      },
+      source: {
+        code: customNoResultsStoryCode,
+      },
+    },
   },
 };

--- a/packages/react-components/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/react-components/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import { Autocomplete, type AutocompleteProps } from './Autocomplete';
 
 type AutocompleteOptionSet = 'countries' | 'cities' | 'empty';
@@ -74,6 +75,26 @@ const countriesOptions = ['England', 'Scotland', 'Wales', 'Northern Ireland'];
 />;
 `;
 
+const autocompleteUsageExample = `import { Autocomplete } from '@ourfuturehealth/react-components';
+
+const options = ['England', 'Scotland', 'Wales', 'Northern Ireland'];
+
+<Autocomplete
+  hint="Start typing to filter the list."
+  label="Country"
+  name="country"
+  options={options}
+/>;
+`;
+
+const autocompleteOptionsShapeExample = `const options = [
+  'England',
+  'Scotland',
+  'Wales',
+  'Northern Ireland',
+];
+`;
+
 const renderAutocompleteStory = ({
   optionSet,
   options = countriesOptions,
@@ -81,8 +102,15 @@ const renderAutocompleteStory = ({
 }: AutocompleteStoryArgs) => {
   const resolvedOptions =
     optionSet === undefined ? options : optionSets[optionSet];
+  const resolvedArgs = {
+    ...args,
+    describedBy: args.describedBy || undefined,
+    errorMessage: args.errorMessage || undefined,
+    hint: args.hint || undefined,
+    noResultsText: args.noResultsText || undefined,
+  };
 
-  return <Autocomplete {...args} options={resolvedOptions} />;
+  return <Autocomplete {...resolvedArgs} options={resolvedOptions} />;
 };
 
 const meta: Meta<AutocompleteStoryArgs> = {
@@ -96,6 +124,62 @@ const meta: Meta<AutocompleteStoryArgs> = {
         component:
           'Use Autocomplete for a text field that suggests matches while the user types. The React API stays small: pass a label, an array of suggestion strings, and the usual form-field props such as hint, error message, width, and `defaultValue` or `value` when you need them. Use the `Builder` story to explore the component with friendly preset controls, and use the other stories as fixed examples.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Pass a required <code>label</code>, <code>name</code>, and an{' '}
+            <code>options</code> array of suggestion strings. Add{' '}
+            <code>hint</code> when the user needs extra guidance, and use{' '}
+            <code>errorMessage</code> when you need to show validation feedback.
+          </p>
+          <p>
+            Use <code>noResultsText</code> when your service needs custom empty
+            state wording, and use <code>width</code> or <code>inputWidth</code>{' '}
+            to control the visible field width.
+          </p>
+          <Source code={autocompleteUsageExample} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes
+            of={Default}
+            include={[
+              'label',
+              'hint',
+              'errorMessage',
+              'name',
+              'options',
+              'noResultsText',
+              'width',
+              'inputWidth',
+              'describedBy',
+              'isPageHeading',
+            ]}
+          />
+
+          <h2>
+            <code>options</code> shape
+          </h2>
+          <p>
+            Pass a plain array of strings. Each string becomes one suggestion in
+            the filtered results list.
+          </p>
+          <Source code={autocompleteOptionsShapeExample} language="tsx" />
+
+          <h2>Storybook builder helpers</h2>
+          <p>
+            <code>optionSet</code> is only used by the Storybook{' '}
+            <code>Builder</code> story so you can swap between preset suggestion
+            lists without editing the real <code>options</code> prop. It is not
+            a React prop accepted by <code>Autocomplete</code>.
+          </p>
+
+          <Stories title="Examples" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],
@@ -108,20 +192,32 @@ const meta: Meta<AutocompleteStoryArgs> = {
     label: {
       control: 'text',
       description: 'Question or field label shown above the autocomplete input.',
+      table: {
+        category: 'AutocompleteProps',
+      },
     },
     hint: {
       control: 'text',
       description:
         'Optional supporting text shown below the label and above any error message.',
+      table: {
+        category: 'AutocompleteProps',
+      },
     },
     errorMessage: {
       control: 'text',
       description:
         'Validation message shown above the input. When present, the input is marked invalid and linked with `aria-describedby`.',
+      table: {
+        category: 'AutocompleteProps',
+      },
     },
     name: {
       control: 'text',
       description: 'HTML name submitted with the form.',
+      table: {
+        category: 'AutocompleteProps',
+      },
     },
     options: {
       control: false,
@@ -131,6 +227,7 @@ const meta: Meta<AutocompleteStoryArgs> = {
         type: {
           summary: 'string[]',
         },
+        category: 'AutocompleteProps',
       },
     },
     optionSet: {
@@ -139,13 +236,16 @@ const meta: Meta<AutocompleteStoryArgs> = {
       description:
         'Storybook-only helper for the Builder story. Switches between preset suggestion lists without editing the real `options` array.',
       table: {
-        disable: true,
+        category: 'Builder story only',
       },
     },
     noResultsText: {
       control: 'text',
       description:
         'Override for the no-results message shown when the query matches no suggestions.',
+      table: {
+        category: 'AutocompleteProps',
+      },
     },
     width: {
       control: 'select',
@@ -159,22 +259,34 @@ const meta: Meta<AutocompleteStoryArgs> = {
       ],
       description:
         'Responsive width utility for the autocomplete field, including its suggestions dropdown.',
+      table: {
+        category: 'AutocompleteProps',
+      },
     },
     inputWidth: {
       control: 'select',
       options: [2, 3, 4, 5, 10, 20, 30],
       description:
         'Fixed character-width modifier that helps signal the expected answer length and also constrains the suggestions dropdown width.',
+      table: {
+        category: 'AutocompleteProps',
+      },
     },
     describedBy: {
       control: 'text',
       description:
         'Additional element IDs to append to the component-generated `aria-describedby` value.',
+      table: {
+        category: 'AutocompleteProps',
+      },
     },
     isPageHeading: {
       control: 'boolean',
       description:
         'Wrap the label in an `h1` when this question is also the page heading.',
+      table: {
+        category: 'AutocompleteProps',
+      },
     },
     onOptionSelect: {
       control: false,
@@ -257,6 +369,10 @@ export const Builder: Story = {
     hint: 'Start typing to filter the list.',
     label: 'Country',
     name: 'country',
+    describedBy: '',
+    errorMessage: '',
+    isPageHeading: false,
+    noResultsText: '',
     optionSet: 'countries',
     options: countriesOptions,
   },

--- a/packages/react-components/src/components/Button/Button.stories.tsx
+++ b/packages/react-components/src/components/Button/Button.stories.tsx
@@ -78,12 +78,50 @@ const meta: Meta<ButtonProps> = {
 export default meta;
 type Story = StoryObj<ButtonProps>;
 
-// Variant stories
+export const Default: Story = {
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'A realistic contained button example. Use this as the first thing to copy when you need the default button pattern.',
+      },
+    },
+  },
+  render: () => <Button variant="contained">Continue</Button>,
+};
+
+export const Builder: Story = {
+  args: {
+    variant: 'contained',
+    children: 'Continue',
+    type: 'button',
+  },
+  parameters: {
+    controls: {
+      include: ['variant', 'children', 'href', 'type', 'disabled'],
+    },
+    docs: {
+      description: {
+        story:
+          'Use the Builder story to try the button API interactively. It is the place to change the visible label, switch between link and button behaviour, and inspect the simple state controls.',
+      },
+    },
+  },
+};
+
 export const Contained: Story = {
   args: {
     variant: 'contained',
     children: 'Contained Button',
     onClick: () => {},
+  },
+  parameters: {
+    controls: {
+      disable: true,
+    },
   },
 };
 
@@ -93,6 +131,11 @@ export const Outlined: Story = {
     children: 'Outlined Button',
     onClick: () => {},
   },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
 };
 
 export const Ghost: Story = {
@@ -101,6 +144,11 @@ export const Ghost: Story = {
     children: 'Ghost Button',
     onClick: () => {},
   },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
 };
 
 export const GhostInverted: Story = {
@@ -108,6 +156,11 @@ export const GhostInverted: Story = {
     variant: 'ghost-inverted',
     children: 'Ghost Inverted Button',
     onClick: () => {},
+  },
+  parameters: {
+    controls: {
+      disable: true,
+    },
   },
   globals: {
     backgrounds: { value: 'dark' },
@@ -120,6 +173,11 @@ export const Text: Story = {
     children: 'Text Button',
     onClick: () => {},
   },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
 };
 
 export const TextInverted: Story = {
@@ -127,6 +185,11 @@ export const TextInverted: Story = {
     variant: 'text-inverted',
     children: 'Text Inverted Button',
     onClick: () => {},
+  },
+  parameters: {
+    controls: {
+      disable: true,
+    },
   },
   globals: {
     backgrounds: { value: 'dark' },
@@ -168,10 +231,13 @@ export const AsLink: Story = {
     children: 'Link Button',
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story:
-          'When an href prop is provided, the button renders as an anchor tag (<a>) instead of a button element.',
+          'A fixed example showing the button rendered as a link when `href` is provided.',
       },
     },
   },

--- a/packages/react-components/src/components/Button/Button.stories.tsx
+++ b/packages/react-components/src/components/Button/Button.stories.tsx
@@ -2,6 +2,26 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import { Button, type ButtonProps } from './Button';
 
+type ButtonVariant =
+  | 'contained'
+  | 'outlined'
+  | 'ghost'
+  | 'ghost-inverted'
+  | 'text'
+  | 'text-inverted';
+
+type ButtonStoryArgs = {
+  actionType?: 'button' | 'link';
+  children?: React.ReactNode;
+  className?: string;
+  disabled?: boolean;
+  href?: string;
+  onClick?: ButtonProps['onClick'];
+  ref?: React.Ref<HTMLButtonElement | HTMLAnchorElement>;
+  type?: 'button' | 'submit' | 'reset';
+  variant?: ButtonVariant;
+};
+
 const buttonUsageExample = `import { Button } from '@ourfuturehealth/react-components';
 
 <Button variant="contained">
@@ -9,9 +29,36 @@ const buttonUsageExample = `import { Button } from '@ourfuturehealth/react-compo
 </Button>;
 `;
 
-const meta: Meta<ButtonProps> = {
+const renderButtonBuilderStory = ({
+  actionType = 'button',
+  children = 'Continue',
+  disabled,
+  href,
+  type,
+  variant,
+}: ButtonStoryArgs) => {
+  if (actionType === 'link') {
+    return (
+      <Button href={href || '/your-next-step'} variant={variant}>
+        {children}
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      disabled={disabled}
+      type={type}
+      variant={variant}
+    >
+      {children}
+    </Button>
+  );
+};
+
+const meta: Meta<ButtonStoryArgs> = {
   title: 'Components/Button',
-  component: Button,
+  component: Button as unknown as React.ComponentType<ButtonStoryArgs>,
   parameters: {
     layout: 'centered',
     docs: {
@@ -42,6 +89,14 @@ const meta: Meta<ButtonProps> = {
             of={Default}
             include={['variant', 'children', 'href', 'type', 'disabled']}
           />
+
+          <h2>Storybook builder helpers</h2>
+          <p>
+            <code>actionType</code> is only used by the Storybook{' '}
+            <code>Builder</code> story so you can switch between button and
+            link behaviour without juggling incompatible controls. It is not a
+            React prop accepted by <code>Button</code>.
+          </p>
 
           <Stories title="Examples" />
         </>
@@ -126,7 +181,7 @@ const meta: Meta<ButtonProps> = {
 };
 
 export default meta;
-type Story = StoryObj<ButtonProps>;
+type Story = StoryObj<ButtonStoryArgs>;
 
 export const Default: Story = {
   parameters: {
@@ -145,15 +200,46 @@ export const Default: Story = {
 
 export const Builder: Story = {
   args: {
+    actionType: 'button',
     children: 'Continue',
     disabled: false,
-    href: '',
+    href: '/your-next-step',
     type: 'button',
     variant: 'contained',
   },
+  render: renderButtonBuilderStory,
+  argTypes: {
+    actionType: {
+      control: 'radio',
+      options: ['button', 'link'],
+      description:
+        'Storybook-only helper for the Builder story. Switches the example between real button behaviour and link behaviour.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
+    disabled: {
+      if: {
+        arg: 'actionType',
+        eq: 'button',
+      },
+    },
+    href: {
+      if: {
+        arg: 'actionType',
+        eq: 'link',
+      },
+    },
+    type: {
+      if: {
+        arg: 'actionType',
+        eq: 'button',
+      },
+    },
+  },
   parameters: {
     controls: {
-      include: ['variant', 'children', 'href', 'type', 'disabled'],
+      include: ['actionType', 'variant', 'children', 'href', 'type', 'disabled'],
     },
     docs: {
       description: {

--- a/packages/react-components/src/components/Button/Button.stories.tsx
+++ b/packages/react-components/src/components/Button/Button.stories.tsx
@@ -1,5 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import { Button, type ButtonProps } from './Button';
+
+const buttonUsageExample = `import { Button } from '@ourfuturehealth/react-components';
+
+<Button variant="contained">
+  Continue
+</Button>;
+`;
 
 const meta: Meta<ButtonProps> = {
   title: 'Components/Button',
@@ -11,6 +19,33 @@ const meta: Meta<ButtonProps> = {
         component:
           'A flexible button component based on the OFH Design System with multiple variants and states. If `href` is provided, the component renders as an anchor instead of a button. The `variant` changes the visual prominence only, not the semantic element.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Use <code>Button</code> for the main action on a page or step. Pass
+            the visible label as <code>children</code> and choose a{' '}
+            <code>variant</code> when you need a different visual emphasis.
+          </p>
+          <p>
+            Add <code>href</code> when the action should navigate to another
+            page. Leave <code>href</code> unset when the action should behave as
+            a real button inside your app or form.
+          </p>
+          <Source code={buttonUsageExample} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes
+            of={Default}
+            include={['variant', 'children', 'href', 'type', 'disabled']}
+          />
+
+          <Stories title="Examples" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],
@@ -27,21 +62,33 @@ const meta: Meta<ButtonProps> = {
       ],
       description:
         'Changes the visual style and prominence of the button. It does not change whether the component renders as a button or link.',
+      table: {
+        category: 'ButtonProps',
+      },
     },
     children: {
       control: 'text',
       description: 'Visible label content for the button or link.',
+      table: {
+        category: 'ButtonProps',
+      },
     },
     href: {
       control: 'text',
       description:
         'Navigation destination. When this is set, the component renders as an anchor (`<a>`) instead of a button.',
+      table: {
+        category: 'ButtonProps',
+      },
     },
     type: {
       control: 'select',
       options: ['button', 'submit', 'reset'],
       description:
         'Button type for real `<button>` elements. This has no effect when `href` is set and the component renders as a link.',
+      table: {
+        category: 'ButtonProps',
+      },
     },
     onClick: {
       control: false,
@@ -55,6 +102,9 @@ const meta: Meta<ButtonProps> = {
       control: 'boolean',
       description:
         'Disables the button. This only applies to real `<button>` elements and has no effect when `href` is set.',
+      table: {
+        category: 'ButtonProps',
+      },
     },
     className: {
       control: false,
@@ -95,9 +145,11 @@ export const Default: Story = {
 
 export const Builder: Story = {
   args: {
-    variant: 'contained',
     children: 'Continue',
+    disabled: false,
+    href: '',
     type: 'button',
+    variant: 'contained',
   },
   parameters: {
     controls: {

--- a/packages/react-components/src/components/Card/Card.stories.tsx
+++ b/packages/react-components/src/components/Card/Card.stories.tsx
@@ -124,7 +124,7 @@ const meta: Meta<CardStoryArgs> = {
     docs: {
       description: {
         component:
-          'Use a card to present short, scannable summaries of content, status or next steps. `headingLevel` changes the semantic heading tag used for the card title, but does not change the visual styling on its own. The React component mirrors the toolkit Card family markup and classes.',
+          'Use a card to present short, scannable summaries of content, status or next steps. `headingLevel` changes the semantic heading tag used for the card title, but does not change the visual styling on its own. The React component mirrors the toolkit Card family markup and classes. Storybook-only helper args such as `tagText`, `iconName`, and `metadataItem1Text` exist only to make the Builder story easier to use and are not part of `CardProps`.',
       },
     },
   },
@@ -266,11 +266,22 @@ const meta: Meta<CardStoryArgs> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {
+export const Default: Story = {
   args: {
     heading: 'If you need help now, but it’s not an emergency',
     description:
       'Go to 111.nhs.uk or call 111 for urgent help that does not need emergency care.',
+  },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'A realistic basic card example. Use this as the first thing to copy when you need a short summary card.',
+      },
+    },
   },
   render: (args) => (
     <div style={{ maxWidth: '32rem' }}>
@@ -279,12 +290,71 @@ export const Basic: Story = {
   ),
 };
 
+export const Builder: Story = {
+  args: {
+    variant: 'clickable',
+    href: '#card-action',
+    heading: 'Introduction to care and support',
+    tagText: 'New',
+    tagVariant: 'blue',
+    description:
+      'A quick guide for people who have care and support needs and their carers.',
+    metadataItem1Icon: 'LocationOutline',
+    metadataItem1Text: 'Online',
+    metadataItem2Icon: 'CalendarOutline',
+    metadataItem2Text: 'Updated today',
+    metadataItem3Icon: 'ClockOutline',
+    metadataItem3Text: '5 minute read',
+    helperText: 'Recommended for new participants.',
+    iconName: 'ArrowCircleRightColour',
+    iconColor: '#FFC62C',
+  },
+  parameters: {
+    controls: {
+      include: [
+        'variant',
+        'heading',
+        'href',
+        'description',
+        'tagText',
+        'tagVariant',
+        'metadataItem1Icon',
+        'metadataItem1Text',
+        'metadataItem2Icon',
+        'metadataItem2Text',
+        'metadataItem3Icon',
+        'metadataItem3Text',
+        'helperText',
+        'iconName',
+        'iconColor',
+      ],
+    },
+    docs: {
+      description: {
+        story:
+          'Use the Builder story to try the Card API interactively. It keeps the complex nested props behind simple text, select, and color controls so you can explore the component without editing raw JSON.',
+      },
+    },
+  },
+  render: renderCard,
+};
+
 export const BasicDismissible: Story = {
   args: {
     heading: 'Update available',
     description: 'A newer version of this content is available for review.',
     dismissButton: {
       label: 'Dismiss update message',
+    },
+  },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story: 'Fixed showcase of a dismissible card.',
+      },
     },
   },
   render: renderCard,
@@ -302,6 +372,11 @@ export const BasicDismissibleWithImage: Story = {
       label: 'Dismiss guidance update',
     },
   },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
   render: renderCard,
 };
 
@@ -312,30 +387,14 @@ export const BasicWithIcon: Story = {
     iconName: 'Check',
     iconColor: '#00725F',
   },
-  argTypes: {
-    icon: {
-      control: false,
-      table: {
-        disable: true,
-      },
-    },
-    iconName: {
-      control: 'select',
-      options: iconNameOptions,
-      description:
-        'Glyph name for the fixed 32px trailing icon slot.',
-    },
-    iconColor: {
-      control: 'color',
-      description:
-        'Colour applied to monochrome icons in the trailing slot. Icons with baked-in fills may ignore it.',
-    },
-  },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story:
-          'Use the `icon` prop to add a supporting icon to a basic card. Success is one common use, but the same pattern can support other short icon-led messages too. This story lets you swap the glyph and tint monochrome icons, while the Card component keeps the trailing icon slot at its built-in 32px size.',
+          'Fixed showcase of a basic card with a supporting trailing icon.',
       },
     },
   },
@@ -349,6 +408,11 @@ export const Clickable: Story = {
     heading: 'Introduction to care and support',
     description:
       'A quick guide for people who have care and support needs and their carers.',
+  },
+  parameters: {
+    controls: {
+      disable: true,
+    },
   },
   render: (args) => (
     <div style={{ maxWidth: '32rem' }}>
@@ -386,11 +450,17 @@ export const ClickableAction: Story = {
     tagText: {
       control: 'text',
       description: 'Text content for the supporting tag.',
+      table: {
+        disable: true,
+      },
     },
     tagVariant: {
       control: 'select',
       options: tagVariantOptions,
       description: 'Visual style variant for the tag.',
+      table: {
+        disable: true,
+      },
     },
     icon: {
       control: false,
@@ -408,46 +478,73 @@ export const ClickableAction: Story = {
       control: 'select',
       options: iconNameOptions,
       description: 'Icon for the first metadata row.',
+      table: {
+        disable: true,
+      },
     },
     metadataItem1Text: {
       control: 'text',
       description: 'Text for the first metadata row.',
+      table: {
+        disable: true,
+      },
     },
     metadataItem2Icon: {
       control: 'select',
       options: iconNameOptions,
       description: 'Icon for the second metadata row.',
+      table: {
+        disable: true,
+      },
     },
     metadataItem2Text: {
       control: 'text',
       description: 'Text for the second metadata row.',
+      table: {
+        disable: true,
+      },
     },
     metadataItem3Icon: {
       control: 'select',
       options: iconNameOptions,
       description: 'Icon for the third metadata row.',
+      table: {
+        disable: true,
+      },
     },
     metadataItem3Text: {
       control: 'text',
       description: 'Text for the third metadata row.',
+      table: {
+        disable: true,
+      },
     },
     iconName: {
       control: 'select',
       options: iconNameOptions,
       description:
         'Trailing icon glyph from the toolkit icon set.',
+      table: {
+        disable: true,
+      },
     },
     iconColor: {
       control: 'color',
       description:
         'Colour applied to monochrome trailing icons. Icons with baked-in fills, such as `ArrowCircleRightColour`, may ignore it.',
+      table: {
+        disable: true,
+      },
     },
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story:
-          'This story exposes simpler controls for the nested tag, metadata rows, and trailing icon props. The tag can be edited as text plus variant, the metadata rows can be edited without raw JSON, and the trailing icon control lets you change the glyph and tint monochrome icons while the Card component keeps that slot at its built-in 32px size.',
+          'Fixed showcase of a clickable card with nested content, metadata, and a trailing icon.',
       },
     },
   },
@@ -462,10 +559,13 @@ export const ClickableNumeric: Story = {
     actionLinkHref: '#card-numeric',
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story:
-          'This story uses simple text controls for the numeric action link instead of exposing the nested `actionLink` object directly.',
+          'Fixed showcase of a numeric action card. Use it to see how the action link sits with the large number treatment.',
       },
     },
   },
@@ -479,10 +579,16 @@ export const ClickableNumeric: Story = {
     actionLinkText: {
       control: 'text',
       description: 'Link text for the numeric card action.',
+      table: {
+        disable: true,
+      },
     },
     actionLinkHref: {
       control: 'text',
       description: 'Destination for the numeric card action link.',
+      table: {
+        disable: true,
+      },
     },
   },
   render: ({
@@ -524,6 +630,11 @@ export const WithImage: Story = {
       <Card {...args} />
     </div>
   ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
 };
 
 export const KeyboardNavigation: Story = {

--- a/packages/react-components/src/components/Card/Card.stories.tsx
+++ b/packages/react-components/src/components/Card/Card.stories.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import iconManifest from '@ourfuturehealth/toolkit/assets/icons/manifest.json';
 import { Card } from './Card';
 import type { TagVariant } from '../Tag';
@@ -31,6 +32,30 @@ const tagVariantOptions: TagVariant[] = [
 const iconNameOptions = iconManifest.icons
   .map(({ name }) => name)
   .sort((left, right) => left.localeCompare(right));
+
+const cardUsageExample = `import { Card } from '@ourfuturehealth/react-components';
+
+<Card
+  description="Go to 111.nhs.uk or call 111 for urgent help that does not need emergency care."
+  heading="If you need help now, but it’s not an emergency"
+/>;
+`;
+
+const cardNestedPropsExample = `const tag = {
+  children: 'New',
+  variant: 'blue',
+};
+
+const metadataItems = [
+  { icon: 'LocationOutline', text: 'Online' },
+  { icon: 'CalendarOutline', text: 'Updated today' },
+];
+
+const actionLink = {
+  text: 'Open tasks',
+  href: '/tasks',
+};
+`;
 
 const renderCard = ({
   tagText,
@@ -126,6 +151,64 @@ const meta: Meta<CardStoryArgs> = {
         component:
           'Use a card to present short, scannable summaries of content, status or next steps. `headingLevel` changes the semantic heading tag used for the card title, but does not change the visual styling on its own. The React component mirrors the toolkit Card family markup and classes. Storybook-only helper args such as `tagText`, `iconName`, and `metadataItem1Text` exist only to make the Builder story easier to use and are not part of `CardProps`.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Use <code>Card</code> for short, scannable summaries of content,
+            status, or next steps. Pass the main title through <code>heading</code>{' '}
+            and the supporting copy through <code>description</code>.
+          </p>
+          <p>
+            Add <code>href</code> and set <code>variant="clickable"</code> when
+            the card should behave like a linked summary. Add nested props like{' '}
+            <code>tag</code>, <code>metadataItems</code>, and{' '}
+            <code>actionLink</code> only when the card needs those extra parts.
+          </p>
+          <Source code={cardUsageExample} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes
+            of={Default}
+            include={[
+              'variant',
+              'heading',
+              'headingLevel',
+              'description',
+              'href',
+              'number',
+              'tag',
+              'metadataItems',
+              'helperText',
+              'actionLink',
+              'imgURL',
+              'imgALT',
+            ]}
+          />
+
+          <h2>Common nested prop shapes</h2>
+          <p>
+            When you need richer card content, these are the main nested object
+            shapes used by the React API:
+          </p>
+          <Source code={cardNestedPropsExample} language="tsx" />
+
+          <h2>Storybook builder helpers</h2>
+          <p>
+            <code>tagText</code>, <code>tagVariant</code>, <code>iconName</code>,{' '}
+            <code>iconColor</code>, <code>metadataItem1Text</code>, and the
+            related metadata/action helper args are only used by the Storybook{' '}
+            <code>Builder</code> story. They exist to make the card easier to
+            explore without editing nested JSON, and they are not React props
+            accepted by <code>Card</code>.
+          </p>
+
+          <Stories title="Examples" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],
@@ -135,11 +218,17 @@ const meta: Meta<CardStoryArgs> = {
       options: ['basic', 'clickable'],
       description:
         'Changes the card behavior. `basic` is a static content card. `clickable` keeps a real link inside the card and expands the card hit area to that primary link.',
+      table: {
+        category: 'CardProps',
+      },
     },
     heading: {
       control: 'text',
       description:
         'Main heading content for the card. This is usually the most prominent text and can include a link when `href` is provided.',
+      table: {
+        category: 'CardProps',
+      },
     },
     headingHtml: {
       control: false,
@@ -162,10 +251,16 @@ const meta: Meta<CardStoryArgs> = {
       options: [2, 3, 4, 5, 6],
       description:
         'Changes the semantic heading element for the title, for example `h2` or `h3`. This helps the card fit the page heading hierarchy, but does not change the visual appearance by itself.',
+      table: {
+        category: 'CardProps',
+      },
     },
     description: {
       control: 'text',
       description: 'Plain text body copy shown below the heading.',
+      table: {
+        category: 'CardProps',
+      },
     },
     descriptionHtml: {
       control: false,
@@ -179,11 +274,17 @@ const meta: Meta<CardStoryArgs> = {
       control: 'text',
       description:
         'Primary link destination. In clickable cards, this makes the heading link the main interactive target for the whole card.',
+      table: {
+        category: 'CardProps',
+      },
     },
     icon: {
       control: 'object',
       description:
         'Optional trailing icon shown to the right of the card content. The card keeps this slot at a fixed 32px size. Monochrome icons can be tinted with `icon.color`, while icons with baked-in fills keep their own colours.',
+      table: {
+        category: 'CardProps',
+      },
     },
     dismissButton: {
       control: false,
@@ -194,21 +295,33 @@ const meta: Meta<CardStoryArgs> = {
       control: 'text',
       description:
         'Large numeric value used in dashboard-style cards where the number is the main message.',
+      table: {
+        category: 'CardProps',
+      },
     },
     tag: {
       control: 'object',
       description:
         'Optional contextual tag shown above the body copy. This uses the React `Tag` API, for example `children`, `variant`, and `className`.',
+      table: {
+        category: 'CardProps',
+      },
     },
     metadataItems: {
       control: 'object',
       description:
         'Optional metadata rows with an icon and text, used for supporting details like location, date, or reading time.',
+      table: {
+        category: 'CardProps',
+      },
     },
     helperText: {
       control: 'text',
       description:
         'Supporting helper text shown after the main body and metadata.',
+      table: {
+        category: 'CardProps',
+      },
     },
     helperHtml: {
       control: false,
@@ -222,15 +335,24 @@ const meta: Meta<CardStoryArgs> = {
       control: 'object',
       description:
         'Optional secondary action link shown at the bottom of the card. In clickable numeric cards without `href`, this can act as the primary link target.',
+      table: {
+        category: 'CardProps',
+      },
     },
     imgURL: {
       control: 'text',
       description: 'Optional image shown at the top of the card.',
+      table: {
+        category: 'CardProps',
+      },
     },
     imgALT: {
       control: 'text',
       description:
         'Alternative text for the image. Use an empty string when the image is decorative.',
+      table: {
+        category: 'CardProps',
+      },
     },
     classes: {
       control: false,

--- a/packages/react-components/src/components/CardCallout/CardCallout.stories.tsx
+++ b/packages/react-components/src/components/CardCallout/CardCallout.stories.tsx
@@ -1,5 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import { CardCallout } from './CardCallout';
+
+const cardCalloutUsageExample = `import { CardCallout } from '@ourfuturehealth/react-components';
+
+<CardCallout
+  heading="Information"
+  text="This is additional context to help the user understand the next step."
+  variant="info"
+/>;
+`;
 
 const meta: Meta<typeof CardCallout> = {
   title: 'Components/Card/Callout',
@@ -11,6 +21,32 @@ const meta: Meta<typeof CardCallout> = {
         component:
           'Use Card / Callout to highlight contextual information such as informational, warning, success or error messages. `heading` changes the colored label text. `headingLevel` changes the semantic heading tag used for that label, but does not change the visual styling.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Use <code>CardCallout</code> when you need a short message block
+            with stronger visual emphasis than a standard paragraph.
+          </p>
+          <p>
+            Pass the message label through <code>heading</code>, the body copy
+            through <code>text</code>, and choose a <code>variant</code> that
+            matches the message type.
+          </p>
+          <Source code={cardCalloutUsageExample} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes
+            of={Default}
+            include={['variant', 'heading', 'headingLevel', 'text']}
+          />
+
+          <Stories title="Examples" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],
@@ -20,11 +56,17 @@ const meta: Meta<typeof CardCallout> = {
       options: ['info', 'error', 'success', 'warning'],
       description:
         'Changes the callout color scheme to match the type of message: informational, warning, success, or error.',
+      table: {
+        category: 'CardCalloutProps',
+      },
     },
     heading: {
       control: 'text',
       description:
         'Text shown in the colored label block at the top of the callout.',
+      table: {
+        category: 'CardCalloutProps',
+      },
     },
     headingHtml: {
       control: false,
@@ -39,6 +81,9 @@ const meta: Meta<typeof CardCallout> = {
       options: [2, 3, 4, 5, 6],
       description:
         'Changes the semantic heading element for the label, for example `h2` or `h3`. This helps the callout fit the page heading hierarchy, but does not change the visual appearance.',
+      table: {
+        category: 'CardCalloutProps',
+      },
     },
     html: {
       control: false,
@@ -51,6 +96,9 @@ const meta: Meta<typeof CardCallout> = {
     text: {
       control: 'text',
       description: 'Plain text body content shown inside the callout.',
+      table: {
+        category: 'CardCalloutProps',
+      },
     },
     classes: {
       control: false,
@@ -180,8 +228,9 @@ export const Default: Story = {
 export const Builder: Story = {
   args: {
     heading: 'Information',
-    variant: 'info',
+    headingLevel: 2,
     text: 'This is additional context to help the user understand the next step.',
+    variant: 'info',
   },
   parameters: {
     controls: {

--- a/packages/react-components/src/components/CardCallout/CardCallout.stories.tsx
+++ b/packages/react-components/src/components/CardCallout/CardCallout.stories.tsx
@@ -93,6 +93,11 @@ export const Info: Story = {
       <CardCallout {...args} />
     </div>
   ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
 };
 
 export const Warning: Story = {
@@ -106,6 +111,11 @@ export const Warning: Story = {
       <CardCallout {...args} />
     </div>
   ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
 };
 
 export const Success: Story = {
@@ -119,6 +129,11 @@ export const Success: Story = {
       <CardCallout {...args} />
     </div>
   ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
 };
 
 export const Error: Story = {
@@ -126,6 +141,58 @@ export const Error: Story = {
     heading: 'Error',
     variant: 'error',
     text: 'There is a problem with the information in this section.',
+  },
+  render: (args) => (
+    <div style={{ maxWidth: '32rem' }}>
+      <CardCallout {...args} />
+    </div>
+  ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
+};
+
+export const Default: Story = {
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'A realistic informational callout example. Use this as the default pattern when you need a simple explanatory message.',
+      },
+    },
+  },
+  render: () => (
+    <div style={{ maxWidth: '32rem' }}>
+      <CardCallout
+        heading="Information"
+        variant="info"
+        text="This is additional context to help the user understand the next step."
+      />
+    </div>
+  ),
+};
+
+export const Builder: Story = {
+  args: {
+    heading: 'Information',
+    variant: 'info',
+    text: 'This is additional context to help the user understand the next step.',
+  },
+  parameters: {
+    controls: {
+      include: ['variant', 'heading', 'text', 'headingLevel'],
+    },
+    docs: {
+      description: {
+        story:
+          'Use the Builder story to try the Card / Callout API interactively. It is the quickest way to compare the message type, label text, and heading semantics.',
+      },
+    },
   },
   render: (args) => (
     <div style={{ maxWidth: '32rem' }}>

--- a/packages/react-components/src/components/CardDoDont/CardDoDont.stories.tsx
+++ b/packages/react-components/src/components/CardDoDont/CardDoDont.stories.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import { CardDoDont } from './CardDoDont';
 
 type CardDoDontStoryArgs = ComponentProps<typeof CardDoDont> & {
@@ -19,6 +20,25 @@ const defaultDontItems = [
   'wear the shoes or use the equipment that caused your blister until it heals',
   'ignore signs that it may be infected',
 ];
+
+const cardDoDontUsageExample = `import { CardDoDont } from '@ourfuturehealth/react-components';
+
+const items = [
+  { item: 'cover blisters that are likely to burst with a soft plaster or dressing' },
+  { item: 'wash your hands before touching a burst blister' },
+  { item: 'allow the fluid to drain before covering it' },
+];
+
+<CardDoDont
+  items={items}
+  type="do"
+/>;
+`;
+
+const cardDoDontItemsShapeExample = `type CardDoDontItem = {
+  item: React.ReactNode;
+};
+`;
 
 const renderCardDoDont = ({ itemsText, items, ...args }: CardDoDontStoryArgs) => {
   const resolvedItems =
@@ -47,6 +67,49 @@ const meta: Meta<CardDoDontStoryArgs> = {
         component:
           'Use Card / Do & Don’t to give users short, actionable recommendations that are easier to scan as positive and negative lists. `heading` changes the navy label text. `headingLevel` changes the semantic heading tag used for that label, but does not change the visual styling.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Use <code>CardDoDont</code> when you want a short, scannable list of
+            recommended or discouraged actions.
+          </p>
+          <p>
+            Pass the list type through <code>type</code> and the bullet content
+            through an <code>items</code> array. You can override the default
+            label with <code>heading</code> if your page needs more specific
+            wording.
+          </p>
+          <Source code={cardDoDontUsageExample} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes
+            of={Default}
+            include={['type', 'heading', 'headingLevel', 'items']}
+          />
+
+          <h2>
+            <code>items</code> shape
+          </h2>
+          <p>
+            Each entry in the <code>items</code> array follows this shape:
+          </p>
+          <Source code={cardDoDontItemsShapeExample} language="tsx" />
+
+          <h2>Storybook builder helpers</h2>
+          <p>
+            <code>itemsText</code> is only used by the Storybook{' '}
+            <code>Builder</code> story so you can edit the list content as simple
+            newline-separated text. It is not a React prop accepted by{' '}
+            <code>CardDoDont</code>.
+          </p>
+
+          <Stories title="Examples" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],
@@ -56,29 +119,41 @@ const meta: Meta<CardDoDontStoryArgs> = {
       options: ['do', 'dont'],
       description:
         'Chooses whether the card presents a positive do list or a negative don’t list.',
+      table: {
+        category: 'CardDoDontProps',
+      },
     },
     heading: {
       control: 'text',
       description:
         'Optional label text shown in the navy heading block. Defaults to `Do` or `Don’t` based on `type`.',
+      table: {
+        category: 'CardDoDontProps',
+      },
     },
     headingLevel: {
       control: 'select',
       options: [2, 3, 4, 5, 6],
       description:
         'Changes the semantic heading element for the label, for example `h2` or `h3`. This helps the component fit the page heading hierarchy, but does not change the visual appearance.',
+      table: {
+        category: 'CardDoDontProps',
+      },
     },
     items: {
-      control: 'object',
+      control: false,
       description:
         'Array of list items rendered in the card body. Pass one object per bullet.',
+      table: {
+        category: 'CardDoDontProps',
+      },
     },
     itemsText: {
       control: 'text',
       description:
         'List items as newline-separated text for this story. Each non-empty line becomes one bullet.',
       table: {
-        disable: true,
+        category: 'Builder story only',
       },
     },
     classes: {
@@ -116,14 +191,6 @@ export const Default: Story = {
     type: 'do',
     itemsText: defaultDoItems.join('\n'),
   },
-  argTypes: {
-    items: {
-      control: false,
-      table: {
-        disable: true,
-      },
-    },
-  },
   render: renderCardDoDont,
   parameters: {
     controls: {
@@ -143,14 +210,6 @@ export const Dont: Story = {
     type: 'dont',
     itemsText: defaultDontItems.join('\n'),
   },
-  argTypes: {
-    items: {
-      control: false,
-      table: {
-        disable: true,
-      },
-    },
-  },
   render: renderCardDoDont,
   parameters: {
     controls: {
@@ -161,16 +220,10 @@ export const Dont: Story = {
 
 export const Builder: Story = {
   args: {
+    heading: '',
+    headingLevel: 2,
     type: 'do',
     itemsText: defaultDoItems.join('\n'),
-  },
-  argTypes: {
-    items: {
-      control: false,
-      table: {
-        disable: true,
-      },
-    },
   },
   parameters: {
     controls: {

--- a/packages/react-components/src/components/CardDoDont/CardDoDont.stories.tsx
+++ b/packages/react-components/src/components/CardDoDont/CardDoDont.stories.tsx
@@ -54,7 +54,8 @@ const meta: Meta<CardDoDontStoryArgs> = {
     type: {
       control: 'select',
       options: ['do', 'dont'],
-      description: 'List type.',
+      description:
+        'Chooses whether the card presents a positive do list or a negative don’t list.',
     },
     heading: {
       control: 'text',
@@ -69,12 +70,16 @@ const meta: Meta<CardDoDontStoryArgs> = {
     },
     items: {
       control: 'object',
-      description: 'Array of list items rendered in the card body.',
+      description:
+        'Array of list items rendered in the card body. Pass one object per bullet.',
     },
     itemsText: {
       control: 'text',
       description:
         'List items as newline-separated text for this story. Each non-empty line becomes one bullet.',
+      table: {
+        disable: true,
+      },
     },
     classes: {
       control: false,
@@ -106,7 +111,7 @@ const meta: Meta<CardDoDontStoryArgs> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Do: Story = {
+export const Default: Story = {
   args: {
     type: 'do',
     itemsText: defaultDoItems.join('\n'),
@@ -120,6 +125,17 @@ export const Do: Story = {
     },
   },
   render: renderCardDoDont,
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'A realistic do-list example. Use this as the default pattern when you need a short, scannable positive recommendation list.',
+      },
+    },
+  },
 };
 
 export const Dont: Story = {
@@ -132,6 +148,38 @@ export const Dont: Story = {
       control: false,
       table: {
         disable: true,
+      },
+    },
+  },
+  render: renderCardDoDont,
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
+};
+
+export const Builder: Story = {
+  args: {
+    type: 'do',
+    itemsText: defaultDoItems.join('\n'),
+  },
+  argTypes: {
+    items: {
+      control: false,
+      table: {
+        disable: true,
+      },
+    },
+  },
+  parameters: {
+    controls: {
+      include: ['type', 'heading', 'headingLevel', 'itemsText'],
+    },
+    docs: {
+      description: {
+        story:
+          'Use the Builder story to try the Card / Do & Don’t API interactively. It is the easiest way to change the list type and swap the bullet content without editing raw JSON.',
       },
     },
   },

--- a/packages/react-components/src/components/CharacterCount/CharacterCount.stories.tsx
+++ b/packages/react-components/src/components/CharacterCount/CharacterCount.stories.tsx
@@ -2,6 +2,11 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import { CharacterCount } from './CharacterCount';
 
+type CharacterCountStoryArgs = React.ComponentProps<typeof CharacterCount> & {
+  countMode?: 'characters' | 'words';
+  limit?: number;
+};
+
 const characterCountUsageExample = `import { CharacterCount } from '@ourfuturehealth/react-components';
 
 <CharacterCount
@@ -12,7 +17,38 @@ const characterCountUsageExample = `import { CharacterCount } from '@ourfuturehe
 />;
 `;
 
-const meta: Meta<typeof CharacterCount> = {
+const renderCharacterCountBuilderStory = ({
+  countMode = 'characters',
+  limit = 200,
+  ...args
+}: CharacterCountStoryArgs) => {
+  const normalizedArgs = {
+    ...args,
+    describedBy: args.describedBy || undefined,
+    errorMessage: args.errorMessage || undefined,
+    hint: args.hint || undefined,
+  };
+
+  if (countMode === 'words') {
+    return (
+      <CharacterCount
+        {...normalizedArgs}
+        maxLength={undefined}
+        maxWords={limit}
+      />
+    );
+  }
+
+  return (
+    <CharacterCount
+      {...normalizedArgs}
+      maxLength={limit}
+      maxWords={undefined}
+    />
+  );
+};
+
+const meta = {
   title: 'Components/Input/Character count',
   component: CharacterCount,
   parameters: {
@@ -57,6 +93,15 @@ const meta: Meta<typeof CharacterCount> = {
               'describedBy',
             ]}
           />
+
+          <h2>Storybook builder helpers</h2>
+          <p>
+            <code>countMode</code> and <code>limit</code> are only used by the
+            Storybook <code>Builder</code> story so you can try character and
+            word counting without activating both real limit props at the same
+            time. They are not React props accepted by{' '}
+            <code>CharacterCount</code>.
+          </p>
 
           <Stories title="Examples" />
         </>
@@ -113,6 +158,23 @@ const meta: Meta<typeof CharacterCount> = {
         category: 'CharacterCountProps',
       },
     },
+    countMode: {
+      control: 'radio',
+      options: ['characters', 'words'],
+      description:
+        'Storybook-only helper for the Builder story. Chooses whether the example maps the limit to `maxLength` or `maxWords`.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
+    limit: {
+      control: 'number',
+      description:
+        'Storybook-only helper for the Builder story. Supplies the active character or word limit value.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
     threshold: {
       control: 'number',
       description: 'Percentage of the limit at which the visible status message appears.',
@@ -150,10 +212,10 @@ const meta: Meta<typeof CharacterCount> = {
       },
     },
   },
-};
+} satisfies Meta<CharacterCountStoryArgs>;
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<CharacterCountStoryArgs>;
 
 export const Default: Story = {
   args: {
@@ -174,16 +236,17 @@ export const Default: Story = {
 
 export const Builder: Story = {
   args: {
+    countMode: 'characters',
     describedBy: '',
     errorMessage: '',
     hint: 'Do not include personal details.',
     label: 'Summary',
-    maxLength: 200,
-    maxWords: undefined,
+    limit: 200,
     name: 'summary',
     rows: 5,
     threshold: 0,
   },
+  render: renderCharacterCountBuilderStory,
   parameters: {
     controls: {
       include: [
@@ -191,8 +254,8 @@ export const Builder: Story = {
         'hint',
         'errorMessage',
         'name',
-        'maxLength',
-        'maxWords',
+        'countMode',
+        'limit',
         'threshold',
         'rows',
         'describedBy',
@@ -201,7 +264,7 @@ export const Builder: Story = {
     docs: {
       description: {
         story:
-          'Interactive character-count example. Adjust the real props to see how the counter changes with character or word limits.',
+          'Interactive character-count example. Use the friendly Builder helpers to swap between character and word limits without editing both real limit props at once.',
       },
     },
   },

--- a/packages/react-components/src/components/CharacterCount/CharacterCount.stories.tsx
+++ b/packages/react-components/src/components/CharacterCount/CharacterCount.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Description, Stories, Title } from '@storybook/addon-docs/blocks';
 import { CharacterCount } from './CharacterCount';
 
 const meta: Meta<typeof CharacterCount> = {
@@ -12,6 +13,14 @@ const meta: Meta<typeof CharacterCount> = {
         component:
           'A textarea with live character or word count messaging that follows the toolkit character-count pattern and shared input-family styling. Use `maxLength` for character counts or `maxWords` for word counts; only one limit mode should be active at a time.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+          <ArgTypes />
+          <Stories title="Examples" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],
@@ -31,7 +40,8 @@ const meta: Meta<typeof CharacterCount> = {
     },
     errorMessage: {
       control: 'text',
-      description: 'Validation message shown above the textarea. This is separate from the automatic over-limit count status.',
+      description:
+        'Validation message shown above the textarea. This is separate from the automatic over-limit count status.',
     },
     name: {
       control: 'text',
@@ -55,7 +65,8 @@ const meta: Meta<typeof CharacterCount> = {
     },
     describedBy: {
       control: 'text',
-      description: 'Additional element IDs to append to the component-generated `aria-describedby` value.',
+      description:
+        'Additional element IDs to append to the component-generated `aria-describedby` value.',
     },
     countMessageClassName: {
       control: false,
@@ -82,9 +93,30 @@ export const Default: Story = {
     hint: 'Do not include personal details.',
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
-        story: 'Default character-count textarea with the visible count message shown from the start.',
+        story:
+          'Default character-count textarea with the visible count message shown from the start.',
+      },
+    },
+  },
+};
+
+export const Builder: Story = {
+  args: {
+    hint: 'Do not include personal details.',
+    label: 'Summary',
+    maxLength: 200,
+    name: 'summary',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Interactive character-count example. Adjust the real props to see how the counter changes with character or word limits.',
       },
     },
   },
@@ -96,9 +128,13 @@ export const WithThreshold: Story = {
     threshold: 75,
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
-        story: 'The visible count message stays hidden until the user reaches 75% of the limit.',
+        story:
+          'The visible count message stays hidden until the user reaches 75% of the limit.',
       },
     },
   },
@@ -111,6 +147,9 @@ export const WordCount: Story = {
     maxWords: 50,
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story: 'Switches the component from character counting to word counting.',
@@ -127,9 +166,13 @@ export const WithError: Story = {
     maxLength: 40,
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
-        story: 'Example of an explicit validation error alongside the automatic over-limit state.',
+        story:
+          'Example of an explicit validation error alongside the automatic over-limit state.',
       },
     },
   },

--- a/packages/react-components/src/components/CharacterCount/CharacterCount.stories.tsx
+++ b/packages/react-components/src/components/CharacterCount/CharacterCount.stories.tsx
@@ -1,6 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { ArgTypes, Description, Stories, Title } from '@storybook/addon-docs/blocks';
+import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import { CharacterCount } from './CharacterCount';
+
+const characterCountUsageExample = `import { CharacterCount } from '@ourfuturehealth/react-components';
+
+<CharacterCount
+  hint="Do not include personal details."
+  label="Summary"
+  maxLength={200}
+  name="summary"
+/>;
+`;
 
 const meta: Meta<typeof CharacterCount> = {
   title: 'Components/Input/Character count',
@@ -17,7 +27,37 @@ const meta: Meta<typeof CharacterCount> = {
         <>
           <Title />
           <Description />
-          <ArgTypes />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Use <code>CharacterCount</code> when you need a textarea with a
+            live count message. Pass a required <code>label</code> and{' '}
+            <code>name</code>, then choose either <code>maxLength</code> for a
+            character limit or <code>maxWords</code> for a word limit.
+          </p>
+          <p>
+            Use <code>threshold</code> when you want the visible status message
+            to stay hidden until the user gets close to the limit, and use{' '}
+            <code>rows</code> to control the initial textarea height.
+          </p>
+          <Source code={characterCountUsageExample} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes
+            of={Default}
+            include={[
+              'label',
+              'hint',
+              'errorMessage',
+              'name',
+              'maxLength',
+              'maxWords',
+              'threshold',
+              'rows',
+              'describedBy',
+            ]}
+          />
+
           <Stories title="Examples" />
         </>
       ),
@@ -33,40 +73,67 @@ const meta: Meta<typeof CharacterCount> = {
     label: {
       control: 'text',
       description: 'Question or field label shown above the textarea.',
+      table: {
+        category: 'CharacterCountProps',
+      },
     },
     hint: {
       control: 'text',
       description: 'Optional supporting text shown below the label and above the count message.',
+      table: {
+        category: 'CharacterCountProps',
+      },
     },
     errorMessage: {
       control: 'text',
       description:
         'Validation message shown above the textarea. This is separate from the automatic over-limit count status.',
+      table: {
+        category: 'CharacterCountProps',
+      },
     },
     name: {
       control: 'text',
       description: 'HTML name submitted with the form.',
+      table: {
+        category: 'CharacterCountProps',
+      },
     },
     maxLength: {
       control: 'number',
       description: 'Character limit before the count message switches to an over-limit state.',
+      table: {
+        category: 'CharacterCountProps',
+      },
     },
     maxWords: {
       control: 'number',
       description: 'Word limit when using word-count mode instead of character-count mode.',
+      table: {
+        category: 'CharacterCountProps',
+      },
     },
     threshold: {
       control: 'number',
       description: 'Percentage of the limit at which the visible status message appears.',
+      table: {
+        category: 'CharacterCountProps',
+      },
     },
     rows: {
       control: 'number',
       description: 'Visible row count for the underlying textarea.',
+      table: {
+        category: 'CharacterCountProps',
+      },
     },
     describedBy: {
       control: 'text',
       description:
         'Additional element IDs to append to the component-generated `aria-describedby` value.',
+      table: {
+        category: 'CharacterCountProps',
+      },
     },
     countMessageClassName: {
       control: false,
@@ -107,12 +174,30 @@ export const Default: Story = {
 
 export const Builder: Story = {
   args: {
+    describedBy: '',
+    errorMessage: '',
     hint: 'Do not include personal details.',
     label: 'Summary',
     maxLength: 200,
+    maxWords: undefined,
     name: 'summary',
+    rows: 5,
+    threshold: 0,
   },
   parameters: {
+    controls: {
+      include: [
+        'label',
+        'hint',
+        'errorMessage',
+        'name',
+        'maxLength',
+        'maxWords',
+        'threshold',
+        'rows',
+        'describedBy',
+      ],
+    },
     docs: {
       description: {
         story:

--- a/packages/react-components/src/components/Checkboxes/Checkboxes.stories.tsx
+++ b/packages/react-components/src/components/Checkboxes/Checkboxes.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { ArgTypes, Description, Stories, Title } from '@storybook/addon-docs/blocks';
+import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import { TextInput } from '../TextInput';
 import { Checkboxes, type CheckboxesProps } from './Checkboxes';
 
@@ -89,15 +89,60 @@ const checkboxItemSets: Record<
   exclusive: exclusiveItems,
 };
 
+const checkboxesUsageExample = `import { Checkboxes } from '@ourfuturehealth/react-components';
+
+const items = [
+  { value: 'email', label: 'Email', exclusiveGroup: 'contact' },
+  { value: 'phone', label: 'Phone', exclusiveGroup: 'contact' },
+  { divider: 'or' },
+  {
+    value: 'none',
+    label: 'No, I do not want to be contacted',
+    exclusive: true,
+    exclusiveGroup: 'contact',
+  },
+];
+
+<Checkboxes
+  hint="Select all contact methods that apply."
+  items={items}
+  legend="How should we contact you?"
+  name="contact-method"
+/>;
+`;
+
+const checkboxItemsShapeExample = `type CheckboxItem =
+  | {
+      value: string | number;
+      label: React.ReactNode;
+      hint?: React.ReactNode;
+      checked?: boolean;
+      disabled?: boolean;
+      exclusive?: boolean;
+      exclusiveGroup?: string;
+      conditional?: React.ReactNode;
+      inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+    }
+  | {
+      divider: React.ReactNode;
+    };
+`;
+
 const renderCheckboxesBuilderStory = ({
   itemSet,
   ...args
 }: CheckboxesStoryArgs) => {
   const items = itemSet ? checkboxItemSets[itemSet] : args.items ?? contactItems;
+  const resolvedArgs = {
+    ...args,
+    describedBy: args.describedBy || undefined,
+    errorMessage: args.errorMessage || undefined,
+    hint: args.hint || undefined,
+  };
 
   return (
     <Checkboxes
-      {...args}
+      {...resolvedArgs}
       items={items}
     />
   );
@@ -118,7 +163,53 @@ const meta: Meta<CheckboxesStoryArgs> = {
         <>
           <Title />
           <Description />
-          <ArgTypes exclude={['itemSet']} />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Pass a required <code>legend</code>, <code>name</code>, and an{' '}
+            <code>items</code> array. Each item becomes one checkbox row, and
+            you can add a divider row where the list needs a visual break.
+          </p>
+          <p>
+            Use <code>hint</code> for group-level guidance,{' '}
+            <code>errorMessage</code> for validation feedback, and use{' '}
+            <code>idPrefix</code> when you want predictable generated IDs for
+            the inputs and any conditional content.
+          </p>
+          <Source code={checkboxesUsageExample} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes
+            of={Default}
+            include={[
+              'legend',
+              'hint',
+              'errorMessage',
+              'name',
+              'idPrefix',
+              'items',
+              'describedBy',
+              'isPageHeading',
+            ]}
+          />
+
+          <h2>
+            <code>items</code> shape
+          </h2>
+          <p>
+            Each entry in the <code>items</code> array is either a checkbox item
+            object or a divider row:
+          </p>
+          <Source code={checkboxItemsShapeExample} language="tsx" />
+
+          <h2>Storybook builder helpers</h2>
+          <p>
+            <code>itemSet</code> is only used by the Storybook{' '}
+            <code>Builder</code> story so you can switch between realistic
+            checkbox examples without editing the real <code>items</code> prop.
+            It is not a React prop accepted by <code>Checkboxes</code>.
+          </p>
+
           <Stories title="Examples" />
         </>
       ),
@@ -142,22 +233,37 @@ const meta: Meta<CheckboxesStoryArgs> = {
     legend: {
       control: 'text',
       description: 'Question shown as the fieldset legend for the checkbox group.',
+      table: {
+        category: 'CheckboxesProps',
+      },
     },
     hint: {
       control: 'text',
       description: 'Optional supporting text shown below the legend and above any error message.',
+      table: {
+        category: 'CheckboxesProps',
+      },
     },
     errorMessage: {
       control: 'text',
       description: 'Validation message shown above the checkbox items. When present, the fieldset is linked with `aria-describedby`.',
+      table: {
+        category: 'CheckboxesProps',
+      },
     },
     name: {
       control: 'text',
       description: 'HTML name used for each checkbox input in the group.',
+      table: {
+        category: 'CheckboxesProps',
+      },
     },
     idPrefix: {
       control: 'text',
       description: 'Optional prefix used when generating checkbox IDs.',
+      table: {
+        category: 'CheckboxesProps',
+      },
     },
     items: {
       control: false,
@@ -168,16 +274,23 @@ const meta: Meta<CheckboxesStoryArgs> = {
           detail:
             "{ value: string | number; label: ReactNode; hint?: ReactNode; checked?: boolean; disabled?: boolean; exclusive?: boolean; exclusiveGroup?: string; conditional?: ReactNode; inputProps?: InputHTMLAttributes<HTMLInputElement> }[] | { divider: ReactNode }[]",
         },
+        category: 'CheckboxesProps',
       },
     },
     describedBy: {
       control: 'text',
       description: 'Additional element IDs to append to the component-generated `aria-describedby` value.',
+      table: {
+        category: 'CheckboxesProps',
+      },
     },
     isPageHeading: {
       control: 'boolean',
       description:
         'Wrap the legend content in an `h1` when this question is also the page heading.',
+      table: {
+        category: 'CheckboxesProps',
+      },
     },
     onChange: {
       control: false,
@@ -249,8 +362,11 @@ export const Default: Story = {
 
 export const Builder: Story = {
   args: {
+    describedBy: '',
+    errorMessage: '',
     hint: 'Select all contact methods that apply.',
     idPrefix: 'contact-method-builder',
+    isPageHeading: false,
     itemSet: 'contact',
     legend: 'How should we contact you?',
     name: 'contact-method-builder',

--- a/packages/react-components/src/components/Checkboxes/Checkboxes.stories.tsx
+++ b/packages/react-components/src/components/Checkboxes/Checkboxes.stories.tsx
@@ -1,8 +1,25 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Description, Stories, Title } from '@storybook/addon-docs/blocks';
 import { TextInput } from '../TextInput';
-import { Checkboxes } from './Checkboxes';
+import { Checkboxes, type CheckboxesProps } from './Checkboxes';
 
-const conditionalItems = [
+type CheckboxesStoryArgs = CheckboxesProps & {
+  itemSet?: 'contact' | 'conditional' | 'exclusive';
+};
+
+const contactItems: CheckboxesProps['items'] = [
+  { value: 'email', label: 'Email', exclusiveGroup: 'contact' },
+  { value: 'phone', label: 'Phone', exclusiveGroup: 'contact' },
+  { divider: 'or' as const },
+  {
+    value: 'none',
+    label: 'No, I do not want to be contacted',
+    exclusive: true,
+    exclusiveGroup: 'contact',
+  },
+];
+
+const conditionalItems: CheckboxesProps['items'] = [
   {
     value: 'email',
     label: 'Email',
@@ -38,7 +55,7 @@ const conditionalItems = [
   },
 ];
 
-const exclusiveItems = [
+const exclusiveItems: CheckboxesProps['items'] = [
   {
     value: 'sore-throat',
     label: 'Sore throat',
@@ -63,7 +80,30 @@ const exclusiveItems = [
   },
 ];
 
-const meta: Meta<typeof Checkboxes> = {
+const checkboxItemSets: Record<
+  NonNullable<CheckboxesStoryArgs['itemSet']>,
+  CheckboxesProps['items']
+> = {
+  contact: contactItems,
+  conditional: conditionalItems,
+  exclusive: exclusiveItems,
+};
+
+const renderCheckboxesBuilderStory = ({
+  itemSet,
+  ...args
+}: CheckboxesStoryArgs) => {
+  const items = itemSet ? checkboxItemSets[itemSet] : args.items ?? contactItems;
+
+  return (
+    <Checkboxes
+      {...args}
+      items={items}
+    />
+  );
+};
+
+const meta: Meta<CheckboxesStoryArgs> = {
   title: 'Components/Input/Checkboxes',
   component: Checkboxes,
   parameters: {
@@ -74,25 +114,31 @@ const meta: Meta<typeof Checkboxes> = {
         component:
           'A checkbox group that reuses the toolkit fieldset, input-family supporting text, updated 48px controllers, and conditional reveal patterns. Items can include hints, exclusive options, and conditional content that is revealed when selected.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+          <ArgTypes exclude={['itemSet']} />
+          <Stories title="Examples" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],
   args: {
-    items: [
-      { value: 'email', label: 'Email', exclusiveGroup: 'contact' },
-      { value: 'phone', label: 'Phone', exclusiveGroup: 'contact' },
-      { divider: 'or' as const },
-      {
-        value: 'none',
-        label: 'No, I do not want to be contacted',
-        exclusive: true,
-        exclusiveGroup: 'contact',
-      },
-    ],
     legend: 'How should we contact you?',
     name: 'contact-method',
   },
   argTypes: {
+    itemSet: {
+      control: 'select',
+      options: ['contact', 'conditional', 'exclusive'],
+      description:
+        'Builder-only Storybook helper. Switches between the contact, conditional, and exclusive checkbox presets.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
     legend: {
       control: 'text',
       description: 'Question shown as the fieldset legend for the checkbox group.',
@@ -176,6 +222,7 @@ const meta: Meta<typeof Checkboxes> = {
       },
     },
   },
+  render: renderCheckboxesBuilderStory,
 };
 
 export default meta;
@@ -185,7 +232,39 @@ export const Default: Story = {
   args: {
     hint: 'Select all contact methods that apply.',
     idPrefix: 'contact-method-default',
+    items: contactItems,
     name: 'contact-method-default',
+  },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story: 'Default contact-method checkbox group with an exclusive none option.',
+      },
+    },
+  },
+};
+
+export const Builder: Story = {
+  args: {
+    hint: 'Select all contact methods that apply.',
+    idPrefix: 'contact-method-builder',
+    itemSet: 'contact',
+    legend: 'How should we contact you?',
+    name: 'contact-method-builder',
+  },
+  parameters: {
+    controls: {
+      include: ['itemSet', 'legend', 'hint', 'errorMessage', 'name', 'idPrefix', 'isPageHeading'],
+    },
+    docs: {
+      description: {
+        story:
+          'Interactive checkbox example. Switch between the preset item sets and adjust the real group props without editing raw JSON.',
+      },
+    },
   },
 };
 
@@ -201,6 +280,9 @@ export const WithHint: Story = {
     name: 'contact-method-with-hint',
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story:
@@ -234,6 +316,9 @@ export const WithItemHints: Story = {
     name: 'contact-method-item-hints',
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story: 'Each checkbox item can carry its own hint text under the main label.',
@@ -251,6 +336,9 @@ export const ConditionalContent: Story = {
     name: 'contact-method-conditional',
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story:
@@ -269,6 +357,9 @@ export const WithExclusiveNoneOption: Story = {
     name: 'symptoms-exclusive-none',
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story:
@@ -286,6 +377,9 @@ export const WithError: Story = {
     name: 'contact-method-error',
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story: 'Example of a group-level validation error for checkbox questions.',

--- a/packages/react-components/src/components/DateInput/DateInput.stories.tsx
+++ b/packages/react-components/src/components/DateInput/DateInput.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { ArgTypes, Description, Stories, Title } from '@storybook/addon-docs/blocks';
+import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import { DateInput, type DateInputProps } from './DateInput';
 
 type DateInputStoryArgs = DateInputProps & {
@@ -86,15 +86,52 @@ const dateInputItemSets: Record<
   'page-heading': pageHeadingItems,
 };
 
+const dateInputUsageExample = `import { DateInput } from '@ourfuturehealth/react-components';
+
+const items = [
+  { name: 'day', inputWidth: 2 },
+  { name: 'month', inputWidth: 2 },
+  { name: 'year', inputWidth: 4 },
+];
+
+<DateInput
+  hint="For example, 31 3 1980"
+  id="date-of-birth"
+  items={items}
+  legend="What is your date of birth?"
+  namePrefix="date-of-birth"
+/>;
+`;
+
+const dateInputItemsShapeExample = `type DateInputItem = {
+  name: string;
+  label?: React.ReactNode;
+  inputWidth?: 2 | 3 | 4 | 5 | 10 | 20 | 30;
+  hasError?: boolean;
+  autoComplete?: string;
+  inputMode?: string;
+  pattern?: string;
+  defaultValue?: string;
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+  className?: string;
+};
+`;
+
 const renderDateInputBuilderStory = ({
   itemSet,
   ...args
 }: DateInputStoryArgs) => {
   const items = itemSet ? dateInputItemSets[itemSet] : args.items ?? defaultItems;
+  const resolvedArgs = {
+    ...args,
+    describedBy: args.describedBy || undefined,
+    errorMessage: args.errorMessage || undefined,
+    hint: args.hint || undefined,
+  };
 
   return (
     <DateInput
-      {...args}
+      {...resolvedArgs}
       items={items}
     />
   );
@@ -115,7 +152,52 @@ const meta: Meta<DateInputStoryArgs> = {
         <>
           <Title />
           <Description />
-          <ArgTypes exclude={['itemSet']} />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Pass a required <code>legend</code>, <code>id</code>, and{' '}
+            <code>namePrefix</code>. The component renders a grouped day, month,
+            and year input by default.
+          </p>
+          <p>
+            Pass a custom <code>items</code> array only when you need to change
+            one of the child fields, for example to add browser autocomplete
+            tokens, per-field error styling, or a different input width.
+          </p>
+          <Source code={dateInputUsageExample} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes
+            of={Default}
+            include={[
+              'legend',
+              'hint',
+              'errorMessage',
+              'id',
+              'namePrefix',
+              'describedBy',
+              'isPageHeading',
+              'items',
+            ]}
+          />
+
+          <h2>
+            <code>items</code> shape
+          </h2>
+          <p>
+            Each entry in the optional <code>items</code> array follows this
+            shape:
+          </p>
+          <Source code={dateInputItemsShapeExample} language="tsx" />
+
+          <h2>Storybook builder helpers</h2>
+          <p>
+            <code>itemSet</code> is only used by the Storybook{' '}
+            <code>Builder</code> story so you can switch between realistic date
+            input presets without editing the real <code>items</code> prop. It
+            is not a React prop accepted by <code>DateInput</code>.
+          </p>
+
           <Stories title="Examples" />
         </>
       ),
@@ -140,31 +222,52 @@ const meta: Meta<DateInputStoryArgs> = {
     legend: {
       control: 'text',
       description: 'Question shown as the fieldset legend for the grouped date fields.',
+      table: {
+        category: 'DateInputProps',
+      },
     },
     hint: {
       control: 'text',
       description: 'Optional supporting text shown below the legend and above any error message.',
+      table: {
+        category: 'DateInputProps',
+      },
     },
     errorMessage: {
       control: 'text',
       description: 'Validation message shown above the date fields. When present, the fieldset is linked with `aria-describedby`.',
+      table: {
+        category: 'DateInputProps',
+      },
     },
     id: {
       control: 'text',
       description: 'Base ID used for the group and for generated child field IDs.',
+      table: {
+        category: 'DateInputProps',
+      },
     },
     namePrefix: {
       control: 'text',
       description: 'Prefix applied to each child input name, such as `date-of-birth-day` and `date-of-birth-month`.',
+      table: {
+        category: 'DateInputProps',
+      },
     },
     describedBy: {
       control: 'text',
       description: 'Additional element IDs to append to the component-generated `aria-describedby` value.',
+      table: {
+        category: 'DateInputProps',
+      },
     },
     isPageHeading: {
       control: 'boolean',
       description:
         'Wrap the legend content in an `h1` when this question is also the page heading.',
+      table: {
+        category: 'DateInputProps',
+      },
     },
     items: {
       control: false,
@@ -176,6 +279,7 @@ const meta: Meta<DateInputStoryArgs> = {
           detail:
             "{ name: string; label?: ReactNode; inputWidth?: 2 | 3 | 4 | 5 | 10 | 20 | 30; hasError?: boolean; autoComplete?: string; inputMode?: string; pattern?: string; defaultValue?: string; inputProps?: InputHTMLAttributes<HTMLInputElement>; className?: string }[]",
         },
+        category: 'DateInputProps',
       },
     },
     className: {
@@ -249,8 +353,11 @@ export const Default: Story = {
 
 export const Builder: Story = {
   args: {
+    describedBy: '',
+    errorMessage: '',
     hint: 'For example, 31 3 1980',
     id: 'date-of-birth-builder',
+    isPageHeading: false,
     itemSet: 'default',
     legend: 'What is your date of birth?',
     namePrefix: 'date-of-birth-builder',

--- a/packages/react-components/src/components/DateInput/DateInput.stories.tsx
+++ b/packages/react-components/src/components/DateInput/DateInput.stories.tsx
@@ -1,7 +1,106 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { DateInput } from './DateInput';
+import { ArgTypes, Description, Stories, Title } from '@storybook/addon-docs/blocks';
+import { DateInput, type DateInputProps } from './DateInput';
 
-const meta: Meta<typeof DateInput> = {
+type DateInputStoryArgs = DateInputProps & {
+  itemSet?: 'default' | 'browser-autocomplete' | 'errors' | 'single-field-error' | 'page-heading';
+};
+
+const defaultItems: NonNullable<DateInputStoryArgs['items']> = [
+  {
+    name: 'day',
+    inputWidth: 2,
+  },
+  {
+    name: 'month',
+    inputWidth: 2,
+  },
+  {
+    name: 'year',
+    inputWidth: 4,
+  },
+];
+
+const browserAutocompleteItems: NonNullable<DateInputStoryArgs['items']> = [
+  {
+    name: 'day',
+    inputWidth: 2,
+    autoComplete: 'bday-day',
+  },
+  {
+    name: 'month',
+    inputWidth: 2,
+    autoComplete: 'bday-month',
+  },
+  {
+    name: 'year',
+    inputWidth: 4,
+    autoComplete: 'bday-year',
+  },
+];
+
+const errorItems: NonNullable<DateInputStoryArgs['items']> = [
+  {
+    name: 'day',
+    inputWidth: 2,
+    hasError: true,
+  },
+  {
+    name: 'month',
+    inputWidth: 2,
+    hasError: true,
+  },
+  {
+    name: 'year',
+    inputWidth: 4,
+    hasError: true,
+  },
+];
+
+const singleFieldErrorItems: NonNullable<DateInputStoryArgs['items']> = [
+  {
+    name: 'day',
+    inputWidth: 2,
+    hasError: true,
+  },
+  {
+    name: 'month',
+    inputWidth: 2,
+  },
+  {
+    name: 'year',
+    inputWidth: 4,
+  },
+];
+
+const pageHeadingItems: NonNullable<DateInputStoryArgs['items']> = defaultItems;
+
+const dateInputItemSets: Record<
+  NonNullable<DateInputStoryArgs['itemSet']>,
+  NonNullable<DateInputStoryArgs['items']>
+> = {
+  default: defaultItems,
+  'browser-autocomplete': browserAutocompleteItems,
+  errors: errorItems,
+  'single-field-error': singleFieldErrorItems,
+  'page-heading': pageHeadingItems,
+};
+
+const renderDateInputBuilderStory = ({
+  itemSet,
+  ...args
+}: DateInputStoryArgs) => {
+  const items = itemSet ? dateInputItemSets[itemSet] : args.items ?? defaultItems;
+
+  return (
+    <DateInput
+      {...args}
+      items={items}
+    />
+  );
+};
+
+const meta: Meta<DateInputStoryArgs> = {
   title: 'Components/Input/Date input',
   component: DateInput,
   parameters: {
@@ -12,6 +111,14 @@ const meta: Meta<typeof DateInput> = {
         component:
           'A grouped date input for day, month, and year fields. Use the default setup for a standard date-of-birth style question. Pass `items` only when you need to customise an individual field label, width, autocomplete token, or native input props.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+          <ArgTypes exclude={['itemSet']} />
+          <Stories title="Examples" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],
@@ -21,6 +128,15 @@ const meta: Meta<typeof DateInput> = {
     namePrefix: 'date-of-birth',
   },
   argTypes: {
+    itemSet: {
+      control: 'select',
+      options: ['default', 'browser-autocomplete', 'errors', 'single-field-error', 'page-heading'],
+      description:
+        'Builder-only Storybook helper. Switches between the default, autocomplete, error, and page-heading date presets.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
     legend: {
       control: 'text',
       description: 'Question shown as the fieldset legend for the grouped date fields.',
@@ -105,6 +221,7 @@ const meta: Meta<typeof DateInput> = {
       },
     },
   },
+  render: renderDateInputBuilderStory,
 };
 
 export default meta;
@@ -114,7 +231,40 @@ export const Default: Story = {
   args: {
     hint: 'For example, 31 3 1980',
     id: 'date-of-birth-default',
+    items: defaultItems,
     namePrefix: 'date-of-birth-default',
+  },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'Default date input for a standard date-of-birth question with the built-in day, month, and year fields.',
+      },
+    },
+  },
+};
+
+export const Builder: Story = {
+  args: {
+    hint: 'For example, 31 3 1980',
+    id: 'date-of-birth-builder',
+    itemSet: 'default',
+    legend: 'What is your date of birth?',
+    namePrefix: 'date-of-birth-builder',
+  },
+  parameters: {
+    controls: {
+      include: ['itemSet', 'legend', 'hint', 'errorMessage', 'id', 'namePrefix', 'isPageHeading'],
+    },
+    docs: {
+      description: {
+        story:
+          'Interactive date input example. Switch between the preset field configurations and adjust the real props without editing raw JSON.',
+      },
+    },
   },
 };
 
@@ -122,26 +272,13 @@ export const WithBrowserAutocomplete: Story = {
   args: {
     hint: 'For example, 31 3 1980',
     id: 'date-of-birth-browser-autocomplete',
-    items: [
-      {
-        name: 'day',
-        inputWidth: 2,
-        autoComplete: 'bday-day',
-      },
-      {
-        name: 'month',
-        inputWidth: 2,
-        autoComplete: 'bday-month',
-      },
-      {
-        name: 'year',
-        inputWidth: 4,
-        autoComplete: 'bday-year',
-      },
-    ],
+    items: browserAutocompleteItems,
     namePrefix: 'date-of-birth-browser-autocomplete',
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story:
@@ -156,26 +293,13 @@ export const WithErrors: Story = {
     errorMessage: 'Enter your date of birth',
     hint: 'For example, 31 3 1980',
     id: 'date-of-birth-errors',
-    items: [
-      {
-        name: 'day',
-        inputWidth: 2,
-        hasError: true,
-      },
-      {
-        name: 'month',
-        inputWidth: 2,
-        hasError: true,
-      },
-      {
-        name: 'year',
-        inputWidth: 4,
-        hasError: true,
-      },
-    ],
+    items: errorItems,
     namePrefix: 'date-of-birth-errors',
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story:
@@ -190,24 +314,13 @@ export const SingleFieldError: Story = {
     errorMessage: 'Enter your date of birth',
     hint: 'For example, 31 3 1980',
     id: 'date-of-birth-single-field-error',
-    items: [
-      {
-        name: 'day',
-        inputWidth: 2,
-        hasError: true,
-      },
-      {
-        name: 'month',
-        inputWidth: 2,
-      },
-      {
-        name: 'year',
-        inputWidth: 4,
-      },
-    ],
+    items: singleFieldErrorItems,
     namePrefix: 'date-of-birth-single-field-error',
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story:
@@ -222,9 +335,13 @@ export const AsPageHeading: Story = {
     hint: 'For example, 31 3 1980',
     id: 'date-of-birth-page-heading',
     isPageHeading: true,
+    items: pageHeadingItems,
     namePrefix: 'date-of-birth-page-heading',
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story:

--- a/packages/react-components/src/components/ErrorSummary/ErrorSummary.stories.tsx
+++ b/packages/react-components/src/components/ErrorSummary/ErrorSummary.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { ArgTypes, Description, Stories, Title } from '@storybook/addon-docs/blocks';
+import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import { TextInput } from '../TextInput';
 import { ErrorSummary, type ErrorSummaryProps } from './ErrorSummary';
 
@@ -47,18 +47,46 @@ const inFormList = [
   },
 ];
 
+const errorSummaryUsageExample = `import { ErrorSummary } from '@ourfuturehealth/react-components';
+
+const errorList = [
+  { text: 'Enter your first name', href: '#first-name' },
+  { text: 'Enter your last name', href: '#last-name' },
+];
+
+<ErrorSummary
+  descriptionText="Check each answer and update the fields that are highlighted below."
+  errorList={errorList}
+  titleText="There is a problem"
+/>;
+`;
+
+const errorListShapeExample = `type ErrorSummaryItem = {
+  href?: string;
+  text?: string;
+  html?: string;
+  attributes?: Record<string, string | number | boolean | null | undefined>;
+};
+`;
+
 const renderErrorSummaryBuilderStory = ({
   scenario,
   ...args
 }: ErrorSummaryStoryArgs) => {
+  const normalizedDescriptionText =
+    args.descriptionText === '' ? undefined : args.descriptionText;
+  const normalizedIdPrefix =
+    args.idPrefix === '' ? undefined : args.idPrefix;
+
   const resolvedArgs = (() => {
     switch (scenario) {
       case 'with-description':
         return {
           ...args,
           descriptionText:
-            args.descriptionText ??
+            normalizedDescriptionText ??
             'Check each answer and update the fields that are highlighted below.',
+          idPrefix: normalizedIdPrefix,
           errorList: args.errorList ?? defaultErrorList,
         };
       case 'multiple-errors':
@@ -66,8 +94,9 @@ const renderErrorSummaryBuilderStory = ({
           ...args,
           errorList: multipleErrorsList,
           descriptionText:
-            args.descriptionText ??
+            normalizedDescriptionText ??
             'Check each answer and update the fields that are highlighted below.',
+          idPrefix: normalizedIdPrefix,
         };
       case 'html-content':
         return {
@@ -76,17 +105,21 @@ const renderErrorSummaryBuilderStory = ({
           descriptionHtml:
             args.descriptionHtml ??
             'Review the <strong>highlighted answers</strong> and update each field before continuing.',
+          idPrefix: normalizedIdPrefix,
           errorList: htmlContentList,
         };
       case 'in-form':
         return {
           ...args,
+          idPrefix: normalizedIdPrefix,
           errorList: inFormList,
         };
       case 'default':
       default:
         return {
           ...args,
+          descriptionText: normalizedDescriptionText,
+          idPrefix: normalizedIdPrefix,
           errorList: args.errorList ?? defaultErrorList,
         };
     }
@@ -184,7 +217,48 @@ const meta: Meta<ErrorSummaryStoryArgs> = {
         <>
           <Title />
           <Description />
-          <ArgTypes exclude={['scenario']} />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Pass an <code>errorList</code> array and a heading through{' '}
+            <code>titleText</code>. Each error can link back to the relevant
+            field using <code>href</code>.
+          </p>
+          <p>
+            Add <code>descriptionText</code> when you want supporting guidance
+            below the heading. Use the HTML variants only when you need trusted
+            markup rather than plain text.
+          </p>
+          <Source code={errorSummaryUsageExample} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes
+            of={Default}
+            include={[
+              'titleText',
+              'descriptionText',
+              'errorList',
+              'idPrefix',
+              'className',
+            ]}
+          />
+
+          <h2>
+            <code>errorList</code> shape
+          </h2>
+          <p>
+            Each entry in the <code>errorList</code> array follows this shape:
+          </p>
+          <Source code={errorListShapeExample} language="tsx" />
+
+          <h2>Storybook builder helpers</h2>
+          <p>
+            <code>scenario</code> is only used by the Storybook{' '}
+            <code>Builder</code> story so you can switch between realistic error
+            summary examples without rebuilding the linked form markup by hand.
+            It is not a React prop accepted by <code>ErrorSummary</code>.
+          </p>
+
           <Stories title="Examples" />
         </>
       ),
@@ -205,6 +279,9 @@ const meta: Meta<ErrorSummaryStoryArgs> = {
       control: 'text',
       description:
         'Plain text heading content for the summary. Ignored if `titleHtml` is provided.',
+      table: {
+        category: 'ErrorSummaryProps',
+      },
     },
     titleHtml: {
       control: false,
@@ -218,6 +295,9 @@ const meta: Meta<ErrorSummaryStoryArgs> = {
       control: 'text',
       description:
         'Optional supporting text shown below the heading. Ignored if `descriptionHtml` is provided.',
+      table: {
+        category: 'ErrorSummaryProps',
+      },
     },
     descriptionHtml: {
       control: false,
@@ -228,7 +308,7 @@ const meta: Meta<ErrorSummaryStoryArgs> = {
       },
     },
     errorList: {
-      control: 'object',
+      control: false,
       description:
         'List of linked or unlinked errors shown in the summary. Each item supports `href`, `text`, `html`, and `attributes`. In stories that render linked fields, keep each `href` aligned with the field ids shown in the story.',
       table: {
@@ -236,6 +316,7 @@ const meta: Meta<ErrorSummaryStoryArgs> = {
           summary:
             'Array<{ href?: string; text?: string; html?: string; attributes?: Record<string, string | number | boolean | null | undefined> }>',
         },
+        category: 'ErrorSummaryProps',
       },
     },
     classes: {
@@ -266,6 +347,9 @@ const meta: Meta<ErrorSummaryStoryArgs> = {
       control: 'text',
       description:
         'Optional prefix used to generate the title id referenced by `aria-labelledby`. Use this when rendering more than one error summary on the same page.',
+      table: {
+        category: 'ErrorSummaryProps',
+      },
     },
     ref: {
       control: false,
@@ -307,9 +391,15 @@ export const Default: Story = {
 
 export const Builder: Story = {
   args: {
+    descriptionText: '',
+    idPrefix: '',
     scenario: 'default',
+    titleText: 'There is a problem',
   },
   parameters: {
+    controls: {
+      include: ['scenario', 'titleText', 'descriptionText', 'idPrefix'],
+    },
     docs: {
       description: {
         story:

--- a/packages/react-components/src/components/ErrorSummary/ErrorSummary.stories.tsx
+++ b/packages/react-components/src/components/ErrorSummary/ErrorSummary.stories.tsx
@@ -130,7 +130,25 @@ const renderErrorSummaryBuilderStory = ({
       <ErrorSummary
         {...resolvedArgs}
         onClick={(event) => {
-          if (event.target instanceof Element && event.target.closest('a')) {
+          const anchor =
+            event.target instanceof Element
+              ? event.target.closest<HTMLAnchorElement>('a[href]')
+              : null;
+
+          if (anchor === null) {
+            return;
+          }
+
+          const href = anchor.getAttribute('href') || '';
+
+          if (!href.startsWith('#')) {
+            event.preventDefault();
+            return;
+          }
+
+          const targetId = href.slice(1);
+
+          if (targetId === '' || document.getElementById(targetId) === null) {
             event.preventDefault();
           }
         }}

--- a/packages/react-components/src/components/ErrorSummary/ErrorSummary.stories.tsx
+++ b/packages/react-components/src/components/ErrorSummary/ErrorSummary.stories.tsx
@@ -1,6 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Description, Stories, Title } from '@storybook/addon-docs/blocks';
 import { TextInput } from '../TextInput';
-import { ErrorSummary } from './ErrorSummary';
+import { ErrorSummary, type ErrorSummaryProps } from './ErrorSummary';
+
+type ErrorSummaryStoryArgs = ErrorSummaryProps & {
+  scenario?: 'default' | 'with-description' | 'multiple-errors' | 'html-content' | 'in-form';
+};
 
 const defaultErrorList = [
   {
@@ -42,21 +47,132 @@ const inFormList = [
   },
 ];
 
-const meta: Meta<typeof ErrorSummary> = {
-  title: 'Components/ErrorSummary',
-  component: ErrorSummary,
-  render: (args) => (
+const renderErrorSummaryBuilderStory = ({
+  scenario,
+  ...args
+}: ErrorSummaryStoryArgs) => {
+  const resolvedArgs = (() => {
+    switch (scenario) {
+      case 'with-description':
+        return {
+          ...args,
+          descriptionText:
+            args.descriptionText ??
+            'Check each answer and update the fields that are highlighted below.',
+          errorList: args.errorList ?? defaultErrorList,
+        };
+      case 'multiple-errors':
+        return {
+          ...args,
+          errorList: multipleErrorsList,
+          descriptionText:
+            args.descriptionText ??
+            'Check each answer and update the fields that are highlighted below.',
+        };
+      case 'html-content':
+        return {
+          ...args,
+          titleHtml: args.titleHtml ?? '<span>There is a problem</span>',
+          descriptionHtml:
+            args.descriptionHtml ??
+            'Review the <strong>highlighted answers</strong> and update each field before continuing.',
+          errorList: htmlContentList,
+        };
+      case 'in-form':
+        return {
+          ...args,
+          errorList: inFormList,
+        };
+      case 'default':
+      default:
+        return {
+          ...args,
+          errorList: args.errorList ?? defaultErrorList,
+        };
+    }
+  })();
+
+  return (
     <div style={{ maxWidth: '40rem' }}>
       <ErrorSummary
-        {...args}
+        {...resolvedArgs}
         onClick={(event) => {
           if (event.target instanceof Element && event.target.closest('a')) {
             event.preventDefault();
           }
         }}
       />
+      {scenario === 'multiple-errors' ? (
+        <form>
+          <TextInput
+            id="multiple-errors-first-name"
+            label="First name"
+            error="Enter your first name"
+          />
+          <div style={{ height: '24rem' }} />
+          <TextInput
+            id="multiple-errors-last-name"
+            label="Last name"
+            error="Enter your last name"
+          />
+        </form>
+      ) : null}
+      {scenario === 'html-content' ? (
+        <form>
+          <TextInput
+            id="html-content-email"
+            label="Email address"
+            error="Email address is required"
+          />
+          <TextInput
+            id="html-content-phone"
+            label="Phone number"
+            error="Phone number must include 11 digits"
+          />
+        </form>
+      ) : null}
+      {scenario === 'in-form' ? (
+        <form noValidate>
+          <TextInput
+            id="in-form-email"
+            label="Email address"
+            type="email"
+            hint="We will use this to send updates about your application."
+            defaultValue="alex@example.com"
+          />
+          <TextInput
+            id="in-form-first-name"
+            label="First name"
+            hint="Enter your given name."
+            error="Enter your first name"
+          />
+          <TextInput
+            id="in-form-phone"
+            label="Phone number"
+            type="tel"
+            hint="Optional. Include this if you want SMS updates."
+          />
+          <TextInput
+            id="in-form-last-name"
+            label="Last name"
+            hint="Enter your family name."
+            error="Enter your last name"
+          />
+          <TextInput
+            id="in-form-postcode"
+            label="Postcode"
+            hint="For example, SW1A 1AA."
+            width="one-half"
+          />
+        </form>
+      ) : null}
     </div>
-  ),
+  );
+};
+
+const meta: Meta<ErrorSummaryStoryArgs> = {
+  title: 'Components/ErrorSummary',
+  component: ErrorSummary,
   parameters: {
     layout: 'padded',
     docs: {
@@ -64,10 +180,27 @@ const meta: Meta<typeof ErrorSummary> = {
         component:
           'Use the Error Summary component to summarise validation errors at the top of a page and link each error back to the relevant answer. `titleHtml` replaces `titleText`, and `descriptionHtml` replaces `descriptionText`. Use `idPrefix` when you need more than one summary on the same page so each summary gets a unique heading id.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+          <ArgTypes exclude={['scenario']} />
+          <Stories title="Examples" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],
   argTypes: {
+    scenario: {
+      control: 'select',
+      options: ['default', 'with-description', 'multiple-errors', 'html-content', 'in-form'],
+      description:
+        'Builder-only Storybook helper. Switches between the common error-summary example shapes.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
     titleText: {
       control: 'text',
       description:
@@ -147,13 +280,22 @@ const meta: Meta<typeof ErrorSummary> = {
     titleText: 'There is a problem',
     errorList: defaultErrorList,
   },
+  render: renderErrorSummaryBuilderStory,
 };
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  args: {
+    titleText: 'There is a problem',
+    errorList: defaultErrorList,
+    scenario: 'default',
+  },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story:
@@ -163,12 +305,32 @@ export const Default: Story = {
   },
 };
 
+export const Builder: Story = {
+  args: {
+    scenario: 'default',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Interactive error-summary example. Switch between the common summary shapes and edit the real props without rebuilding the example by hand.',
+      },
+    },
+  },
+};
+
 export const WithDescription: Story = {
   args: {
     descriptionText:
       'Check each answer and update the fields that are highlighted below.',
+    scenario: 'with-description',
+    errorList: defaultErrorList,
+    titleText: 'There is a problem',
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story:
@@ -181,6 +343,8 @@ export const WithDescription: Story = {
 export const MultipleErrors: Story = {
   args: {
     errorList: multipleErrorsList,
+    scenario: 'multiple-errors',
+    titleText: 'There is a problem',
   },
   parameters: {
     controls: {
@@ -219,6 +383,7 @@ export const HtmlContent: Story = {
     descriptionHtml:
       'Review the <strong>highlighted answers</strong> and update each field before continuing.',
     errorList: htmlContentList,
+    scenario: 'html-content',
   },
   parameters: {
     controls: {
@@ -253,6 +418,8 @@ export const HtmlContent: Story = {
 export const InForm: Story = {
   args: {
     errorList: inFormList,
+    scenario: 'in-form',
+    titleText: 'There is a problem',
   },
   parameters: {
     controls: {

--- a/packages/react-components/src/components/Fieldset/Fieldset.stories.tsx
+++ b/packages/react-components/src/components/Fieldset/Fieldset.stories.tsx
@@ -138,6 +138,12 @@ export const Default: Story = {
     legend: 'Contact details',
     legendSize: 'medium',
   },
+  render: (args) => (
+    <Fieldset {...args}>
+      <TextInput label="Email address" type="email" width="three-quarters" />
+      <TextInput label="Phone number" type="tel" width="two-thirds" />
+    </Fieldset>
+  ),
   parameters: {
     controls: {
       disable: true,
@@ -183,7 +189,27 @@ export const AsPageHeading: Story = {
     isPageHeading: true,
     legendSize: 'large',
   },
-  render: (args) => <Fieldset {...args} />,
+  render: (args) => (
+    <Fieldset {...args}>
+      <TextInput
+        label={
+          <>
+            Building and street{' '}
+            <span className="ofh-u-visually-hidden">line 1 of 2</span>
+          </>
+        }
+      />
+      <TextInput
+        label={
+          <span className="ofh-u-visually-hidden">
+            Building and street line 2 of 2
+          </span>
+        }
+      />
+      <TextInput label="Town or city" width="two-thirds" />
+      <TextInput inputWidth={10} label="Postcode" />
+    </Fieldset>
+  ),
   parameters: {
     controls: {
       disable: true,
@@ -191,7 +217,7 @@ export const AsPageHeading: Story = {
     docs: {
       description: {
         story:
-          'Use `isPageHeading` when the fieldset question is also the page heading. This mirrors the docs-site example where the legend is the page heading and no extra grouped content is needed yet.',
+          'Use `isPageHeading` when the fieldset question is also the page heading. This shows the grouped address fields under a page-heading legend.',
       },
     },
   },

--- a/packages/react-components/src/components/Fieldset/Fieldset.stories.tsx
+++ b/packages/react-components/src/components/Fieldset/Fieldset.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Description, Stories, Title } from '@storybook/addon-docs/blocks';
 import { TextInput } from '../TextInput';
 import { Fieldset } from './Fieldset';
 
@@ -12,6 +13,14 @@ const meta: Meta<typeof Fieldset> = {
         component:
           'A semantic fieldset wrapper for grouped form questions. Use it when several inputs belong to the same question and supply the question text through the legend.\n\nThe React component mirrors the toolkit fieldset macro while smoothing over the toolkit class names:\n- `legend` supplies the legend content and accepts plain text or richer React nodes.\n- `legendSize` applies the built-in legend hierarchy with friendly values: `none`, `small`, `medium`, `large`, and `extraLarge`.\n- `isPageHeading` wraps that legend content in an `h1` when the grouped question is also the page heading.\n- `describedBy` appends external hint or error IDs to the fieldset `aria-describedby` attribute.\n- Native fieldset attributes such as `id`, `role`, `disabled`, and data attributes pass through to the underlying `<fieldset>`.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+          <ArgTypes />
+          <Stories title="Examples" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],
@@ -89,6 +98,24 @@ export const Default: Story = {
     legend: 'Contact details',
     legendSize: 'medium',
   },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'Use a standard legend when the page already has its own heading and the fieldset is grouping a smaller set of related inputs within that page.',
+      },
+    },
+  },
+};
+
+export const Builder: Story = {
+  args: {
+    legend: 'Contact details',
+    legendSize: 'medium',
+  },
   render: (args) => (
     <Fieldset {...args}>
       <TextInput label="Email address" type="email" width="three-quarters" />
@@ -99,7 +126,7 @@ export const Default: Story = {
     docs: {
       description: {
         story:
-          'Use a standard legend when the page already has its own heading and the fieldset is grouping a smaller set of related inputs within that page.',
+          'Interactive fieldset example. Change the real props to see how the legend, page-heading state, and legend size affect the grouped inputs.',
       },
     },
   },
@@ -113,6 +140,9 @@ export const AsPageHeading: Story = {
   },
   render: (args) => <Fieldset {...args} />,
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story:
@@ -216,6 +246,9 @@ export const WithDescribedBy: Story = {
     </div>
   ),
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story:

--- a/packages/react-components/src/components/Fieldset/Fieldset.stories.tsx
+++ b/packages/react-components/src/components/Fieldset/Fieldset.stories.tsx
@@ -1,7 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { ArgTypes, Description, Stories, Title } from '@storybook/addon-docs/blocks';
+import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import { TextInput } from '../TextInput';
 import { Fieldset } from './Fieldset';
+
+const fieldsetUsageExample = `import { Fieldset, TextInput } from '@ourfuturehealth/react-components';
+
+<Fieldset
+  legend="Contact details"
+  legendSize="medium"
+>
+  <TextInput label="Email address" type="email" width="three-quarters" />
+  <TextInput label="Phone number" type="tel" width="two-thirds" />
+</Fieldset>;
+`;
 
 const meta: Meta<typeof Fieldset> = {
   title: 'Components/Fieldset',
@@ -17,7 +28,32 @@ const meta: Meta<typeof Fieldset> = {
         <>
           <Title />
           <Description />
-          <ArgTypes />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Use <code>Fieldset</code> when several inputs belong to the same
+            question. Pass the question text through <code>legend</code>, then
+            render the grouped fields as <code>children</code>.
+          </p>
+          <p>
+            Use <code>legendSize</code> when the grouped question needs a
+            stronger heading treatment, and use <code>isPageHeading</code> when
+            the legend should also be announced as the page heading.
+          </p>
+          <Source code={fieldsetUsageExample} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes
+            of={Default}
+            include={[
+              'legend',
+              'describedBy',
+              'isPageHeading',
+              'legendSize',
+              'className',
+            ]}
+          />
+
           <Stories title="Examples" />
         </>
       ),
@@ -35,6 +71,7 @@ const meta: Meta<typeof Fieldset> = {
         type: {
           summary: 'ReactNode',
         },
+        category: 'FieldsetProps',
       },
     },
     describedBy: {
@@ -45,6 +82,7 @@ const meta: Meta<typeof Fieldset> = {
         type: {
           summary: 'string',
         },
+        category: 'FieldsetProps',
       },
     },
     isPageHeading: {
@@ -55,6 +93,7 @@ const meta: Meta<typeof Fieldset> = {
         type: {
           summary: 'boolean',
         },
+        category: 'FieldsetProps',
       },
     },
     legendSize: {
@@ -66,6 +105,7 @@ const meta: Meta<typeof Fieldset> = {
         type: {
           summary: "'none' | 'small' | 'medium' | 'large' | 'extraLarge'",
         },
+        category: 'FieldsetProps',
       },
     },
     children: {
@@ -113,6 +153,8 @@ export const Default: Story = {
 
 export const Builder: Story = {
   args: {
+    describedBy: '',
+    isPageHeading: false,
     legend: 'Contact details',
     legendSize: 'medium',
   },
@@ -123,6 +165,9 @@ export const Builder: Story = {
     </Fieldset>
   ),
   parameters: {
+    controls: {
+      include: ['legend', 'describedBy', 'isPageHeading', 'legendSize'],
+    },
     docs: {
       description: {
         story:

--- a/packages/react-components/src/components/Icon/Icon.stories.tsx
+++ b/packages/react-components/src/components/Icon/Icon.stories.tsx
@@ -1,10 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import iconManifest from '@ourfuturehealth/toolkit/assets/icons/manifest.json';
 import { Icon } from './Icon';
 
 const iconNameOptions = iconManifest.icons
   .map(({ name }) => name)
   .sort((left, right) => left.localeCompare(right));
+
+const iconUsageExample = `import { Icon } from '@ourfuturehealth/react-components';
+
+<Icon
+  name="Check"
+  size={24}
+/>;
+`;
 
 const meta: Meta<typeof Icon> = {
   title: 'Components/Icon',
@@ -16,6 +25,33 @@ const meta: Meta<typeof Icon> = {
         component:
           'Use Icon to render toolkit icons in React. Choose exactly one sizing mode: `size` for a fixed 16/24/32 icon, or `responsiveSize` to follow the toolkit iconography scale. The responsive scale maps `16` to `16/16/16`, `24` to `16/16/24`, and `32` to `24/24/32` across mobile, tablet, and desktop. Leave `title` empty for decorative icons. Any other SVG props, such as `aria-*`, `data-*`, or event handlers, are passed straight to the rendered `<svg>` element.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Use <code>Icon</code> to render one of the bundled toolkit icons in
+            React. Pass the icon <code>name</code> and choose one sizing mode:
+            fixed <code>size</code> or <code>responsiveSize</code>.
+          </p>
+          <p>
+            Leave <code>title</code> empty when the icon is decorative. Add a{' '}
+            <code>title</code> only when the icon needs to be announced as
+            meaningful content on its own.
+          </p>
+          <Source code={iconUsageExample} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes
+            of={Default}
+            include={['name', 'size', 'responsiveSize', 'title', 'color']}
+          />
+
+          <Stories title="Examples" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],
@@ -25,28 +61,43 @@ const meta: Meta<typeof Icon> = {
       options: iconNameOptions,
       description:
         'Toolkit icon name from the generated manifest. This maps directly to bundled toolkit icon data in the React package.',
+      table: {
+        category: 'IconProps',
+      },
     },
     size: {
       control: 'radio',
       options: [16, 24, 32],
       description:
         'Fixed icon size. Use this when the icon should stay at 16, 24, or 32 across every breakpoint. Mutually exclusive with `responsiveSize`.',
+      table: {
+        category: 'IconProps',
+      },
     },
     responsiveSize: {
       control: 'radio',
       options: [16, 24, 32],
       description:
         'Responsive icon size from the toolkit iconography scale. `16` stays 16 everywhere, `24` becomes 16/16/24, and `32` becomes 24/24/32 across mobile, tablet, and desktop. Mutually exclusive with `size`.',
+      table: {
+        category: 'IconProps',
+      },
     },
     title: {
       control: 'text',
       description:
         'Accessible label for meaningful standalone icons. When set, the icon renders with `role="img"`; leave it empty for decorative icons so it stays hidden from assistive technology.',
+      table: {
+        category: 'IconProps',
+      },
     },
     color: {
       control: 'color',
       description:
         'Optional color override applied through inline style. Use this for monochrome icons that should not inherit surrounding text colour.',
+      table: {
+        category: 'IconProps',
+      },
     },
     className: {
       control: false,
@@ -100,8 +151,11 @@ export const Default: Story = {
 
 export const Builder: Story = {
   args: {
+    color: '',
     name: 'Check',
+    responsiveSize: undefined,
     size: 24,
+    title: '',
   },
   parameters: {
     controls: {

--- a/packages/react-components/src/components/Icon/Icon.stories.tsx
+++ b/packages/react-components/src/components/Icon/Icon.stories.tsx
@@ -83,12 +83,48 @@ export default meta;
 
 type Story = StoryObj<typeof Icon>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'A realistic decorative icon example. Use it as the default copyable pattern when the icon is decorative and does not need an accessible label.',
+      },
+    },
+  },
+  render: () => <Icon name="Check" size={24} />,
+};
+
+export const Builder: Story = {
+  args: {
+    name: 'Check',
+    size: 24,
+  },
+  parameters: {
+    controls: {
+      include: ['name', 'size', 'responsiveSize', 'title', 'color'],
+    },
+    docs: {
+      description: {
+        story:
+          'Use the Builder story to try the icon API interactively. It is the quickest way to test icon names, sizes, labels, and tinting together.',
+      },
+    },
+  },
+};
 
 export const WithTitle: Story = {
   args: {
     name: 'UnfoldMore',
     title: 'Expand options',
+  },
+  parameters: {
+    controls: {
+      disable: true,
+    },
   },
 };
 
@@ -113,10 +149,13 @@ export const ResponsiveScale: Story = {
     responsiveSize: 24,
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story:
-          'Responsive icons follow the toolkit iconography scale instead of staying fixed. Resize the preview viewport to see `responsiveSize={24}` collapse to 16 on mobile and tablet, then return to 24 on desktop.',
+          'A fixed responsive-size example that shows the toolkit iconography scale collapsing and expanding at breakpoint boundaries.',
       },
     },
   },

--- a/packages/react-components/src/components/Icon/Icon.stories.tsx
+++ b/packages/react-components/src/components/Icon/Icon.stories.tsx
@@ -3,6 +3,13 @@ import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-
 import iconManifest from '@ourfuturehealth/toolkit/assets/icons/manifest.json';
 import { Icon } from './Icon';
 
+type IconSize = 16 | 24 | 32;
+
+type IconStoryArgs = React.ComponentProps<typeof Icon> & {
+  builderSize?: IconSize;
+  sizingMode?: 'fixed' | 'responsive';
+};
+
 const iconNameOptions = iconManifest.icons
   .map(({ name }) => name)
   .sort((left, right) => left.localeCompare(right));
@@ -15,7 +22,27 @@ const iconUsageExample = `import { Icon } from '@ourfuturehealth/react-component
 />;
 `;
 
-const meta: Meta<typeof Icon> = {
+const renderIconBuilderStory = ({
+  builderSize = 24,
+  color,
+  name = 'Check',
+  sizingMode = 'fixed',
+  title,
+}: IconStoryArgs) => {
+  const sharedProps = {
+    color: color || undefined,
+    name,
+    title: title || undefined,
+  };
+
+  if (sizingMode === 'responsive') {
+    return <Icon {...sharedProps} responsiveSize={builderSize} />;
+  }
+
+  return <Icon {...sharedProps} size={builderSize} />;
+};
+
+const meta = {
   title: 'Components/Icon',
   component: Icon,
   parameters: {
@@ -48,6 +75,14 @@ const meta: Meta<typeof Icon> = {
             of={Default}
             include={['name', 'size', 'responsiveSize', 'title', 'color']}
           />
+
+          <h2>Storybook builder helpers</h2>
+          <p>
+            <code>sizingMode</code> and <code>builderSize</code> are only used
+            by the Storybook <code>Builder</code> story so you can try one
+            sizing approach at a time. They are not React props accepted by{' '}
+            <code>Icon</code>.
+          </p>
 
           <Stories title="Examples" />
         </>
@@ -99,6 +134,24 @@ const meta: Meta<typeof Icon> = {
         category: 'IconProps',
       },
     },
+    sizingMode: {
+      control: 'radio',
+      options: ['fixed', 'responsive'],
+      description:
+        'Storybook-only helper for the Builder story. Chooses whether the example drives the real `size` prop or the real `responsiveSize` prop.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
+    builderSize: {
+      control: 'radio',
+      options: [16, 24, 32],
+      description:
+        'Storybook-only helper for the Builder story. Sets the active fixed or responsive size value without exposing both sizing props at once.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
     className: {
       control: false,
       description:
@@ -128,11 +181,11 @@ const meta: Meta<typeof Icon> = {
     name: 'Check',
     size: 24,
   },
-};
+} satisfies Meta<IconStoryArgs>;
 
 export default meta;
 
-type Story = StoryObj<typeof Icon>;
+type Story = StoryObj<IconStoryArgs>;
 
 export const Default: Story = {
   parameters: {
@@ -151,15 +204,16 @@ export const Default: Story = {
 
 export const Builder: Story = {
   args: {
+    builderSize: 24,
     color: '',
     name: 'Check',
-    responsiveSize: undefined,
-    size: 24,
+    sizingMode: 'fixed',
     title: '',
   },
+  render: renderIconBuilderStory,
   parameters: {
     controls: {
-      include: ['name', 'size', 'responsiveSize', 'title', 'color'],
+      include: ['name', 'sizingMode', 'builderSize', 'title', 'color'],
     },
     docs: {
       description: {

--- a/packages/react-components/src/components/Radios/Radios.stories.tsx
+++ b/packages/react-components/src/components/Radios/Radios.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { ArgTypes, Description, Stories, Title } from '@storybook/addon-docs/blocks';
+import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import { TextInput } from '../TextInput';
 import { Radios, type RadiosProps } from './Radios';
 
@@ -72,12 +72,50 @@ const radioItemSets: Record<
   inline: inlineItems,
 };
 
+const radiosUsageExample = `import { Radios } from '@ourfuturehealth/react-components';
+
+const items = [
+  { value: 'email', label: 'Email' },
+  { value: 'phone', label: 'Phone' },
+  { divider: 'or' },
+  { value: 'post', label: 'Post' },
+];
+
+<Radios
+  hint="Choose one way for us to contact you."
+  items={items}
+  legend="How should we contact you?"
+  name="contact-method"
+/>;
+`;
+
+const radioItemsShapeExample = `type RadioItem =
+  | {
+      value: string | number;
+      label: React.ReactNode;
+      hint?: React.ReactNode;
+      checked?: boolean;
+      disabled?: boolean;
+      conditional?: React.ReactNode;
+      inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+    }
+  | {
+      divider: React.ReactNode;
+    };
+`;
+
 const renderRadiosBuilderStory = ({ itemSet, ...args }: RadiosStoryArgs) => {
   const items = itemSet ? radioItemSets[itemSet] : args.items ?? contactItems;
+  const resolvedArgs = {
+    ...args,
+    describedBy: args.describedBy || undefined,
+    errorMessage: args.errorMessage || undefined,
+    hint: args.hint || undefined,
+  };
 
   return (
     <Radios
-      {...args}
+      {...resolvedArgs}
       items={items}
     />
   );
@@ -98,7 +136,53 @@ const meta: Meta<RadiosStoryArgs> = {
         <>
           <Title />
           <Description />
-          <ArgTypes exclude={['itemSet']} />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Pass a required <code>legend</code>, <code>name</code>, and an{' '}
+            <code>items</code> array. Each item becomes one radio row, and you
+            can add a divider row where the list needs a visual break.
+          </p>
+          <p>
+            Use <code>hint</code> for group-level guidance,{' '}
+            <code>errorMessage</code> for validation feedback, and use{' '}
+            <code>idPrefix</code> when you want predictable generated IDs for
+            the inputs and any conditional content.
+          </p>
+          <Source code={radiosUsageExample} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes
+            of={Default}
+            include={[
+              'legend',
+              'hint',
+              'errorMessage',
+              'name',
+              'idPrefix',
+              'items',
+              'describedBy',
+              'isPageHeading',
+            ]}
+          />
+
+          <h2>
+            <code>items</code> shape
+          </h2>
+          <p>
+            Each entry in the <code>items</code> array is either a radio item
+            object or a divider row:
+          </p>
+          <Source code={radioItemsShapeExample} language="tsx" />
+
+          <h2>Storybook builder helpers</h2>
+          <p>
+            <code>itemSet</code> is only used by the Storybook{' '}
+            <code>Builder</code> story so you can switch between realistic radio
+            examples without editing the real <code>items</code> prop. It is not
+            a React prop accepted by <code>Radios</code>.
+          </p>
+
           <Stories title="Examples" />
         </>
       ),
@@ -122,22 +206,37 @@ const meta: Meta<RadiosStoryArgs> = {
     legend: {
       control: 'text',
       description: 'Question shown as the fieldset legend for the radio group.',
+      table: {
+        category: 'RadiosProps',
+      },
     },
     hint: {
       control: 'text',
       description: 'Optional supporting text shown below the legend and above any error message.',
+      table: {
+        category: 'RadiosProps',
+      },
     },
     errorMessage: {
       control: 'text',
       description: 'Validation message shown above the radio items. When present, the fieldset is linked with `aria-describedby`.',
+      table: {
+        category: 'RadiosProps',
+      },
     },
     name: {
       control: 'text',
       description: 'HTML name shared by all radio inputs in the group.',
+      table: {
+        category: 'RadiosProps',
+      },
     },
     idPrefix: {
       control: 'text',
       description: 'Optional prefix used when generating radio IDs.',
+      table: {
+        category: 'RadiosProps',
+      },
     },
     items: {
       control: false,
@@ -148,16 +247,23 @@ const meta: Meta<RadiosStoryArgs> = {
           detail:
             "{ value: string | number; label: ReactNode; hint?: ReactNode; checked?: boolean; disabled?: boolean; conditional?: ReactNode; inputProps?: InputHTMLAttributes<HTMLInputElement> }[] | { divider: ReactNode }[]",
         },
+        category: 'RadiosProps',
       },
     },
     describedBy: {
       control: 'text',
       description: 'Additional element IDs to append to the component-generated `aria-describedby` value.',
+      table: {
+        category: 'RadiosProps',
+      },
     },
     isPageHeading: {
       control: 'boolean',
       description:
         'Wrap the legend content in an `h1` when this question is also the page heading.',
+      table: {
+        category: 'RadiosProps',
+      },
     },
     onChange: {
       control: false,
@@ -229,8 +335,11 @@ export const Default: Story = {
 
 export const Builder: Story = {
   args: {
+    describedBy: '',
+    errorMessage: '',
     hint: 'Choose one way for us to contact you.',
     idPrefix: 'contact-method-builder',
+    isPageHeading: false,
     itemSet: 'contact',
     legend: 'How should we contact you?',
     name: 'contact-method-builder',

--- a/packages/react-components/src/components/Radios/Radios.stories.tsx
+++ b/packages/react-components/src/components/Radios/Radios.stories.tsx
@@ -1,8 +1,20 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Description, Stories, Title } from '@storybook/addon-docs/blocks';
 import { TextInput } from '../TextInput';
-import { Radios } from './Radios';
+import { Radios, type RadiosProps } from './Radios';
 
-const conditionalItems = [
+type RadiosStoryArgs = RadiosProps & {
+  itemSet?: 'contact' | 'conditional' | 'divider' | 'inline';
+};
+
+const contactItems: RadiosProps['items'] = [
+  { value: 'email', label: 'Email' },
+  { value: 'phone', label: 'Phone' },
+  { divider: 'or' as const },
+  { value: 'post', label: 'Post' },
+];
+
+const conditionalItems: RadiosProps['items'] = [
   {
     value: 'email',
     label: 'Email',
@@ -38,7 +50,40 @@ const conditionalItems = [
   },
 ];
 
-const meta: Meta<typeof Radios> = {
+const dividerItems: RadiosProps['items'] = [
+  { value: 'nhs-login', label: 'Use NHS login' },
+  { value: 'govuk-verify', label: 'Use GOV.UK Verify' },
+  { divider: 'or' as const },
+  { value: 'create-account', label: 'Create an account' },
+];
+
+const inlineItems: RadiosProps['items'] = [
+  { value: 'yes', label: 'Yes' },
+  { value: 'no', label: 'No' },
+];
+
+const radioItemSets: Record<
+  NonNullable<RadiosStoryArgs['itemSet']>,
+  RadiosProps['items']
+> = {
+  contact: contactItems,
+  conditional: conditionalItems,
+  divider: dividerItems,
+  inline: inlineItems,
+};
+
+const renderRadiosBuilderStory = ({ itemSet, ...args }: RadiosStoryArgs) => {
+  const items = itemSet ? radioItemSets[itemSet] : args.items ?? contactItems;
+
+  return (
+    <Radios
+      {...args}
+      items={items}
+    />
+  );
+};
+
+const meta: Meta<RadiosStoryArgs> = {
   title: 'Components/Input/Radios',
   component: Radios,
   parameters: {
@@ -49,20 +94,31 @@ const meta: Meta<typeof Radios> = {
         component:
           'A radio group that reuses the toolkit fieldset, input-family supporting text, updated 48px controllers, and conditional reveal patterns. Items can include hints or conditional content that is revealed for the selected option.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+          <ArgTypes exclude={['itemSet']} />
+          <Stories title="Examples" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],
   args: {
-    items: [
-      { value: 'email', label: 'Email' },
-      { value: 'phone', label: 'Phone' },
-      { divider: 'or' as const },
-      { value: 'post', label: 'Post' },
-    ],
     legend: 'How should we contact you?',
     name: 'contact-method',
   },
   argTypes: {
+    itemSet: {
+      control: 'select',
+      options: ['contact', 'conditional', 'divider', 'inline'],
+      description:
+        'Builder-only Storybook helper. Switches between the contact, conditional, divider, and inline radio presets.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
     legend: {
       control: 'text',
       description: 'Question shown as the fieldset legend for the radio group.',
@@ -146,6 +202,7 @@ const meta: Meta<typeof Radios> = {
       },
     },
   },
+  render: renderRadiosBuilderStory,
 };
 
 export default meta;
@@ -155,7 +212,39 @@ export const Default: Story = {
   args: {
     hint: 'Choose one way for us to contact you.',
     idPrefix: 'contact-method-default',
+    items: contactItems,
     name: 'contact-method-default',
+  },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story: 'Default contact-method radio group with a divider between contact options and the sign-in path.',
+      },
+    },
+  },
+};
+
+export const Builder: Story = {
+  args: {
+    hint: 'Choose one way for us to contact you.',
+    idPrefix: 'contact-method-builder',
+    itemSet: 'contact',
+    legend: 'How should we contact you?',
+    name: 'contact-method-builder',
+  },
+  parameters: {
+    controls: {
+      include: ['itemSet', 'legend', 'hint', 'errorMessage', 'name', 'idPrefix', 'isPageHeading'],
+    },
+    docs: {
+      description: {
+        story:
+          'Interactive radio example. Switch between the preset item sets and adjust the real group props without editing raw JSON.',
+      },
+    },
   },
 };
 
@@ -172,6 +261,9 @@ export const WithHint: Story = {
     name: 'nhs-number',
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story:
@@ -205,6 +297,9 @@ export const WithItemHints: Story = {
     name: 'contact-method-item-hints',
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story: 'Each radio item can carry its own hint text under the main label.',
@@ -226,6 +321,9 @@ export const WithDivider: Story = {
     name: 'sign-in-method-divider',
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story:
@@ -244,6 +342,9 @@ export const ConditionalContent: Story = {
     name: 'contact-method-conditional',
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story: 'Radio items can reveal conditional content for the currently selected option. This matches the docs-site example with email, phone, and text-message follow-up fields.',
@@ -264,6 +365,9 @@ export const Inline: Story = {
     name: 'age-inline',
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story: 'For short two-option choices, radios can be displayed inline to match the toolkit docs example.',
@@ -280,6 +384,9 @@ export const WithError: Story = {
     name: 'contact-method-error',
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story: 'Example of a group-level validation error for radio questions.',

--- a/packages/react-components/src/components/Select/Select.stories.tsx
+++ b/packages/react-components/src/components/Select/Select.stories.tsx
@@ -1,14 +1,119 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Select } from './Select';
+import { Select, type SelectProps } from './Select';
 
-const items = [
+type SelectItemSet = 'contact-methods' | 'contact-methods-selected' | 'countries';
+
+type SelectStoryArgs = SelectProps & {
+  itemSet?: SelectItemSet;
+};
+
+const contactMethodItems = [
   { value: '', text: 'Choose an option' },
   { value: 'email', text: 'Email' },
   { value: 'phone', text: 'Phone' },
   { value: 'text-message', text: 'Text message', disabled: true },
 ];
 
-const meta: Meta<typeof Select> = {
+const contactMethodSelectedItems = [
+  { value: '', text: 'Choose an option' },
+  { value: 'email', text: 'Email', selected: true },
+  { value: 'phone', text: 'Phone' },
+  { value: 'text-message', text: 'Text message', disabled: true },
+];
+
+const countryItems = [
+  { value: '', text: 'Choose a country' },
+  { value: 'england', text: 'England' },
+  { value: 'scotland', text: 'Scotland' },
+  { value: 'wales', text: 'Wales' },
+  { value: 'northern-ireland', text: 'Northern Ireland' },
+];
+
+const itemSets: Record<SelectItemSet, SelectProps['items']> = {
+  'contact-methods': contactMethodItems,
+  'contact-methods-selected': contactMethodSelectedItems,
+  countries: countryItems,
+};
+
+const defaultStoryCode = `import { Select } from '@ourfuturehealth/react-components';
+
+const contactMethodItems = [
+  { value: '', text: 'Choose an option' },
+  { value: 'email', text: 'Email' },
+  { value: 'phone', text: 'Phone' },
+  { value: 'text-message', text: 'Text message', disabled: true },
+];
+
+<Select
+  hint="Choose how you would like us to contact you."
+  items={contactMethodItems}
+  label="Preferred contact method"
+  name="contact-method"
+/>;
+`;
+
+const withErrorStoryCode = `import { Select } from '@ourfuturehealth/react-components';
+
+const contactMethodItems = [
+  { value: '', text: 'Choose an option' },
+  { value: 'email', text: 'Email' },
+  { value: 'phone', text: 'Phone' },
+  { value: 'text-message', text: 'Text message', disabled: true },
+];
+
+<Select
+  errorMessage="Select how you would like us to contact you"
+  items={contactMethodItems}
+  label="Preferred contact method"
+  name="contact-method"
+/>;
+`;
+
+const withSelectedOptionStoryCode = `import { Select } from '@ourfuturehealth/react-components';
+
+const contactMethodItems = [
+  { value: '', text: 'Choose an option' },
+  { value: 'email', text: 'Email', selected: true },
+  { value: 'phone', text: 'Phone' },
+  { value: 'text-message', text: 'Text message', disabled: true },
+];
+
+<Select
+  items={contactMethodItems}
+  label="Preferred contact method"
+  name="contact-method"
+/>;
+`;
+
+const asPageHeadingStoryCode = `import { Select } from '@ourfuturehealth/react-components';
+
+const countryItems = [
+  { value: '', text: 'Choose a country' },
+  { value: 'england', text: 'England' },
+  { value: 'scotland', text: 'Scotland' },
+  { value: 'wales', text: 'Wales' },
+  { value: 'northern-ireland', text: 'Northern Ireland' },
+];
+
+<Select
+  isPageHeading
+  items={countryItems}
+  label="How should we contact you?"
+  name="contact-method"
+/>;
+`;
+
+const renderSelectStory = ({
+  itemSet,
+  items = contactMethodItems,
+  ...args
+}: SelectStoryArgs) => {
+  const resolvedItems = itemSet === undefined ? items : itemSets[itemSet];
+
+  return <Select {...args} items={resolvedItems} />;
+};
+
+const meta: Meta<SelectStoryArgs> = {
   title: 'Components/Input/Select',
   component: Select,
   parameters: {
@@ -17,13 +122,13 @@ const meta: Meta<typeof Select> = {
     docs: {
       description: {
         component:
-          'A native select that reuses the toolkit select classes and shared input-family label, hint, error, and icon treatment. Each item defines the visible option text and value, with optional `optionProps` for extra native `<option>` attributes.',
+          'Use Select for a native dropdown where the choices are known up front. The React API is intentionally small: pass a label, an ordered array of items, and the usual input-style props such as hint, error message, and `isPageHeading` when the question is also the page heading. Use the `Builder` story to explore the component with friendly preset item sets.',
       },
     },
   },
   tags: ['autodocs'],
   args: {
-    items,
+    items: contactMethodItems,
     label: 'Preferred contact method',
     name: 'contact-method',
   },
@@ -34,11 +139,13 @@ const meta: Meta<typeof Select> = {
     },
     hint: {
       control: 'text',
-      description: 'Optional supporting text shown below the label and above any error message.',
+      description:
+        'Optional supporting text shown below the label and above any error message.',
     },
     errorMessage: {
       control: 'text',
-      description: 'Validation message shown above the select. When present, the select is marked invalid and linked with `aria-describedby`.',
+      description:
+        'Validation message shown above the select. When present, the select is marked invalid and linked with `aria-describedby`.',
     },
     name: {
       control: 'text',
@@ -46,7 +153,8 @@ const meta: Meta<typeof Select> = {
     },
     describedBy: {
       control: 'text',
-      description: 'Additional element IDs to append to the component-generated `aria-describedby` value.',
+      description:
+        'Additional element IDs to append to the component-generated `aria-describedby` value.',
     },
     isPageHeading: {
       control: 'boolean',
@@ -55,13 +163,27 @@ const meta: Meta<typeof Select> = {
     },
     items: {
       control: false,
-      description: 'Option items rendered inside the select. Each item uses `text`, `value`, and optional `disabled`, `selected`, or `optionProps` values.',
+      description:
+        'Ordered option items rendered inside the select. Each item uses `text`, `value`, and optional `disabled`, `selected`, or `optionProps` values.',
       table: {
         type: {
           summary: 'SelectItem[]',
           detail:
             "{ text: ReactNode; value?: string | number; disabled?: boolean; selected?: boolean; optionProps?: OptionHTMLAttributes<HTMLOptionElement> }[]",
         },
+      },
+    },
+    itemSet: {
+      control: 'select',
+      options: [
+        'contact-methods',
+        'contact-methods-selected',
+        'countries',
+      ],
+      description:
+        'Storybook-only helper for the Builder story. Switches between preset item arrays without editing the real `items` prop directly.',
+      table: {
+        disable: true,
       },
     },
     className: {
@@ -117,22 +239,88 @@ export const Default: Story = {
   args: {
     hint: 'Choose how you would like us to contact you.',
   },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story: 'A realistic select example with a simple contact-method list.',
+      },
+      source: {
+        code: defaultStoryCode,
+      },
+    },
+  },
+};
+
+export const Builder: Story = {
+  args: {
+    hint: 'Choose how you would like us to contact you.',
+    itemSet: 'contact-methods',
+    items: contactMethodItems,
+    label: 'Preferred contact method',
+    name: 'contact-method',
+  },
+  render: renderSelectStory,
+  parameters: {
+    controls: {
+      include: [
+        'label',
+        'hint',
+        'errorMessage',
+        'name',
+        'describedBy',
+        'isPageHeading',
+        'itemSet',
+      ],
+    },
+    docs: {
+      description: {
+        story:
+          'Use the friendly controls here to try preset option sets and the main visible props without editing raw item arrays.',
+      },
+    },
+  },
 };
 
 export const WithError: Story = {
   args: {
     errorMessage: 'Select how you would like us to contact you',
   },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'Shows how the component presents a validation message above the select.',
+      },
+      source: {
+        code: withErrorStoryCode,
+      },
+    },
+  },
 };
 
 export const WithSelectedOption: Story = {
   args: {
-    items: [
-      { value: '', text: 'Choose an option' },
-      { value: 'email', text: 'Email', selected: true },
-      { value: 'phone', text: 'Phone' },
-      { value: 'text-message', text: 'Text message', disabled: true },
-    ],
+    items: contactMethodSelectedItems,
+  },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'Shows how the select behaves when one option is already selected.',
+      },
+      source: {
+        code: withSelectedOptionStoryCode,
+      },
+    },
   },
 };
 
@@ -142,10 +330,16 @@ export const AsPageHeading: Story = {
     label: 'How should we contact you?',
   },
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story:
           'Use `isPageHeading` when the select question should also be announced as the page heading.',
+      },
+      source: {
+        code: asPageHeadingStoryCode,
       },
     },
   },
@@ -163,7 +357,7 @@ export const FormExample: Story = {
     >
       <Select
         hint="Choose how you would like us to contact you."
-        items={items}
+        items={contactMethodItems}
         label="Preferred contact method"
       />
       <Select
@@ -185,7 +379,8 @@ export const FormExample: Story = {
     },
     docs: {
       description: {
-        story: 'Example of how selects work together in a form.',
+        story:
+          'Example of how selects work together in a form, including an error state.',
       },
     },
   },

--- a/packages/react-components/src/components/Select/Select.stories.tsx
+++ b/packages/react-components/src/components/Select/Select.stories.tsx
@@ -99,8 +99,8 @@ const countryItems = [
 <Select
   isPageHeading
   items={countryItems}
-  label="How should we contact you?"
-  name="contact-method"
+  label="Which country do you live in?"
+  name="country"
 />;
 `;
 
@@ -433,7 +433,9 @@ export const WithSelectedOption: Story = {
 export const AsPageHeading: Story = {
   args: {
     isPageHeading: true,
-    label: 'How should we contact you?',
+    items: countryItems,
+    label: 'Which country do you live in?',
+    name: 'country',
   },
   parameters: {
     controls: {

--- a/packages/react-components/src/components/Select/Select.stories.tsx
+++ b/packages/react-components/src/components/Select/Select.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import { Select, type SelectProps } from './Select';
 
 type SelectItemSet = 'contact-methods' | 'contact-methods-selected' | 'countries';
@@ -103,14 +104,45 @@ const countryItems = [
 />;
 `;
 
+const selectUsageExample = `import { Select } from '@ourfuturehealth/react-components';
+
+const items = [
+  { value: '', text: 'Choose an option' },
+  { value: 'email', text: 'Email' },
+  { value: 'phone', text: 'Phone' },
+];
+
+<Select
+  hint="Choose how you would like us to contact you."
+  items={items}
+  label="Preferred contact method"
+  name="contact-method"
+/>;
+`;
+
+const selectItemsShapeExample = `type SelectItem = {
+  text: React.ReactNode;
+  value?: string | number;
+  disabled?: boolean;
+  selected?: boolean;
+  optionProps?: React.OptionHTMLAttributes<HTMLOptionElement>;
+};
+`;
+
 const renderSelectStory = ({
   itemSet,
   items = contactMethodItems,
   ...args
 }: SelectStoryArgs) => {
   const resolvedItems = itemSet === undefined ? items : itemSets[itemSet];
+  const resolvedArgs = {
+    ...args,
+    describedBy: args.describedBy || undefined,
+    errorMessage: args.errorMessage || undefined,
+    hint: args.hint || undefined,
+  };
 
-  return <Select {...args} items={resolvedItems} />;
+  return <Select {...resolvedArgs} items={resolvedItems} />;
 };
 
 const meta: Meta<SelectStoryArgs> = {
@@ -124,6 +156,58 @@ const meta: Meta<SelectStoryArgs> = {
         component:
           'Use Select for a native dropdown where the choices are known up front. The React API is intentionally small: pass a label, an ordered array of items, and the usual input-style props such as hint, error message, and `isPageHeading` when the question is also the page heading. Use the `Builder` story to explore the component with friendly preset item sets.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Pass a required <code>label</code>, <code>name</code>, and an{' '}
+            <code>items</code> array. Each item becomes one native{' '}
+            <code>{'<option>'}</code> inside the dropdown.
+          </p>
+          <p>
+            Add <code>hint</code> or <code>errorMessage</code> when the field
+            needs extra guidance or validation feedback. Use{' '}
+            <code>isPageHeading</code> when the select question should also be
+            announced as the page heading.
+          </p>
+          <Source code={selectUsageExample} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes
+            of={Default}
+            include={[
+              'label',
+              'hint',
+              'errorMessage',
+              'name',
+              'items',
+              'describedBy',
+              'isPageHeading',
+            ]}
+          />
+
+          <h2>
+            <code>items</code> shape
+          </h2>
+          <p>
+            Each entry in the <code>items</code> array follows this shape:
+          </p>
+          <Source code={selectItemsShapeExample} language="tsx" />
+
+          <h2>Storybook builder helpers</h2>
+          <p>
+            <code>itemSet</code> is only used by the Storybook{' '}
+            <code>Builder</code> story so you can try realistic option lists
+            without editing the real <code>items</code> prop directly. It is not
+            a React prop accepted by <code>Select</code>.
+          </p>
+
+          <Stories title="Examples" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],
@@ -136,30 +220,48 @@ const meta: Meta<SelectStoryArgs> = {
     label: {
       control: 'text',
       description: 'Question or field label shown above the select.',
+      table: {
+        category: 'SelectProps',
+      },
     },
     hint: {
       control: 'text',
       description:
         'Optional supporting text shown below the label and above any error message.',
+      table: {
+        category: 'SelectProps',
+      },
     },
     errorMessage: {
       control: 'text',
       description:
         'Validation message shown above the select. When present, the select is marked invalid and linked with `aria-describedby`.',
+      table: {
+        category: 'SelectProps',
+      },
     },
     name: {
       control: 'text',
       description: 'HTML name submitted with the form.',
+      table: {
+        category: 'SelectProps',
+      },
     },
     describedBy: {
       control: 'text',
       description:
         'Additional element IDs to append to the component-generated `aria-describedby` value.',
+      table: {
+        category: 'SelectProps',
+      },
     },
     isPageHeading: {
       control: 'boolean',
       description:
         'Wrap the label in an `h1` when this question is also the page heading.',
+      table: {
+        category: 'SelectProps',
+      },
     },
     items: {
       control: false,
@@ -171,6 +273,7 @@ const meta: Meta<SelectStoryArgs> = {
           detail:
             "{ text: ReactNode; value?: string | number; disabled?: boolean; selected?: boolean; optionProps?: OptionHTMLAttributes<HTMLOptionElement> }[]",
         },
+        category: 'SelectProps',
       },
     },
     itemSet: {
@@ -183,7 +286,7 @@ const meta: Meta<SelectStoryArgs> = {
       description:
         'Storybook-only helper for the Builder story. Switches between preset item arrays without editing the real `items` prop directly.',
       table: {
-        disable: true,
+        category: 'Builder story only',
       },
     },
     className: {
@@ -257,6 +360,9 @@ export const Default: Story = {
 export const Builder: Story = {
   args: {
     hint: 'Choose how you would like us to contact you.',
+    describedBy: '',
+    errorMessage: '',
+    isPageHeading: false,
     itemSet: 'contact-methods',
     items: contactMethodItems,
     label: 'Preferred contact method',

--- a/packages/react-components/src/components/Tag/Tag.stories.tsx
+++ b/packages/react-components/src/components/Tag/Tag.stories.tsx
@@ -51,10 +51,32 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story:
-          'Interactive single-tag example. Use the `variant` control to inspect each supported Tag style.',
+          'A realistic neutral tag example. Use this as the default pattern when you want a short, non-interactive label.',
+      },
+    },
+  },
+  render: () => <Tag variant="neutral">Inactive</Tag>,
+};
+
+export const Builder: Story = {
+  args: {
+    children: 'Inactive',
+    variant: 'neutral',
+  },
+  parameters: {
+    controls: {
+      include: ['children', 'variant'],
+    },
+    docs: {
+      description: {
+        story:
+          'Use the Builder story to try the Tag API interactively. It is the simplest place to change the label text and visual variant.',
       },
     },
   },

--- a/packages/react-components/src/components/Tag/Tag.stories.tsx
+++ b/packages/react-components/src/components/Tag/Tag.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import { Tag, type TagVariant } from './Tag';
 
 const variantOptions: TagVariant[] = [
@@ -10,6 +11,13 @@ const variantOptions: TagVariant[] = [
   'red',
 ];
 
+const tagUsageExample = `import { Tag } from '@ourfuturehealth/react-components';
+
+<Tag variant="neutral">
+  Inactive
+</Tag>;
+`;
+
 const meta: Meta<typeof Tag> = {
   title: 'Components/Tag',
   component: Tag,
@@ -20,6 +28,31 @@ const meta: Meta<typeof Tag> = {
         component:
           'Use Tag to show short status labels. The default Tag style is neutral. Choose a supported variant through the `variant` prop. Toolkit markup still supports the deprecated `ofh-tag--grey` class as an alias of neutral, but React uses the canonical `neutral` variant name.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Use <code>Tag</code> for short, non-interactive status labels or
+            contextual markers.
+          </p>
+          <p>
+            Pass the visible label as <code>children</code> and choose a{' '}
+            <code>variant</code> when you need a different color treatment.
+          </p>
+          <Source code={tagUsageExample} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes
+            of={Default}
+            include={['children', 'variant', 'className']}
+          />
+
+          <Stories title="Examples" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],
@@ -27,17 +60,26 @@ const meta: Meta<typeof Tag> = {
     children: {
       control: 'text',
       description: 'Tag content.',
+      table: {
+        category: 'TagProps',
+      },
     },
     variant: {
       control: 'select',
       options: variantOptions,
       description:
         'Visual style variant. Use `neutral`, `brand`, `blue`, `green`, `yellow`, or `red`.',
+      table: {
+        category: 'TagProps',
+      },
     },
     className: {
       control: 'text',
       description:
         'Additional classes added alongside the toolkit classes. Use this for integration hooks rather than choosing a Tag variant.',
+      table: {
+        category: 'TagProps',
+      },
     },
   },
   args: {

--- a/packages/react-components/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/react-components/src/components/TextInput/TextInput.stories.tsx
@@ -1,5 +1,17 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import { TextInput } from './TextInput';
+
+const textInputUsageExample = `import { TextInput } from '@ourfuturehealth/react-components';
+
+<TextInput
+  hint="Tell us the name you use on official documents."
+  label="Full name"
+  name="full-name"
+  placeholder="Enter your full name"
+  type="text"
+/>;
+`;
 
 const meta: Meta<typeof TextInput> = {
   title: 'Components/Input/Text input',
@@ -12,6 +24,45 @@ const meta: Meta<typeof TextInput> = {
         component:
           'A single-line text input that reuses the toolkit markup and classes, including the shared input-family label, hint, error, and width treatments. Native input props such as `autoComplete`, `disabled`, `placeholder`, and `required` pass straight through to the underlying `<input>`.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Pass a required <code>label</code> and <code>name</code>. Set{' '}
+            <code>type</code> to the native input type you need, such as{' '}
+            <code>text</code>, <code>email</code>, or <code>tel</code>.
+          </p>
+          <p>
+            Add <code>hint</code> for supporting guidance,{' '}
+            <code>errorMessage</code> for validation feedback, and use{' '}
+            <code>width</code> or <code>inputWidth</code> when you need to guide
+            layout or expected answer length.
+          </p>
+          <Source code={textInputUsageExample} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes
+            of={Default}
+            include={[
+              'label',
+              'hint',
+              'errorMessage',
+              'name',
+              'type',
+              'placeholder',
+              'describedBy',
+              'width',
+              'inputWidth',
+              'isPageHeading',
+            ]}
+          />
+
+          <Stories title="Examples" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],
@@ -24,14 +75,23 @@ const meta: Meta<typeof TextInput> = {
     label: {
       control: 'text',
       description: 'Question or field label shown above the input.',
+      table: {
+        category: 'TextInputProps',
+      },
     },
     hint: {
       control: 'text',
       description: 'Optional supporting text shown below the label and above any error message.',
+      table: {
+        category: 'TextInputProps',
+      },
     },
     errorMessage: {
       control: 'text',
       description: 'Validation message shown above the input. When present, the input is marked invalid and linked with `aria-describedby`.',
+      table: {
+        category: 'TextInputProps',
+      },
     },
     error: {
       control: false,
@@ -42,19 +102,31 @@ const meta: Meta<typeof TextInput> = {
     name: {
       control: 'text',
       description: 'HTML name submitted with the form.',
+      table: {
+        category: 'TextInputProps',
+      },
     },
     type: {
       control: 'select',
       options: ['text', 'email', 'tel', 'search', 'password', 'url', 'number'],
       description: 'Native input type for the underlying `<input>` element.',
+      table: {
+        category: 'TextInputProps',
+      },
     },
     placeholder: {
       control: 'text',
       description: 'Placeholder text shown when the input is empty.',
+      table: {
+        category: 'TextInputProps',
+      },
     },
     describedBy: {
       control: 'text',
       description: 'Additional element IDs to append to the component-generated `aria-describedby` value.',
+      table: {
+        category: 'TextInputProps',
+      },
     },
     width: {
       control: 'select',
@@ -67,16 +139,25 @@ const meta: Meta<typeof TextInput> = {
         'one-quarter',
       ],
       description: 'Responsive width utility for broader layout sizing. Use this for layout width, not expected answer length.',
+      table: {
+        category: 'TextInputProps',
+      },
     },
     inputWidth: {
       control: 'select',
       options: [2, 3, 4, 5, 10, 20, 30],
       description: 'Fixed character-width modifier that helps signal the expected answer length.',
+      table: {
+        category: 'TextInputProps',
+      },
     },
     isPageHeading: {
       control: 'boolean',
       description:
         'Wrap the label in an `h1` when this question is also the page heading.',
+      table: {
+        category: 'TextInputProps',
+      },
     },
     className: {
       control: false,
@@ -145,7 +226,10 @@ export const Default: Story = {
 
 export const Builder: Story = {
   args: {
+    describedBy: '',
+    errorMessage: '',
     hint: 'Tell us the name you use on official documents.',
+    isPageHeading: false,
     label: 'Full name',
     name: 'full-name',
     placeholder: 'Enter your full name',
@@ -178,6 +262,7 @@ export const WithHint: Story = {
   args: {
     label: 'Email address',
     hint: "We'll never share your email with anyone else",
+    name: 'email-address',
     type: 'email',
     placeholder: 'name@example.com',
   },
@@ -191,6 +276,7 @@ export const WithHint: Story = {
 export const WithError: Story = {
   args: {
     label: 'Email address',
+    name: 'email-address',
     type: 'email',
     errorMessage: 'Enter a valid email address',
     defaultValue: 'invalid-email',

--- a/packages/react-components/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/react-components/src/components/TextInput/TextInput.stories.tsx
@@ -131,6 +131,47 @@ export const Default: Story = {
   args: {
     placeholder: 'Enter your full name',
   },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story: 'A realistic single-line text input example.',
+      },
+    },
+  },
+};
+
+export const Builder: Story = {
+  args: {
+    hint: 'Tell us the name you use on official documents.',
+    label: 'Full name',
+    name: 'full-name',
+    placeholder: 'Enter your full name',
+    type: 'text',
+  },
+  parameters: {
+    controls: {
+      include: [
+        'label',
+        'hint',
+        'errorMessage',
+        'name',
+        'type',
+        'placeholder',
+        'width',
+        'inputWidth',
+        'isPageHeading',
+      ],
+    },
+    docs: {
+      description: {
+        story:
+          'Use the friendly controls here to explore the most useful text-input props without editing code.',
+      },
+    },
+  },
 };
 
 export const WithHint: Story = {
@@ -140,6 +181,11 @@ export const WithHint: Story = {
     type: 'email',
     placeholder: 'name@example.com',
   },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
 };
 
 export const WithError: Story = {
@@ -148,6 +194,11 @@ export const WithError: Story = {
     type: 'email',
     errorMessage: 'Enter a valid email address',
     defaultValue: 'invalid-email',
+  },
+  parameters: {
+    controls: {
+      disable: true,
+    },
   },
 };
 
@@ -225,6 +276,9 @@ export const AsPageHeading: Story = {
         story:
           'Use `isPageHeading` when the question should also be announced as the page heading. The component applies the larger heading label treatment automatically.',
       },
+    },
+    controls: {
+      disable: true,
     },
   },
 };

--- a/packages/react-components/src/components/Textarea/Textarea.stories.tsx
+++ b/packages/react-components/src/components/Textarea/Textarea.stories.tsx
@@ -106,6 +106,44 @@ export const Default: Story = {
   args: {
     hint: 'Do not include personal or financial information.',
   },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story: 'A realistic multiline text area example.',
+      },
+    },
+  },
+};
+
+export const Builder: Story = {
+  args: {
+    hint: 'Do not include personal or financial information.',
+    label: 'Can you provide more detail?',
+    name: 'details',
+    rows: 4,
+  },
+  parameters: {
+    controls: {
+      include: [
+        'label',
+        'hint',
+        'errorMessage',
+        'name',
+        'placeholder',
+        'rows',
+        'isPageHeading',
+      ],
+    },
+    docs: {
+      description: {
+        story:
+          'Use the friendly controls here to explore the main textarea props without editing code.',
+      },
+    },
+  },
 };
 
 export const WithError: Story = {
@@ -113,12 +151,22 @@ export const WithError: Story = {
     errorMessage: 'You must provide an explanation.',
     label: "Why can't you provide a National Insurance number?",
   },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
 };
 
 export const Longer: Story = {
   args: {
     hint: 'Do not include personal or financial information.',
     rows: 10,
+  },
+  parameters: {
+    controls: {
+      disable: true,
+    },
   },
 };
 
@@ -133,6 +181,9 @@ export const AsPageHeading: Story = {
         story:
           'Use `isPageHeading` when the textarea question should also be announced as the page heading.',
       },
+    },
+    controls: {
+      disable: true,
     },
   },
 };

--- a/packages/react-components/src/components/Textarea/Textarea.stories.tsx
+++ b/packages/react-components/src/components/Textarea/Textarea.stories.tsx
@@ -1,5 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import { Textarea } from './Textarea';
+
+const textareaUsageExample = `import { Textarea } from '@ourfuturehealth/react-components';
+
+<Textarea
+  hint="Do not include personal or financial information."
+  label="Can you provide more detail?"
+  name="details"
+  rows={4}
+/>;
+`;
 
 const meta: Meta<typeof Textarea> = {
   title: 'Components/Input/Textarea',
@@ -12,6 +23,43 @@ const meta: Meta<typeof Textarea> = {
         component:
           'A multiline input that reuses the toolkit textarea classes and shared input-family label, hint, and error treatments. Native textarea props such as `placeholder`, `rows`, `disabled`, and `required` pass through to the underlying `<textarea>`.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Pass a required <code>label</code> and <code>name</code>, then set{' '}
+            <code>rows</code> to the visible height you want before the field
+            scrolls.
+          </p>
+          <p>
+            Add <code>hint</code> for supporting guidance,{' '}
+            <code>errorMessage</code> for validation feedback, and use{' '}
+            <code>isPageHeading</code> when the textarea question should also be
+            the page heading.
+          </p>
+          <Source code={textareaUsageExample} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes
+            of={Default}
+            include={[
+              'label',
+              'hint',
+              'errorMessage',
+              'name',
+              'placeholder',
+              'rows',
+              'describedBy',
+              'isPageHeading',
+            ]}
+          />
+
+          <Stories title="Examples" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],
@@ -23,35 +71,59 @@ const meta: Meta<typeof Textarea> = {
     label: {
       control: 'text',
       description: 'Question or field label shown above the textarea.',
+      table: {
+        category: 'TextareaProps',
+      },
     },
     hint: {
       control: 'text',
       description: 'Optional supporting text shown below the label and above any error message.',
+      table: {
+        category: 'TextareaProps',
+      },
     },
     errorMessage: {
       control: 'text',
       description: 'Validation message shown above the textarea. When present, the textarea is marked invalid and linked with `aria-describedby`.',
+      table: {
+        category: 'TextareaProps',
+      },
     },
     name: {
       control: 'text',
       description: 'HTML name submitted with the form.',
+      table: {
+        category: 'TextareaProps',
+      },
     },
     placeholder: {
       control: 'text',
       description: 'Placeholder text shown when the textarea is empty.',
+      table: {
+        category: 'TextareaProps',
+      },
     },
     rows: {
       control: 'number',
       description: 'Visible row count for the textarea before it scrolls.',
+      table: {
+        category: 'TextareaProps',
+      },
     },
     describedBy: {
       control: 'text',
       description: 'Additional element IDs to append to the component-generated `aria-describedby` value.',
+      table: {
+        category: 'TextareaProps',
+      },
     },
     isPageHeading: {
       control: 'boolean',
       description:
         'Wrap the label in an `h1` when this question is also the page heading.',
+      table: {
+        category: 'TextareaProps',
+      },
     },
     className: {
       control: false,
@@ -120,9 +192,13 @@ export const Default: Story = {
 
 export const Builder: Story = {
   args: {
+    describedBy: '',
+    errorMessage: '',
     hint: 'Do not include personal or financial information.',
+    isPageHeading: false,
     label: 'Can you provide more detail?',
     name: 'details',
+    placeholder: '',
     rows: 4,
   },
   parameters: {
@@ -150,6 +226,7 @@ export const WithError: Story = {
   args: {
     errorMessage: 'You must provide an explanation.',
     label: "Why can't you provide a National Insurance number?",
+    name: 'ni-number-explanation',
   },
   parameters: {
     controls: {


### PR DESCRIPTION
## Description
This PR delivers a **Storybook story pattern uplift** across the React component library and the reusable component-workflow prompts.

It standardises the Storybook teaching pattern so existing components use a clearer split between a developer-facing `Docs` page, a realistic `Default` example, an interactive `Builder` story, and fixed showcase stories. It also updates the reusable prompts so future component work follows the same standard by default.

## Release scope
- None.
- Docs / Storybook only.
- No package version bump.

## Breaking Changes
- None.

## Key Changes
- updates the component update / QA / merge-readiness prompt templates to encode the `Docs` / `Default` / `Builder` / showcase story pattern
- refreshes the already-live React Storybook stories for:
  - `Autocomplete`
  - `Button`
  - `Card`
  - `Card / Callout`
  - `Card / Do & Don’t`
  - `Character count`
  - `Checkboxes`
  - `Date input`
  - `Error summary`
  - `Fieldset`
  - `Icon`
  - `Radios`
  - `Select`
  - `Tag`
  - `Text input`
  - `Textarea`
- makes docs pages teach the real React API more clearly with `How to use the React component` guidance
- adds shape guidance where structured props are important, such as `items`, `options`, and `errorList`
- keeps Storybook-only helper args in `Builder` stories instead of letting them blur into the component API docs
- makes `Default` stories realistic fixed examples rather than generic playgrounds
- improves Builder controls so they are easier for stakeholders to use without editing raw nested JSON
- improves copyable source snippets so structured prop shapes are visible and easier to adopt

## Validation
- `npm test`
- `pnpm lint`
- `pnpm --filter=@ourfuturehealth/react-components build:storybook`
- manual QA across the updated Storybook stories

## Reviewer Focus
- Storybook docs pages should now teach the real React API clearly and consistently
- Builder stories should feel friendly to explore and avoid raw nested controls where possible
- fixed example stories should remain fixed examples, not playgrounds
- the reusable prompt templates should now encode the same Storybook standard for future component work

## Example screenshots
<img width="3000" height="8740" alt="autocomplete-docs" src="https://github.com/user-attachments/assets/9370d892-73f1-479d-abe3-d4e5565ac324" />
<img width="3000" height="10786" alt="button-docs" src="https://github.com/user-attachments/assets/690a6668-1f9a-48fe-865b-a7969c813adb" />
<img width="3000" height="17206" alt="card-basic-docs" src="https://github.com/user-attachments/assets/74449e77-1bd1-4c79-bf90-81463f2df0f9" />
<img width="3000" height="11052" alt="date-input-docs" src="https://github.com/user-attachments/assets/92ebac8d-6288-4186-9b44-76aee38a410d" />
<img width="3000" height="13176" alt="error-summary-docs" src="https://github.com/user-attachments/assets/8dc6d9c3-abd8-4497-b930-2c1436948692" />
<img width="3400" height="1440" alt="storybook-overview-button-docs" src="https://github.com/user-attachments/assets/81bb2681-3cdd-4cf5-b1d6-fd2f1d69407e" />
