### PR TITLE
DSE-334 :: Task List FE update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ### Unreleased
 
+#### @ourfuturehealth/toolkit 4.15.0 (`toolkit-v4.15.0`)
+
+##### Added
+
+- Task list docs-site examples for `with-hints` and `status-variants`
+
+##### Changed
+
+- Refreshed the toolkit `task-list` component to the current Figma-aligned row structure and spacing
+- Removed the legacy first-row top divider so the rendered task list matches the design reference more closely
+- Updated task-list docs-site guidance and examples to match the refreshed component usage
+
+#### @ourfuturehealth/react-components 0.14.0 (`react-v0.14.0`)
+
+##### Added
+
+- New public `TaskList` component using the shared React `Tag` component for row status
+- Storybook coverage for `TaskList` including `Default`, `Builder`, `WithHints`, and `StatusVariants`
+
+##### Changed
+
+- Refined the Task List Storybook docs page so it teaches the React API, `items` shape, and Builder-only helper controls more clearly
+
 #### @ourfuturehealth/react-components 0.8.0 (`react-v0.8.0`)
 
 ##### ⚠️ BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ## Monorepo Package Releases (`toolkit-v*`, `react-v*`)
 
+### 2026-04-30
+
+#### @ourfuturehealth/toolkit 4.15.0 (`toolkit-v4.15.0`)
+
+##### Added
+
+- Task list docs-site examples for `with-hints` and `status-variants`
+
+##### Changed
+
+- Refreshed the toolkit `task-list` component to the current Figma-aligned row structure and spacing
+- Removed the legacy first-row top divider so the rendered task list matches the design reference more closely
+- Updated task-list docs-site guidance and examples to match the refreshed component usage
+
+#### @ourfuturehealth/react-components 0.14.0 (`react-v0.14.0`)
+
+##### Added
+
+- New public `TaskList` component using the shared React `Tag` component for row status
+- Storybook coverage for `TaskList` including `Default`, `Builder`, `WithHints`, and `StatusVariants`
+
+##### Changed
+
+- Refined the Task List Storybook docs page so it teaches the React API, `items` shape, and Builder-only helper controls more clearly
+
 ### 2026-04-28
 
 #### @ourfuturehealth/toolkit 4.14.0 (`toolkit-v4.14.0`)
@@ -120,31 +145,6 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
   - `LinkAction`
   - `LinkIcon`
   - `LinkSkip`
-
-### 2026-04-30
-
-#### @ourfuturehealth/toolkit 4.15.0 (`toolkit-v4.15.0`)
-
-##### Added
-
-- Task list docs-site examples for `with-hints` and `status-variants`
-
-##### Changed
-
-- Refreshed the toolkit `task-list` component to the current Figma-aligned row structure and spacing
-- Removed the legacy first-row top divider so the rendered task list matches the design reference more closely
-- Updated task-list docs-site guidance and examples to match the refreshed component usage
-
-#### @ourfuturehealth/react-components 0.14.0 (`react-v0.14.0`)
-
-##### Added
-
-- New public `TaskList` component using the shared React `Tag` component for row status
-- Storybook coverage for `TaskList` including `Default`, `Builder`, `WithHints`, and `StatusVariants`
-
-##### Changed
-
-- Refined the Task List Storybook docs page so it teaches the React API, `items` shape, and Builder-only helper controls more clearly
 
 ### 2026-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,31 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
   - `LinkIcon`
   - `LinkSkip`
 
+### 2026-04-30
+
+#### @ourfuturehealth/toolkit 4.15.0 (`toolkit-v4.15.0`)
+
+##### Added
+
+- Task list docs-site examples for `with-hints` and `status-variants`
+
+##### Changed
+
+- Refreshed the toolkit `task-list` component to the current Figma-aligned row structure and spacing
+- Removed the legacy first-row top divider so the rendered task list matches the design reference more closely
+- Updated task-list docs-site guidance and examples to match the refreshed component usage
+
+#### @ourfuturehealth/react-components 0.14.0 (`react-v0.14.0`)
+
+##### Added
+
+- New public `TaskList` component using the shared React `Tag` component for row status
+- Storybook coverage for `TaskList` including `Default`, `Builder`, `WithHints`, and `StatusVariants`
+
+##### Changed
+
+- Refined the Task List Storybook docs page so it teaches the React API, `items` shape, and Builder-only helper controls more clearly
+
 ### 2026-04-15
 
 #### @ourfuturehealth/react-components 0.8.0 (`react-v0.8.0`)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,7 +8,7 @@ This guide provides detailed migration instructions for upgrading between versio
 
 | Version                                                 | Date          | Breaking Changes           | Migration Complexity                     |
 | ------------------------------------------------------- | ------------- | -------------------------- | ---------------------------------------- |
-| [v4.15.0 / React v0.14.0](#upgrading-to-v4150--react-v0140) | April 2026    | No breaking changes        | 🟢 Low - adopt the new Task List APIs only if relevant |
+| [v4.15.0 / React v0.14.0](#upgrading-to-v4150--react-v0140) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React TaskList if needed and use the refreshed toolkit task-list APIs when relevant |
 | [v4.14.0 / React v0.13.0](#upgrading-to-v4140--react-v0130) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React pagination if needed |
 | [v4.13.0 / React v0.12.0](#upgrading-to-v4130--react-v0120) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React footer if needed |
 | [v4.12.0 / React v0.11.0](#upgrading-to-v4120--react-v0110) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React summary list if needed |
@@ -48,8 +48,8 @@ This release refreshes the toolkit `task-list` component to the current design-s
 ### Migration Steps
 
 1. Adopt the public React `TaskList` component where you need toolkit-parity task navigation in React.
-2. Re-run visual QA if you have local task-list overrides, especially around first-row dividers, responsive spacing, hint text, and status tag alignment.
-3. Move the docs-site IA reference for Task List to `Content presentation` rather than `Navigation` when cross-checking internal references.
+2. Prefer the refreshed toolkit task-list API, docs examples, and canonical usage when touching existing Nunjucks templates.
+3. Re-run visual QA if you have local task-list overrides, especially around first-row dividers, responsive spacing, hint text, and status tag alignment.
 
 #### React example
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,6 +8,7 @@ This guide provides detailed migration instructions for upgrading between versio
 
 | Version                                                 | Date          | Breaking Changes           | Migration Complexity                     |
 | ------------------------------------------------------- | ------------- | -------------------------- | ---------------------------------------- |
+| [v4.15.0 / React v0.14.0](#upgrading-to-v4150--react-v0140) | April 2026    | No breaking changes        | 🟢 Low - adopt the new Task List APIs only if relevant |
 | [React v0.8.0](#upgrading-to-react-v080)                | April 2026    | React `spritePath` removal | 🟢 Low - Remove the deprecated prop      |
 | [v4.9.0 / React v0.7.0](#upgrading-to-v490--react-v070) | April 2026    | Icon naming sync           | 🟡 Medium - Search/replace icon names    |
 | [v4.8.0 / React v0.6.0](#upgrading-to-v480--react-v060) | March 2026    | No breaking changes        | 🟢 Low - only relevant if you adopted the earlier TextInput prototype |
@@ -19,6 +20,56 @@ This guide provides detailed migration instructions for upgrading between versio
 | [v4.0.0](#upgrading-to-v400-monorepo-restructure)       | 2025          | Monorepo restructure       | 🔴 High - Installation & paths change    |
 
 ---
+
+## Upgrading to v4.15.0 / React v0.14.0
+
+**Planned:** April 2026
+**Affected packages:**
+
+- `@ourfuturehealth/toolkit` v4.15.0+
+- `@ourfuturehealth/react-components` v0.14.0+
+
+### Release Overview
+
+This release does not introduce a supported breaking API change.
+
+Toolkit consumers should review the refreshed `task-list` layout and docs examples if they already use the task list component.
+
+React consumers can now adopt the public `TaskList` component when they need long-form task navigation with right-aligned status tags.
+
+### Task List
+
+- Toolkit `task-list` rows now match the current Figma treatment more closely, including the first-row divider removal and responsive row gap
+- React now exposes `TaskList` as a public component with an `items` array and optional `idPrefix`
+- Storybook and docs-site examples now cover default, hints, and status-variant task list usage
+
+#### React example
+
+```tsx
+import { TaskList } from '@ourfuturehealth/react-components';
+
+const items = [
+  {
+    title: 'Company directors',
+    href: '/company/directors',
+    status: {
+      children: 'Complete',
+      variant: 'green',
+    },
+  },
+  {
+    title: 'Financial history',
+    href: '/company/financial-history',
+    hint: 'Include 5 years of the company’s relevant financial information.',
+    status: {
+      children: 'Incomplete',
+      variant: 'blue',
+    },
+  },
+];
+
+<TaskList items={items} idPrefix="company-task-list" />;
+```
 
 ## Upgrading to React v0.8.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,13 +6,14 @@ This guide provides detailed migration instructions for upgrading between versio
 
 ## Breaking Changes by Version
 
-| Version                                                 | Date          | Breaking Changes      | Migration Complexity                  |
-| ------------------------------------------------------- | ------------- | --------------------- | ------------------------------------- |
-| [v4.14.0 / React v0.13.0](#upgrading-to-v4140--react-v0130) | April 2026    | No breaking changes | 🟢 Low - adopt the public React pagination if needed |
-| [v4.13.0 / React v0.12.0](#upgrading-to-v4130--react-v0120) | April 2026    | No breaking changes | 🟢 Low - adopt the public React footer if needed |
-| [v4.12.0 / React v0.11.0](#upgrading-to-v4120--react-v0110) | April 2026    | No breaking changes | 🟢 Low - adopt the public React summary list if needed |
-| [v4.11.0 / React v0.10.0](#upgrading-to-v4110--react-v0100) | April 2026    | No breaking changes | 🟢 Low - adopt the public React details family if needed |
-| [v4.10.0 / React v0.9.0](#upgrading-to-v4100--react-v090) | April 2026    | No breaking changes | 🟢 Low - Adopt the public link family and canonical names for new usage |
+| Version                                                 | Date          | Breaking Changes           | Migration Complexity                     |
+| ------------------------------------------------------- | ------------- | -------------------------- | ---------------------------------------- |
+| [v4.15.0 / React v0.14.0](#upgrading-to-v4150--react-v0140) | April 2026    | No breaking changes        | 🟢 Low - adopt the new Task List APIs only if relevant |
+| [v4.14.0 / React v0.13.0](#upgrading-to-v4140--react-v0130) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React pagination if needed |
+| [v4.13.0 / React v0.12.0](#upgrading-to-v4130--react-v0120) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React footer if needed |
+| [v4.12.0 / React v0.11.0](#upgrading-to-v4120--react-v0110) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React summary list if needed |
+| [v4.11.0 / React v0.10.0](#upgrading-to-v4110--react-v0100) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React details family if needed |
+| [v4.10.0 / React v0.9.0](#upgrading-to-v4100--react-v090) | April 2026    | No breaking changes        | 🟢 Low - Adopt the public link family and canonical names for new usage |
 | [React v0.8.0](#upgrading-to-react-v080)                | April 2026    | React `spritePath` removal | 🟢 Low - Remove the deprecated prop      |
 | [v4.9.0 / React v0.7.0](#upgrading-to-v490--react-v070) | April 2026    | Icon naming sync    | 🟡 Medium - Search/replace icon names  |
 | [v4.8.0 / React v0.6.0](#upgrading-to-v480--react-v060) | March 2026    | No breaking changes | 🟢 Low - only relevant if you adopted the earlier TextInput prototype |
@@ -22,6 +23,63 @@ This guide provides detailed migration instructions for upgrading between versio
 | [v4.3.0 / React v0.2.0](#upgrading-to-v430--react-v020) | March 2026    | Button variant naming      | 🟡 Medium - Find/replace required        |
 | [v4.1.0](#upgrading-to-v410)                            | February 2026 | Spacing scale indices      | 🟡 Medium - Index updates required       |
 | [v4.0.0](#upgrading-to-v400-monorepo-restructure)       | 2025          | Monorepo restructure       | 🔴 High - Installation & paths change    |
+
+---
+
+## Upgrading to v4.15.0 / React v0.14.0
+
+**Released:** April 2026
+**Affected packages:**
+
+- `@ourfuturehealth/toolkit` v4.15.0+
+- `@ourfuturehealth/react-components` v0.14.0+
+
+### Breaking Changes
+
+None.
+
+### Release Overview
+
+This release refreshes the toolkit `task-list` component to the current design-system treatment and introduces the first public React `TaskList` component.
+
+- Toolkit consumers should review the refreshed task-list row spacing, the removal of the old first-row divider, and the expanded docs examples for hints and status variants.
+- React consumers can now adopt the public `TaskList` component when they need long-form task navigation with right-aligned Tag-based statuses.
+
+### Migration Steps
+
+1. Adopt the public React `TaskList` component where you need toolkit-parity task navigation in React.
+2. Re-run visual QA if you have local task-list overrides, especially around first-row dividers, responsive spacing, hint text, and status tag alignment.
+3. Move the docs-site IA reference for Task List to `Content presentation` rather than `Navigation` when cross-checking internal references.
+
+#### React example
+
+**New in `react-v0.14.0`:**
+
+```tsx
+import { TaskList } from '@ourfuturehealth/react-components';
+
+const items = [
+  {
+    title: 'Company directors',
+    href: '/company/directors',
+    status: {
+      children: 'Complete',
+      variant: 'green',
+    },
+  },
+  {
+    title: 'Financial history',
+    href: '/company/financial-history',
+    hint: 'Include 5 years of the company’s relevant financial information.',
+    status: {
+      children: 'Incomplete',
+      variant: 'blue',
+    },
+  },
+];
+
+<TaskList items={items} idPrefix="company-task-list" />;
+```
 
 ---
 

--- a/docs/consuming-react-components.md
+++ b/docs/consuming-react-components.md
@@ -142,6 +142,7 @@ The React components package currently provides the following components:
 - `Icon` - Toolkit icon component with fixed and responsive sizing using bundled SVG data
 - `ErrorSummary` - Page-level validation summaries with linked errors
 - `Tag` - Status tags aligned with toolkit Tag variants
+- `TaskList` - Ordered service tasks with optional hint text and shared Tag-based statuses
 - `Card` - Content presentation cards for summaries, status, and next steps
 - `CardCallout` - Feedback-style callout cards for informational, warning, success, and error messages
 - `CardDoDont` - Positive and negative recommendation lists

--- a/docs/consuming-react-components.md
+++ b/docs/consuming-react-components.md
@@ -133,6 +133,7 @@ The React components package currently provides the following components:
 - `Icon` - Toolkit icon component with fixed and responsive sizing using bundled SVG data
 - `ErrorSummary` - Page-level validation summaries with linked errors
 - `Tag` - Status tags aligned with toolkit Tag variants
+- `TaskList` - Ordered service tasks with optional hint text and shared Tag-based statuses
 - `Card` - Content presentation cards for summaries, status, and next steps
 - `CardCallout` - Feedback-style callout cards for informational, warning, success, and error messages
 - `CardDoDont` - Positive and negative recommendation lists

--- a/docs/release-versioning-strategy.md
+++ b/docs/release-versioning-strategy.md
@@ -103,7 +103,7 @@ npm pack ./packages/react-components --ignore-scripts
 
 ## Version Correlation Table
 
-This table is illustrative, not exhaustive. It shows the transition from the pre-monorepo single-package release model to the monorepo model where toolkit and React release independently.
+This table is illustrative, not exhaustive. It shows the transition from the pre-monorepo single-package release model to the monorepo model where toolkit and React release independently, plus the tag format future monorepo releases continue to use.
 
 | Order | Release tag      | Toolkit version | React version | Repo model     | Status                 |
 | ----- | ---------------- | --------------- | ------------- | -------------- | ---------------------- |
@@ -114,8 +114,8 @@ This table is illustrative, not exhaustive. It shows the transition from the pre
 | 5     | `react-v0.0.1`   | N/A             | `0.0.1`       | Monorepo       | Released               |
 | 6     | `toolkit-v4.1.0` | `4.1.0`         | N/A           | Monorepo       | Released               |
 | 7     | `react-v0.1.0`   | N/A             | `0.1.0`       | Monorepo       | Released               |
-| 8     | `toolkit-v4.15.0` | `4.15.0`       | N/A           | Monorepo       | Planned in this branch |
-| 9     | `react-v0.14.0`   | N/A            | `0.14.0`      | Monorepo       | Planned in this branch |
+| 8     | `toolkit-vX.Y.Z` | `X.Y.Z`         | N/A           | Monorepo       | Future releases follow this format |
+| 9     | `react-vA.B.C`   | N/A             | `A.B.C`       | Monorepo       | Future releases follow this format |
 
 ## References
 

--- a/docs/release-versioning-strategy.md
+++ b/docs/release-versioning-strategy.md
@@ -103,7 +103,7 @@ npm pack ./packages/react-components --ignore-scripts
 
 ## Version Correlation Table
 
-This table is a visual aid for pre-monorepo versus post-monorepo releases.
+This table is illustrative, not exhaustive. It shows the transition from the pre-monorepo single-package release model to the monorepo model where toolkit and React release independently.
 
 | Order | Release tag      | Toolkit version | React version | Repo model     | Status                 |
 | ----- | ---------------- | --------------- | ------------- | -------------- | ---------------------- |
@@ -114,33 +114,8 @@ This table is a visual aid for pre-monorepo versus post-monorepo releases.
 | 5     | `react-v0.0.1`   | N/A             | `0.0.1`       | Monorepo       | Released               |
 | 6     | `toolkit-v4.1.0` | `4.1.0`         | N/A           | Monorepo       | Released               |
 | 7     | `react-v0.1.0`   | N/A             | `0.1.0`       | Monorepo       | Released               |
-| 8     | `toolkit-v4.2.0` | `4.2.0`         | N/A           | Monorepo       | Released               |
-| 9     | `toolkit-v4.3.0` | `4.3.0`         | N/A           | Monorepo       | Released               |
-| 10    | `react-v0.2.0`   | N/A             | `0.2.0`       | Monorepo       | Released               |
-| 11    | `toolkit-v4.4.0` | `4.4.0`         | N/A           | Monorepo       | Released               |
-| 12    | `react-v0.3.0`   | N/A             | `0.3.0`       | Monorepo       | Released               |
-| 13    | `toolkit-v4.5.0` | `4.5.0`         | N/A           | Monorepo       | Released               |
-| 14    | `toolkit-v4.6.0` | `4.6.0`         | N/A           | Monorepo       | Released               |
-| 15    | `react-v0.4.0`   | N/A             | `0.4.0`       | Monorepo       | Released               |
-| 16    | `toolkit-v4.7.0` | `4.7.0`         | N/A           | Monorepo       | Released               |
-| 17    | `react-v0.5.0`   | N/A             | `0.5.0`       | Monorepo       | Released               |
-| 18    | `toolkit-v4.8.0` | `4.8.0`         | N/A           | Monorepo       | Released               |
-| 19    | `react-v0.6.0`   | N/A             | `0.6.0`       | Monorepo       | Released               |
-| 20    | `toolkit-v4.9.0` | `4.9.0`         | N/A           | Monorepo       | Released               |
-| 21    | `react-v0.7.0`   | N/A             | `0.7.0`       | Monorepo       | Released               |
-| 22    | `react-v0.8.0`    | N/A            | `0.8.0`       | Monorepo       | Released               |
-| 23    | `toolkit-v4.10.0` | `4.10.0`       | N/A           | Monorepo       | Released               |
-| 24    | `react-v0.9.0`    | N/A            | `0.9.0`       | Monorepo       | Released               |
-| 25    | `toolkit-v4.11.0` | `4.11.0`       | N/A           | Monorepo       | Released               |
-| 26    | `react-v0.10.0`   | N/A            | `0.10.0`      | Monorepo       | Released               |
-| 27    | `toolkit-v4.12.0` | `4.12.0`       | N/A           | Monorepo       | Released               |
-| 28    | `react-v0.11.0`   | N/A            | `0.11.0`      | Monorepo       | Released               |
-| 29    | `toolkit-v4.13.0` | `4.13.0`       | N/A           | Monorepo       | Released               |
-| 30    | `react-v0.12.0`   | N/A            | `0.12.0`      | Monorepo       | Released               |
-| 31    | `toolkit-v4.14.0` | `4.14.0`       | N/A           | Monorepo       | Released               |
-| 32    | `react-v0.13.0`   | N/A            | `0.13.0`      | Monorepo       | Released               |
-| 33    | `toolkit-v4.15.0` | `4.15.0`       | N/A           | Monorepo       | Planned in this branch |
-| 34    | `react-v0.14.0`   | N/A            | `0.14.0`      | Monorepo       | Planned in this branch |
+| 8     | `toolkit-v4.15.0` | `4.15.0`       | N/A           | Monorepo       | Planned in this branch |
+| 9     | `react-v0.14.0`   | N/A            | `0.14.0`      | Monorepo       | Planned in this branch |
 
 ## References
 

--- a/docs/release-versioning-strategy.md
+++ b/docs/release-versioning-strategy.md
@@ -31,8 +31,8 @@ For consumer migration instructions, use [Upgrading Guide](../UPGRADING.md).
 
 | Package                             | Canonical tag pattern | Example tag      |
 | ----------------------------------- | --------------------- | ---------------- |
-| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.9.0` |
-| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.7.0`   |
+| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.15.0` |
+| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.14.0`   |
 
 The release workflow still accepts legacy toolkit tags in the `v*` format for backward compatibility, but new toolkit releases should use `toolkit-v*`.
 
@@ -128,7 +128,18 @@ This table is a visual aid for pre-monorepo versus post-monorepo releases.
 | 19    | `react-v0.6.0`   | N/A             | `0.6.0`       | Monorepo       | Released               |
 | 20    | `toolkit-v4.9.0` | `4.9.0`         | N/A           | Monorepo       | Released               |
 | 21    | `react-v0.7.0`   | N/A             | `0.7.0`       | Monorepo       | Released               |
-| 22    | `react-v0.8.0`   | N/A             | `0.8.0`       | Monorepo       | Planned in this branch |
+| 22    | `toolkit-v4.10.0` | `4.10.0`       | N/A           | Monorepo       | Planned in open branch |
+| 23    | `react-v0.9.0`    | N/A            | `0.9.0`       | Monorepo       | Planned in open branch |
+| 24    | `toolkit-v4.11.0` | `4.11.0`       | N/A           | Monorepo       | Planned in open branch |
+| 25    | `react-v0.10.0`   | N/A            | `0.10.0`      | Monorepo       | Planned in open branch |
+| 26    | `toolkit-v4.12.0` | `4.12.0`       | N/A           | Monorepo       | Planned in open branch |
+| 27    | `react-v0.11.0`   | N/A            | `0.11.0`      | Monorepo       | Planned in open branch |
+| 28    | `toolkit-v4.13.0` | `4.13.0`       | N/A           | Monorepo       | Planned in open branch |
+| 29    | `react-v0.12.0`   | N/A            | `0.12.0`      | Monorepo       | Planned in open branch |
+| 30    | `toolkit-v4.14.0` | `4.14.0`       | N/A           | Monorepo       | Planned in open branch |
+| 31    | `react-v0.13.0`   | N/A            | `0.13.0`      | Monorepo       | Planned in open branch |
+| 32    | `toolkit-v4.15.0` | `4.15.0`       | N/A           | Monorepo       | Planned in this branch |
+| 33    | `react-v0.14.0`   | N/A            | `0.14.0`      | Monorepo       | Planned in this branch |
 
 ## References
 

--- a/docs/release-versioning-strategy.md
+++ b/docs/release-versioning-strategy.md
@@ -31,8 +31,8 @@ For consumer migration instructions, use [Upgrading Guide](../UPGRADING.md).
 
 | Package                             | Canonical tag pattern | Example tag      |
 | ----------------------------------- | --------------------- | ---------------- |
-| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.14.0` |
-| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.13.0`   |
+| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.15.0` |
+| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.14.0`   |
 
 The release workflow still accepts legacy toolkit tags in the `v*` format for backward compatibility, but new toolkit releases should use `toolkit-v*`.
 
@@ -60,7 +60,7 @@ Consumers must install the package release tarball:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/toolkit": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/toolkit-v4.14.0/ourfuturehealth-toolkit-4.14.0.tgz"
+    "@ourfuturehealth/toolkit": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/toolkit-v4.15.0/ourfuturehealth-toolkit-4.15.0.tgz"
   }
 }
 ```
@@ -70,7 +70,7 @@ React consumers follow the same contract:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.13.0/ourfuturehealth-react-components-0.13.0.tgz"
+    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.14.0/ourfuturehealth-react-components-0.14.0.tgz"
   }
 }
 ```
@@ -139,6 +139,8 @@ This table is a visual aid for pre-monorepo versus post-monorepo releases.
 | 30    | `react-v0.12.0`   | N/A            | `0.12.0`      | Monorepo       | Released               |
 | 31    | `toolkit-v4.14.0` | `4.14.0`       | N/A           | Monorepo       | Released               |
 | 32    | `react-v0.13.0`   | N/A            | `0.13.0`      | Monorepo       | Released               |
+| 33    | `toolkit-v4.15.0` | `4.15.0`       | N/A           | Monorepo       | Planned in this branch |
+| 34    | `react-v0.14.0`   | N/A            | `0.14.0`      | Monorepo       | Planned in this branch |
 
 ## References
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -305,16 +305,26 @@ A card for short do and don’t recommendation lists.
 **Props:**
 
 - `type`: 'do' | 'dont'
+- `heading?`: React.ReactNode
+- `headingLevel?`: 1 | 2 | 3 | 4 | 5 | 6
+- `items`: `{ item: ReactNode }[]`
+- `classes?`: string
+- `className?`: string
+- `ref?`: React ref forwarded to the root card element
 
 ### TaskList
 
 A task list that reuses the shared `Tag` component for the status column.
+
+Commonly used props are listed below. `TaskListProps` also includes optional `classes` and `ref` props.
 
 **Props:**
 
 - `items`: `{ title: ReactNode; href?: string; hint?: ReactNode; status: TagProps; className?: string; titleClassName?: string; hintClassName?: string }[]`
 - `idPrefix?`: string
 - `className?`: string
+- `classes?`: styling override classes for the root task list element
+- `ref?`: React ref forwarded to the root task list element
 
 ### Icons
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -54,6 +54,7 @@ import {
   Icon,
   Radios,
   Select,
+  TaskList,
   Tag,
   Textarea,
   TextInput,
@@ -85,6 +86,26 @@ function App() {
         ]}
       />
       <Tag variant="brand">Beta</Tag>
+      <TaskList
+        items={[
+          {
+            title: 'Company directors',
+            href: '#directors',
+            status: {
+              children: 'Complete',
+              variant: 'green',
+            },
+          },
+          {
+            title: 'Registered company details',
+            href: '#company-details',
+            status: {
+              children: 'Incomplete',
+              variant: 'blue',
+            },
+          },
+        ]}
+      />
       <Button variant="contained">Click me</Button>
       <Icon name="Search" size={24} />
       <Card heading="Profile complete" description="You’ve completed all the required profile details." />
@@ -188,6 +209,7 @@ The package also provides:
 - `CharacterCount`
 - `Checkboxes`
 - `Radios`
+- `TaskList`
 - `Icon`
 
 ### ErrorSummary
@@ -239,6 +261,15 @@ A card for short do and don’t recommendation lists.
 **Props:**
 
 - `type`: 'do' | 'dont'
+
+### TaskList
+
+A task list that reuses the shared `Tag` component for the status column.
+
+**Props:**
+
+- `items`: `{ title: ReactNode; href?: string; hint?: ReactNode; status: TagProps; className?: string; titleClassName?: string; hintClassName?: string }[]`
+- `idPrefix`: string
 - `heading`, `headingLevel`
 - `items`
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -269,9 +269,8 @@ A task list that reuses the shared `Tag` component for the status column.
 **Props:**
 
 - `items`: `{ title: ReactNode; href?: string; hint?: ReactNode; status: TagProps; className?: string; titleClassName?: string; hintClassName?: string }[]`
-- `idPrefix`: string
-- `heading`, `headingLevel`
-- `items`
+- `idPrefix?`: string
+- `className?`: string
 
 ### Icons
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -55,13 +55,14 @@ import {
   Fieldset,
   Footer,
   Icon,
-  Pagination,
   LinkAction,
   LinkIcon,
   LinkSkip,
+  Pagination,
   Radios,
   Select,
   SummaryList,
+  TaskList,
   Tag,
   Textarea,
   TextInput,
@@ -109,15 +110,27 @@ function App() {
         information.
       </Expander>
       <SummaryList rows={summaryRows} />
-      <Details summary="Why we ask for this">
-        We use your answers to tailor the information you see next.
-      </Details>
-      <Expander summary="What happens next">
-        We will review your answers and let you know if we need any more
-        information.
-      </Expander>
-      <SummaryList rows={summaryRows} />
       <Tag variant="brand">Beta</Tag>
+      <TaskList
+        items={[
+          {
+            title: 'Company directors',
+            href: '#directors',
+            status: {
+              children: 'Complete',
+              variant: 'green',
+            },
+          },
+          {
+            title: 'Registered company details',
+            href: '#company-details',
+            status: {
+              children: 'Incomplete',
+              variant: 'blue',
+            },
+          },
+        ]}
+      />
       <Button variant="contained">Click me</Button>
       <Pagination
         previousUrl="/section/treatments"
@@ -238,6 +251,7 @@ The package also provides:
 - `CharacterCount`
 - `Checkboxes`
 - `Radios`
+- `TaskList`
 - `Icon`
 - `Pagination`
 - `SummaryList`
@@ -291,6 +305,15 @@ A card for short do and don’t recommendation lists.
 **Props:**
 
 - `type`: 'do' | 'dont'
+
+### TaskList
+
+A task list that reuses the shared `Tag` component for the status column.
+
+**Props:**
+
+- `items`: `{ title: ReactNode; href?: string; hint?: ReactNode; status: TagProps; className?: string; titleClassName?: string; hintClassName?: string }[]`
+- `idPrefix`: string
 - `heading`, `headingLevel`
 - `items`
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -9,7 +9,7 @@ Install the packaged GitHub release artifact:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.13.0/ourfuturehealth-react-components-0.13.0.tgz",
+    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.14.0/ourfuturehealth-react-components-0.14.0.tgz",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   }
@@ -313,9 +313,8 @@ A task list that reuses the shared `Tag` component for the status column.
 **Props:**
 
 - `items`: `{ title: ReactNode; href?: string; hint?: ReactNode; status: TagProps; className?: string; titleClassName?: string; hintClassName?: string }[]`
-- `idPrefix`: string
-- `heading`, `headingLevel`
-- `items`
+- `idPrefix?`: string
+- `className?`: string
 
 ### Icons
 

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/react-components",
-  "version": "0.8.0",
+  "version": "0.14.0",
   "type": "module",
   "description": "React component library for OFH Design System",
   "packageManager": "pnpm@10.29.2",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/react-components",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "type": "module",
   "description": "React component library for OFH Design System",
   "packageManager": "pnpm@10.29.2",

--- a/packages/react-components/src/components/TaskList/TaskList.stories.tsx
+++ b/packages/react-components/src/components/TaskList/TaskList.stories.tsx
@@ -1,0 +1,204 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { TaskList } from './TaskList';
+import type { TaskListItemProps } from './TaskList';
+
+const defaultItems: TaskListItemProps[] = [
+  {
+    title: 'Company directors',
+    href: '#directors',
+    status: {
+      children: 'Complete',
+      variant: 'green',
+    },
+  },
+  {
+    title: 'Registered company details',
+    href: '#company-details',
+    status: {
+      children: 'Incomplete',
+      variant: 'blue',
+    },
+  },
+  {
+    title: 'Financial history',
+    hint: 'Include 5 years of the company’s relevant financial information.',
+    href: '#financial-history',
+    status: {
+      children: 'Complete',
+      variant: 'green',
+    },
+  },
+  {
+    title: 'Business plan',
+    href: '#business-plan',
+    status: {
+      children: 'Pending',
+      variant: 'yellow',
+    },
+  },
+  {
+    title: 'References',
+    href: '#references',
+    status: {
+      children: 'Incomplete',
+      variant: 'blue',
+    },
+  },
+];
+
+const meta: Meta<typeof TaskList> = {
+  title: 'Components/Content Presentation/Task list',
+  component: TaskList,
+  parameters: {
+    docsNamespaceArgKeys: ['idPrefix'],
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'A task list for content-presentation journeys. It keeps the toolkit row structure, uses the shared Tag component for the status column, and applies the same clickable row pattern as the toolkit version.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    idPrefix: 'task-list-default',
+    items: defaultItems,
+  },
+  argTypes: {
+    idPrefix: {
+      control: 'text',
+      description:
+        'Prefix used to generate the hint and status ids for each row. Use a unique value when rendering more than one task list on the same docs page.',
+    },
+    items: {
+      control: 'object',
+      description:
+        'Array of task rows. Each row includes title content, an optional hint, an optional href, and a Tag configuration for the status.',
+      table: {
+        type: {
+          summary: 'TaskListItemProps[]',
+        },
+      },
+    },
+    classes: {
+      control: false,
+      description:
+        'Toolkit-parity alias for adding extra classes to the root element. In React-only usage, prefer `className`.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+    className: {
+      control: false,
+      description:
+        'Adds extra classes to the root `<ul>` element for layout or integration hooks.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+    ref: {
+      control: false,
+      description:
+        'React ref for the root `<ul>` element. Use this only when you need direct access to the rendered DOM node.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    idPrefix: 'task-list-default',
+    items: defaultItems,
+  },
+};
+
+export const WithHints: Story = {
+  args: {
+    idPrefix: 'task-list-with-hints',
+    items: [
+      {
+        title: 'Company directors',
+        href: '#directors',
+        hint: 'Add each director’s full name and date of birth.',
+        status: {
+          children: 'Complete',
+          variant: 'green',
+        },
+      },
+      {
+        title: 'Registered company details',
+        href: '#company-details',
+        hint: 'Use the company registration number from your records.',
+        status: {
+          children: 'Incomplete',
+          variant: 'blue',
+        },
+      },
+      {
+        title: 'Financial history',
+        href: '#financial-history',
+        hint: 'Include 5 years of the company’s relevant financial information.',
+        status: {
+          children: 'Pending',
+          variant: 'yellow',
+        },
+      },
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Shows how the optional hint text sits beneath the linked task title while the status tag remains aligned on the right.',
+      },
+    },
+  },
+};
+
+export const StatusVariants: Story = {
+  args: {
+    idPrefix: 'task-list-status-variants',
+    items: [
+      {
+        title: 'Company directors',
+        href: '#directors',
+        status: {
+          children: 'Complete',
+          variant: 'green',
+        },
+      },
+      {
+        title: 'Registered company details',
+        href: '#company-details',
+        status: {
+          children: 'Incomplete',
+          variant: 'blue',
+        },
+      },
+      {
+        title: 'Financial history',
+        href: '#financial-history',
+        status: {
+          children: 'Pending',
+          variant: 'yellow',
+        },
+      },
+    ],
+  },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'A compact example that shows the existing Tag component reused across the task list status column.',
+      },
+    },
+  },
+};

--- a/packages/react-components/src/components/TaskList/TaskList.stories.tsx
+++ b/packages/react-components/src/components/TaskList/TaskList.stories.tsx
@@ -1,6 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Description, Source, Stories, Title } from '@storybook/addon-docs/blocks';
 import { TaskList } from './TaskList';
-import type { TaskListItemProps } from './TaskList';
+import type { TaskListItemProps, TaskListProps } from './TaskList';
+
+type TaskListPreset = 'default' | 'with-hints' | 'status-variants';
+type TaskListStatusMode = 'mixed' | 'complete' | 'incomplete' | 'pending';
+type TaskListStoryArgs = TaskListProps & {
+  taskSet?: TaskListPreset;
+  showHints?: boolean;
+  statusMode?: TaskListStatusMode;
+  itemCount?: 3 | 5;
+};
 
 const defaultItems: TaskListItemProps[] = [
   {
@@ -46,8 +56,297 @@ const defaultItems: TaskListItemProps[] = [
   },
 ];
 
-const meta: Meta<typeof TaskList> = {
-  title: 'Components/Content Presentation/Task list',
+const withHintItems: TaskListItemProps[] = [
+  {
+    title: 'Company directors',
+    href: '#directors',
+    hint: 'Add each director’s full name and date of birth.',
+    status: {
+      children: 'Complete',
+      variant: 'green',
+    },
+  },
+  {
+    title: 'Registered company details',
+    href: '#company-details',
+    hint: 'Use the company registration number from your records.',
+    status: {
+      children: 'Incomplete',
+      variant: 'blue',
+    },
+  },
+  {
+    title: 'Financial history',
+    href: '#financial-history',
+    hint: 'Include 5 years of the company’s relevant financial information.',
+    status: {
+      children: 'Pending',
+      variant: 'yellow',
+    },
+  },
+];
+
+const statusVariantItems: TaskListItemProps[] = [
+  {
+    title: 'Company directors',
+    href: '#directors',
+    status: {
+      children: 'Complete',
+      variant: 'green',
+    },
+  },
+  {
+    title: 'Registered company details',
+    href: '#company-details',
+    status: {
+      children: 'Incomplete',
+      variant: 'blue',
+    },
+  },
+  {
+    title: 'Financial history',
+    href: '#financial-history',
+    status: {
+      children: 'Pending',
+      variant: 'yellow',
+    },
+  },
+];
+
+const taskItemSets: Record<TaskListPreset, TaskListItemProps[]> = {
+  default: defaultItems,
+  'with-hints': withHintItems,
+  'status-variants': statusVariantItems,
+};
+
+const statusVariantMap = {
+  complete: 'green',
+  incomplete: 'blue',
+  pending: 'yellow',
+} satisfies Record<
+  Exclude<TaskListStatusMode, 'mixed'>,
+  NonNullable<TaskListItemProps['status']['variant']>
+>;
+
+const friendlyControlNames = [
+  'taskSet',
+  'showHints',
+  'statusMode',
+  'itemCount',
+  'idPrefix',
+] satisfies Array<keyof TaskListStoryArgs>;
+
+const taskListUsageExample = `import { TaskList } from '@ourfuturehealth/react-components';
+
+const items = [
+  {
+    title: 'Company directors',
+    href: '/company/directors',
+    status: {
+      children: 'Complete',
+      variant: 'green',
+    },
+  },
+  {
+    title: 'Financial history',
+    href: '/company/financial-history',
+    hint: 'Include 5 years of the company’s relevant financial information.',
+    status: {
+      children: 'Incomplete',
+      variant: 'blue',
+    },
+  },
+];
+
+<TaskList
+  idPrefix="company-task-list"
+  items={items}
+/>;
+`;
+
+const taskListItemShapeExample = `type TaskListItemProps = {
+  title: React.ReactNode;
+  href?: string;
+  hint?: React.ReactNode;
+  status: {
+    children: React.ReactNode;
+    variant?: 'neutral' | 'brand' | 'blue' | 'green' | 'yellow' | 'red';
+  };
+  className?: string;
+  titleClassName?: string;
+  hintClassName?: string;
+};
+`;
+
+const defaultStoryCode = `import { TaskList } from '@ourfuturehealth/react-components';
+
+const defaultItems = [
+  {
+    title: 'Company directors',
+    href: '#directors',
+    status: {
+      children: 'Complete',
+      variant: 'green',
+    },
+  },
+  {
+    title: 'Registered company details',
+    href: '#company-details',
+    status: {
+      children: 'Incomplete',
+      variant: 'blue',
+    },
+  },
+  {
+    title: 'Financial history',
+    href: '#financial-history',
+    hint: 'Include 5 years of the company’s relevant financial information.',
+    status: {
+      children: 'Complete',
+      variant: 'green',
+    },
+  },
+  {
+    title: 'Business plan',
+    href: '#business-plan',
+    status: {
+      children: 'Pending',
+      variant: 'yellow',
+    },
+  },
+  {
+    title: 'References',
+    href: '#references',
+    status: {
+      children: 'Incomplete',
+      variant: 'blue',
+    },
+  },
+];
+
+<TaskList
+  idPrefix="task-list-default"
+  items={defaultItems}
+/>;
+`;
+
+const withHintsStoryCode = `import { TaskList } from '@ourfuturehealth/react-components';
+
+const withHintItems = [
+  {
+    title: 'Company directors',
+    href: '#directors',
+    hint: 'Add each director’s full name and date of birth.',
+    status: {
+      children: 'Complete',
+      variant: 'green',
+    },
+  },
+  {
+    title: 'Registered company details',
+    href: '#company-details',
+    hint: 'Use the company registration number from your records.',
+    status: {
+      children: 'Incomplete',
+      variant: 'blue',
+    },
+  },
+  {
+    title: 'Financial history',
+    href: '#financial-history',
+    hint: 'Include 5 years of the company’s relevant financial information.',
+    status: {
+      children: 'Pending',
+      variant: 'yellow',
+    },
+  },
+];
+
+<TaskList
+  idPrefix="task-list-with-hints"
+  items={withHintItems}
+/>;
+`;
+
+const statusVariantsStoryCode = `import { TaskList } from '@ourfuturehealth/react-components';
+
+const statusVariantItems = [
+  {
+    title: 'Company directors',
+    href: '#directors',
+    status: {
+      children: 'Complete',
+      variant: 'green',
+    },
+  },
+  {
+    title: 'Registered company details',
+    href: '#company-details',
+    status: {
+      children: 'Incomplete',
+      variant: 'blue',
+    },
+  },
+  {
+    title: 'Financial history',
+    href: '#financial-history',
+    status: {
+      children: 'Pending',
+      variant: 'yellow',
+    },
+  },
+];
+
+<TaskList
+  idPrefix="task-list-status-variants"
+  items={statusVariantItems}
+/>;
+`;
+
+const buildTaskItems = ({
+  items = [],
+  taskSet = 'default',
+  showHints = true,
+  statusMode = 'mixed',
+  itemCount = 5,
+}: Pick<
+  TaskListStoryArgs,
+  'items' | 'taskSet' | 'showHints' | 'statusMode' | 'itemCount'
+>): TaskListItemProps[] =>
+  (items.length > 0 ? items : taskItemSets[taskSet]).slice(0, itemCount).map((item) => ({
+    ...item,
+    hint: showHints ? item.hint : undefined,
+    status: {
+      ...item.status,
+      variant:
+        statusMode === 'mixed'
+          ? item.status.variant
+          : statusVariantMap[statusMode],
+    },
+  }));
+
+const renderTaskListStory = ({
+  items = [],
+  taskSet = 'default',
+  showHints = true,
+  statusMode = 'mixed',
+  itemCount = 5,
+  ...args
+}: TaskListStoryArgs) => (
+  <TaskList
+    {...args}
+    items={buildTaskItems({
+      items,
+      taskSet,
+      showHints,
+      statusMode,
+      itemCount,
+    })}
+  />
+);
+
+const meta: Meta<TaskListStoryArgs> = {
+  title: 'Components/Task list',
   component: TaskList,
   parameters: {
     docsNamespaceArgKeys: ['idPrefix'],
@@ -55,45 +354,134 @@ const meta: Meta<typeof TaskList> = {
     docs: {
       description: {
         component:
-          'A task list for content-presentation journeys. It keeps the toolkit row structure, uses the shared Tag component for the status column, and applies the same clickable row pattern as the toolkit version.',
+          'Use Task list for long, complex services where users may need to complete tasks in more than one session and can choose the order that works for them. In React, the component API is intentionally small: you pass an `items` array, and you can optionally provide an `idPrefix` when you want stable ids for the row hint/status relationships. The `Builder` story uses extra Storybook-only helper controls, but those are not part of `TaskListProps`.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Pass a required <code>items</code> array. Each item becomes one task
+            row. Use <code>href</code> when the row should be clickable, use
+            <code>hint</code> for optional supporting text, and pass the shared
+            <code>Tag</code> props through <code>status</code>.
+          </p>
+          <p>
+            Use <code>idPrefix</code> when you want predictable ids for the hint
+            and status relationships, such as tests, snapshots, or pages that
+            render more than one task list.
+          </p>
+          <Source code={taskListUsageExample} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes
+            of={Default}
+            include={['idPrefix', 'items', 'classes', 'className']}
+          />
+
+          <h2>
+            <code>items</code> shape
+          </h2>
+          <p>
+            Each entry in the <code>items</code> array follows this shape:
+          </p>
+          <Source code={taskListItemShapeExample} language="tsx" />
+
+          <h2>Storybook builder helpers</h2>
+          <p>
+            <code>taskSet</code>, <code>showHints</code>,{' '}
+            <code>statusMode</code>, and <code>itemCount</code> are only used by
+            the Storybook <code>Builder</code> story to make the component easier
+            to explore. They are not React component props accepted by{' '}
+            <code>TaskList</code>.
+          </p>
+
+          <Stories title="Examples" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],
   args: {
     idPrefix: 'task-list-default',
     items: defaultItems,
+    taskSet: 'default',
+    showHints: true,
+    statusMode: 'mixed',
+    itemCount: 5,
   },
+  render: renderTaskListStory,
   argTypes: {
+    taskSet: {
+      control: 'select',
+      options: ['default', 'with-hints', 'status-variants'],
+      description:
+        'Builder-only Storybook helper. Chooses a preset task list before the other Builder controls are applied.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
+    showHints: {
+      control: 'boolean',
+      description:
+        'Builder-only Storybook helper. Shows or hides any available hint text beneath the task title.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
+    statusMode: {
+      control: 'select',
+      options: ['mixed', 'complete', 'incomplete', 'pending'],
+      description:
+        'Builder-only Storybook helper. Switches between the mixed status example and single-status rows.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
+    itemCount: {
+      control: 'radio',
+      options: [3, 5],
+      description:
+        'Builder-only Storybook helper. Chooses how many rows to show when the selected preset has enough items.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
     idPrefix: {
       control: 'text',
       description:
-        'Prefix used to generate the hint and status ids for each row. Use a unique value when rendering more than one task list on the same docs page.',
+        'Optional prefix used to generate the ids behind each row’s hint and status text. Set this when you want predictable ids for tests, snapshots, or pages that render more than one task list.',
+      table: {
+        category: 'TaskListProps',
+      },
     },
     items: {
-      control: 'object',
+      control: false,
       description:
-        'Array of task rows. Each row includes title content, an optional hint, an optional href, and a Tag configuration for the status.',
+        'Required task row data. Pass one object per task in the order you want the rows to appear. Each item contains the row title, optional `href`, optional `hint`, and the shared `Tag` props used for the status on the right.',
       table: {
         type: {
           summary: 'TaskListItemProps[]',
         },
+        category: 'TaskListProps',
       },
     },
     classes: {
       control: false,
       description:
-        'Toolkit-parity alias for adding extra classes to the root element. In React-only usage, prefer `className`.',
+        'Toolkit-parity escape hatch for adding extra classes to the root `<ul>`. Most React consumers should ignore this and use `className` instead.',
       table: {
-        category: 'Advanced',
+        category: 'TaskListProps',
       },
     },
     className: {
       control: false,
       description:
-        'Adds extra classes to the root `<ul>` element for layout or integration hooks.',
+        'Adds extra classes to the root `<ul>` element. Use this for layout tweaks or integration hooks when you need to target the component from your app.',
       table: {
-        category: 'Advanced',
+        category: 'TaskListProps',
       },
     },
     ref: {
@@ -101,7 +489,7 @@ const meta: Meta<typeof TaskList> = {
       description:
         'React ref for the root `<ul>` element. Use this only when you need direct access to the rendered DOM node.',
       table: {
-        category: 'Advanced',
+        category: 'TaskListProps',
       },
     },
   },
@@ -111,85 +499,80 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  render: () => (
+    <TaskList
+      idPrefix="task-list-default"
+      items={defaultItems}
+    />
+  ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'A realistic default task list example with mixed statuses and one row that includes hint text.',
+      },
+      source: {
+        code: defaultStoryCode,
+      },
+    },
+  },
+};
+
+export const Builder: Story = {
   args: {
-    idPrefix: 'task-list-default',
+    idPrefix: 'task-list-builder',
     items: defaultItems,
+    taskSet: 'default',
+    showHints: true,
+    statusMode: 'mixed',
+    itemCount: 5,
+  },
+  parameters: {
+    controls: {
+      include: friendlyControlNames,
+    },
+    docs: {
+      description: {
+        story:
+          'Use the friendly controls to switch between the built-in task sets, toggle hint text, and try different status patterns without editing raw JSON.',
+      },
+    },
   },
 };
 
 export const WithHints: Story = {
-  args: {
-    idPrefix: 'task-list-with-hints',
-    items: [
-      {
-        title: 'Company directors',
-        href: '#directors',
-        hint: 'Add each director’s full name and date of birth.',
-        status: {
-          children: 'Complete',
-          variant: 'green',
-        },
-      },
-      {
-        title: 'Registered company details',
-        href: '#company-details',
-        hint: 'Use the company registration number from your records.',
-        status: {
-          children: 'Incomplete',
-          variant: 'blue',
-        },
-      },
-      {
-        title: 'Financial history',
-        href: '#financial-history',
-        hint: 'Include 5 years of the company’s relevant financial information.',
-        status: {
-          children: 'Pending',
-          variant: 'yellow',
-        },
-      },
-    ],
-  },
+  render: () => (
+    <TaskList
+      idPrefix="task-list-with-hints"
+      items={withHintItems}
+    />
+  ),
   parameters: {
+    controls: {
+      disable: true,
+    },
     docs: {
       description: {
         story:
           'Shows how the optional hint text sits beneath the linked task title while the status tag remains aligned on the right.',
+      },
+      source: {
+        code: withHintsStoryCode,
       },
     },
   },
 };
 
 export const StatusVariants: Story = {
-  args: {
-    idPrefix: 'task-list-status-variants',
-    items: [
-      {
-        title: 'Company directors',
-        href: '#directors',
-        status: {
-          children: 'Complete',
-          variant: 'green',
-        },
-      },
-      {
-        title: 'Registered company details',
-        href: '#company-details',
-        status: {
-          children: 'Incomplete',
-          variant: 'blue',
-        },
-      },
-      {
-        title: 'Financial history',
-        href: '#financial-history',
-        status: {
-          children: 'Pending',
-          variant: 'yellow',
-        },
-      },
-    ],
-  },
+  render: () => (
+    <TaskList
+      idPrefix="task-list-status-variants"
+      items={statusVariantItems}
+    />
+  ),
   parameters: {
     controls: {
       disable: true,
@@ -198,6 +581,9 @@ export const StatusVariants: Story = {
       description: {
         story:
           'A compact example that shows the existing Tag component reused across the task list status column.',
+      },
+      source: {
+        code: statusVariantsStoryCode,
       },
     },
   },

--- a/packages/react-components/src/components/TaskList/TaskList.test.tsx
+++ b/packages/react-components/src/components/TaskList/TaskList.test.tsx
@@ -1,0 +1,127 @@
+import { createRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import { axe } from 'vitest-axe';
+import { describe, expect, it } from 'vitest';
+import { TaskList } from './TaskList';
+
+describe('TaskList', () => {
+  const items = [
+    {
+      title: 'Company directors',
+      href: '#directors',
+      status: {
+        children: 'Complete',
+        variant: 'green' as const,
+      },
+    },
+    {
+      title: 'Registered company details',
+      href: '#company-details',
+      status: {
+        children: 'Incomplete',
+        variant: 'blue' as const,
+      },
+    },
+    {
+      title: 'Financial history',
+      hint: 'Include 5 years of the company’s relevant financial information.',
+      href: '#financial-history',
+      status: {
+        children: 'Pending',
+        variant: 'yellow' as const,
+      },
+    },
+  ];
+
+  it('renders task rows with linked titles, hints, and Tag statuses', () => {
+    render(<TaskList idPrefix="company-details" items={items} />);
+
+    expect(screen.getByRole('link', { name: 'Company directors' })).toHaveAttribute(
+      'href',
+      '#directors',
+    );
+    expect(screen.getByText('Financial history')).toHaveClass(
+      'ofh-link',
+      'ofh-task-list__link',
+    );
+    expect(
+      screen.getByText(
+        "Include 5 years of the company’s relevant financial information.",
+      ),
+    ).toHaveClass('ofh-task-list__hint');
+    expect(screen.getByText('Complete')).toHaveClass(
+      'ofh-tag',
+      'ofh-tag--green',
+    );
+    expect(screen.getByText('Incomplete')).toHaveClass(
+      'ofh-tag',
+      'ofh-tag--blue',
+    );
+    expect(screen.getByText('Pending')).toHaveClass(
+      'ofh-tag',
+      'ofh-tag--yellow',
+    );
+  });
+
+  it('links the title to the hint and status ids', () => {
+    render(<TaskList idPrefix="company-details" items={items} />);
+
+    expect(screen.getByRole('link', { name: 'Financial history' })).toHaveAttribute(
+      'aria-describedby',
+      'company-details-3-hint company-details-3-status',
+    );
+  });
+
+  it('forwards ref to the list element', () => {
+    const ref = createRef<HTMLUListElement>();
+
+    render(<TaskList ref={ref} idPrefix="company-details" items={items} />);
+
+    expect(ref.current).toBeInstanceOf(HTMLUListElement);
+    expect(ref.current).toHaveClass('ofh-task-list');
+  });
+
+  it('generates unique ids when no idPrefix is provided', () => {
+    render(
+      <div>
+        <TaskList
+          items={[
+            {
+              title: 'First task',
+              href: '#first',
+              status: {
+                children: 'Complete',
+              },
+            },
+          ]}
+        />
+        <TaskList
+          items={[
+            {
+              title: 'Second task',
+              href: '#second',
+              status: {
+                children: 'Incomplete',
+              },
+            },
+          ]}
+        />
+      </div>,
+    );
+
+    const firstLink = screen.getByRole('link', { name: 'First task' });
+    const secondLink = screen.getByRole('link', { name: 'Second task' });
+
+    expect(firstLink.getAttribute('aria-describedby')).not.toEqual(
+      secondLink.getAttribute('aria-describedby'),
+    );
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(<TaskList idPrefix="company-details" items={items} />);
+
+    const results = await axe(container);
+
+    expect(results.violations).toHaveLength(0);
+  });
+});

--- a/packages/react-components/src/components/TaskList/TaskList.tsx
+++ b/packages/react-components/src/components/TaskList/TaskList.tsx
@@ -3,12 +3,19 @@ import { joinClassNames } from '../_internal/joinClassNames';
 import { Tag, type TagProps } from '../Tag';
 
 export interface TaskListItemProps {
+  /** Task title content shown at the start of the row. */
   title: React.ReactNode;
+  /** Optional URL. When provided, the task row becomes a clickable link. */
   href?: string;
+  /** Optional short supporting text shown below the task title. */
   hint?: React.ReactNode;
+  /** Shared Tag props used to render the task status on the right. */
   status: TagProps;
+  /** Additional classes added to the row container. */
   className?: string;
+  /** Additional classes added to the task title element or link. */
   titleClassName?: string;
+  /** Additional classes added to the optional hint element. */
   hintClassName?: string;
 }
 
@@ -17,10 +24,15 @@ export interface TaskListProps
     React.HTMLAttributes<HTMLUListElement>,
     'children' | 'className' | 'ref'
   > {
+  /** Optional prefix used to generate the internal hint and status ids for each row. */
   idPrefix?: string;
+  /** Task rows to render in order. */
   items: TaskListItemProps[];
+  /** Toolkit-parity alias for adding extra classes to the root element. */
   classes?: string;
+  /** Additional classes added to the root `<ul>` element. */
   className?: string;
+  /** React ref for the root `<ul>` element. */
   ref?: React.Ref<HTMLUListElement>;
 }
 

--- a/packages/react-components/src/components/TaskList/TaskList.tsx
+++ b/packages/react-components/src/components/TaskList/TaskList.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { joinClassNames } from '../_internal/joinClassNames';
+import { Tag, type TagProps } from '../Tag';
+
+export interface TaskListItemProps {
+  title: React.ReactNode;
+  href?: string;
+  hint?: React.ReactNode;
+  status: TagProps;
+  className?: string;
+  titleClassName?: string;
+  hintClassName?: string;
+}
+
+export interface TaskListProps
+  extends Omit<
+    React.HTMLAttributes<HTMLUListElement>,
+    'children' | 'className' | 'ref'
+  > {
+  idPrefix?: string;
+  items: TaskListItemProps[];
+  classes?: string;
+  className?: string;
+  ref?: React.Ref<HTMLUListElement>;
+}
+
+export const TaskList = ({
+  idPrefix,
+  items,
+  classes = '',
+  className = '',
+  ref,
+  ...props
+}: TaskListProps) => {
+  const generatedId = React.useId().replace(/:/g, '');
+  const resolvedIdPrefix = idPrefix ?? `task-list-${generatedId}`;
+
+  return (
+    <ul
+      {...props}
+      ref={ref}
+      className={joinClassNames('ofh-task-list', classes, className)}
+    >
+      {items.map((item, index) => {
+        const itemIndex = index + 1;
+        const hintId = item.hint
+          ? `${resolvedIdPrefix}-${itemIndex}-hint`
+          : undefined;
+        const statusId = `${resolvedIdPrefix}-${itemIndex}-status`;
+        const itemClasses = joinClassNames(
+          'ofh-task-list__item',
+          item.href ? 'ofh-task-list__item--with-link' : undefined,
+          item.className,
+        );
+        const nameAndHintClasses = joinClassNames('ofh-task-list__name-and-hint');
+        const titleClasses = joinClassNames(
+          item.href ? 'ofh-link ofh-task-list__link' : undefined,
+          item.titleClassName,
+        );
+
+        return (
+          <li className={itemClasses} key={`${statusId}-${itemIndex}`}>
+            <div className={nameAndHintClasses}>
+              {item.href ? (
+                <a
+                  className={titleClasses}
+                  href={item.href}
+                  aria-describedby={
+                    [hintId, statusId].filter(Boolean).join(' ') || undefined
+                  }
+                >
+                  {item.title}
+                </a>
+              ) : (
+                <div className={item.titleClassName}>{item.title}</div>
+              )}
+
+              {item.hint ? (
+                <div id={hintId} className={joinClassNames('ofh-task-list__hint', item.hintClassName)}>
+                  {item.hint}
+                </div>
+              ) : null}
+            </div>
+
+            <div className="ofh-task-list__status" id={statusId}>
+              <Tag {...item.status} />
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+TaskList.displayName = 'TaskList';

--- a/packages/react-components/src/components/TaskList/index.ts
+++ b/packages/react-components/src/components/TaskList/index.ts
@@ -1,0 +1,2 @@
+export { TaskList } from './TaskList';
+export type { TaskListItemProps, TaskListProps } from './TaskList';

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -104,3 +104,6 @@ export type {
   SummaryListProps,
   SummaryListRow,
 } from './components/SummaryList';
+
+export { TaskList } from './components/TaskList';
+export type { TaskListItemProps, TaskListProps } from './components/TaskList';

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -66,3 +66,6 @@ export type { CardDoDontItem, CardDoDontProps } from './components/CardDoDont';
 
 export { Tag } from './components/Tag';
 export type { TagProps, TagVariant } from './components/Tag';
+
+export { TaskList } from './components/TaskList';
+export type { TaskListItemProps, TaskListProps } from './components/TaskList';

--- a/packages/site/views/_includes/_side-nav.njk
+++ b/packages/site/views/_includes/_side-nav.njk
@@ -72,7 +72,6 @@
   { title: "Link icon", url: "/design-system/components/link-icon" },
   { title: "Link skip", url: "/design-system/components/link-skip" },
   { title: "Pagination", url: "/design-system/components/pagination" },
-  { title: "Task list", url: "/design-system/components/task-list" }
 ] %}
 
 {% set contentPresentation = [
@@ -86,7 +85,8 @@
   { title: "Inset text", url: "/design-system/components/inset-text" },
   { title: "Summary list", url: "/design-system/components/summary-list" },
   { title: "Table", url: "/design-system/components/table" },
-  { title: "Tag", url: "/design-system/components/tag" }
+  { title: "Tag", url: "/design-system/components/tag" },
+  { title: "Task list", url: "/design-system/components/task-list" }
 ] %}
 
 {% set inputComponents = [

--- a/packages/site/views/_includes/_side-nav.njk
+++ b/packages/site/views/_includes/_side-nav.njk
@@ -71,7 +71,7 @@
   { title: "Link action", url: "/design-system/components/link-action" },
   { title: "Link icon", url: "/design-system/components/link-icon" },
   { title: "Link skip", url: "/design-system/components/link-skip" },
-  { title: "Pagination", url: "/design-system/components/pagination" },
+  { title: "Pagination", url: "/design-system/components/pagination" }
 ] %}
 
 {% set contentPresentation = [

--- a/packages/site/views/design-system/components/task-list/index.njk
+++ b/packages/site/views/design-system/components/task-list/index.njk
@@ -2,7 +2,7 @@
 {% set pageSection = "Design system" %}
 {% set subSection = "Components" %}
 {% set pageDescription = "The task list component displays all the tasks a user needs to do, and allows users to easily identify which ones are done and which they still need to do." %}
-{% set theme = "Navigation" %}
+{% set theme = "Content Presentation" %}
 {% set dateUpdated = "March 2024" %}
 {% set backlog_issue_id = "5" %}
 
@@ -51,7 +51,7 @@
   <h4>Grouping tasks</h4>
   <p>If there are a lot of tasks to complete, you might find that grouping them makes it easier for users to understand and plan what they need to do. Tasks can be grouped into separate task lists on a page. Give each task list a short heading that clearly explains the grouping.</p>
   <h3>Statuses</h3>
-  <p>Statuses use colour and a short descriptor to give users a quick overview of how much of the task list they have completed, and how much is left to do.</p>
+  <p>Statuses use a short descriptor to give users a quick overview of how much of the task list they have completed, and how much is left to do.</p>
   <p>Statuses should be helpful to users. The more you add, the harder it is for users to remember them. Start with the smallest number of different statuses you think might work, for example ‘Completed’ and ‘Incomplete’, then add more if your user research shows there’s a need for them.</p>
 
 

--- a/packages/site/views/design-system/components/task-list/index.njk
+++ b/packages/site/views/design-system/components/task-list/index.njk
@@ -2,7 +2,7 @@
 {% set pageSection = "Design system" %}
 {% set subSection = "Components" %}
 {% set pageDescription = "The task list component displays all the tasks a user needs to do, and allows users to easily identify which ones are done and which they still need to do." %}
-{% set theme = "Content Presentation" %}
+{% set theme = "Navigation" %}
 {% set dateUpdated = "March 2024" %}
 {% set backlog_issue_id = "5" %}
 
@@ -18,6 +18,24 @@
     group: "components",
     item: "task-list",
     type: "default"
+  }) }}
+
+  <h3>Task list with hints</h3>
+  <p>Use hint text sparingly when users need a small amount of extra context before they open a task.</p>
+
+  {{ designExample({
+    group: "components",
+    item: "task-list",
+    type: "with-hints"
+  }) }}
+
+  <h3>Status variants</h3>
+  <p>Use short, consistent status labels so users can quickly scan what is complete, incomplete, or still pending.</p>
+
+  {{ designExample({
+    group: "components",
+    item: "task-list",
+    type: "status-variants"
   }) }}
 
   <h2>When to use task lists</h2>

--- a/packages/site/views/design-system/components/task-list/index.njk
+++ b/packages/site/views/design-system/components/task-list/index.njk
@@ -2,8 +2,8 @@
 {% set pageSection = "Design system" %}
 {% set subSection = "Components" %}
 {% set pageDescription = "The task list component displays all the tasks a user needs to do, and allows users to easily identify which ones are done and which they still need to do." %}
-{% set theme = "Navigation" %}
-{% set dateUpdated = "March 2024" %}
+{% set theme = "Content presentation" %}
+{% set dateUpdated = "April 2026" %}
 {% set backlog_issue_id = "5" %}
 
 {% extends "app-layout.njk" %}

--- a/packages/site/views/design-system/components/task-list/status-variants/index.njk
+++ b/packages/site/views/design-system/components/task-list/status-variants/index.njk
@@ -1,7 +1,7 @@
 {% from 'task-list/macro.njk' import taskList %}
 
 {{ taskList({
-  idPrefix: "company-details",
+  idPrefix: "company-details-status-variants",
   items: [
     {
       title: {
@@ -31,38 +31,11 @@
       title: {
         text: "Financial history"
       },
-      hint: {
-        text: "Include 5 years of the company’s relevant financial information."
-      },
-      href: "#",
-      status: {
-        tag: {
-          text: "Complete",
-          classes: "ofh-tag--green"
-        }
-      }
-    },
-    {
-      title: {
-        text: "Business plan"
-      },
       href: "#",
       status: {
         tag: {
           text: "Pending",
           classes: "ofh-tag--yellow"
-        }
-      }
-    },
-    {
-      title: {
-        text: "References"
-      },
-      href: "#",
-      status: {
-        tag: {
-          text: "Incomplete",
-          classes: "ofh-tag--blue"
         }
       }
     }

--- a/packages/site/views/design-system/components/task-list/with-hints/index.njk
+++ b/packages/site/views/design-system/components/task-list/with-hints/index.njk
@@ -1,13 +1,16 @@
 {% from 'task-list/macro.njk' import taskList %}
 
 {{ taskList({
-  idPrefix: "company-details",
+  idPrefix: "company-details-with-hints",
   items: [
     {
       title: {
         text: "Company directors"
       },
       href: "#",
+      hint: {
+        text: "Add each director’s full name and date of birth."
+      },
       status: {
         tag: {
           text: "Complete",
@@ -20,6 +23,9 @@
         text: "Registered company details"
       },
       href: "#",
+      hint: {
+        text: "Use the company registration number from your records."
+      },
       status: {
         tag: {
           text: "Incomplete",
@@ -31,38 +37,14 @@
       title: {
         text: "Financial history"
       },
+      href: "#",
       hint: {
         text: "Include 5 years of the company’s relevant financial information."
       },
-      href: "#",
-      status: {
-        tag: {
-          text: "Complete",
-          classes: "ofh-tag--green"
-        }
-      }
-    },
-    {
-      title: {
-        text: "Business plan"
-      },
-      href: "#",
       status: {
         tag: {
           text: "Pending",
           classes: "ofh-tag--yellow"
-        }
-      }
-    },
-    {
-      title: {
-        text: "References"
-      },
-      href: "#",
-      status: {
-        tag: {
-          text: "Incomplete",
-          classes: "ofh-tag--blue"
         }
       }
     }

--- a/packages/site/views/examples/components/task-list/index.njk
+++ b/packages/site/views/examples/components/task-list/index.njk
@@ -1,6 +1,6 @@
 {% set html_style = 'background-color: #f0f4f5;' %}
-{% set pageTitle = 'Back link' %}
-{% from 'back-link/macro.njk' import backLink %}
+{% set pageTitle = 'Task list' %}
+{% from 'task-list/macro.njk' import taskList %}
 {% extends 'standalone-example-layout.njk' %}
 
 {% block body %}
@@ -10,9 +10,68 @@
 
       <div class="ofh-grid-row">
         <div class="ofh-grid-column-two-thirds">
-          {{ backLink({
-            "href": "#",
-            "text": "Go back"
+          {{ taskList({
+            idPrefix: "company-details",
+            items: [
+              {
+                title: {
+                  text: "Company directors"
+                },
+                href: "#",
+                status: {
+                  tag: {
+                    text: "Complete"
+                  }
+                }
+              },
+              {
+                title: {
+                  text: "Registered company details"
+                },
+                href: "#",
+                status: {
+                  tag: {
+                    text: "Incomplete"
+                  }
+                }
+              },
+              {
+                title: {
+                  text: "Financial history"
+                },
+                hint: {
+                  text: "Include 5 years of the company’s relevant financial information."
+                },
+                href: "#",
+                status: {
+                  tag: {
+                    text: "Complete"
+                  }
+                }
+              },
+              {
+                title: {
+                  text: "Business plan"
+                },
+                href: "#",
+                status: {
+                  tag: {
+                    text: "Pending"
+                  }
+                }
+              },
+              {
+                title: {
+                  text: "References"
+                },
+                href: "#",
+                status: {
+                  tag: {
+                    text: "Incomplete"
+                  }
+                }
+              }
+            ]
           }) }}
         </div>
       </div>

--- a/packages/toolkit/components/task-list/README.md
+++ b/packages/toolkit/components/task-list/README.md
@@ -1,0 +1,59 @@
+# Task list
+
+## Guidance
+
+Use the task list to show a user the tasks they need to complete, along with a short status tag for each task and optional hint text.
+
+## Quick start example
+
+[Preview the task list component](https://ourfuturehealth.github.io/design-system-toolkit/components/task-list/index.html)
+
+### HTML markup
+
+```html
+<ul class="ofh-task-list">
+  <li class="ofh-task-list__item">
+    <div class="ofh-task-list__name-and-hint">
+      <a class="ofh-link ofh-task-list__link" href="#">
+        Company directors
+      </a>
+      <div class="ofh-task-list__hint">Add the details for each director.</div>
+    </div>
+    <div class="ofh-task-list__status">
+      <strong class="ofh-tag">Complete</strong>
+    </div>
+  </li>
+</ul>
+```
+
+### Nunjucks macro
+
+```njk
+{% from 'components/task-list/macro.njk' import taskList %}
+
+{{ taskList({
+  idPrefix: "company-details",
+  items: [
+    {
+      title: {
+        text: "Company directors"
+      },
+      href: "#",
+      hint: {
+        text: "Add the details for each director."
+      },
+      status: {
+        tag: {
+          text: "Complete"
+        }
+      }
+    }
+  ]
+}) }}
+```
+
+### Notes
+
+- Use `status.tag` to render the existing Tag component inside each task row.
+- The task title is linked when `href` is provided and the whole row remains clickable through the shared overlay.
+- Use `hint` only when extra context will help users complete the task.

--- a/packages/toolkit/components/task-list/_task-list.scss
+++ b/packages/toolkit/components/task-list/_task-list.scss
@@ -20,7 +20,9 @@
 
 .ofh-task-list__item {
   border-bottom: 1px solid $ofh-color-border-primary;
-  display: table;
+  display: flex;
+  gap: $ofh-size-24;
+  align-items: flex-start;
   margin-bottom: 0;
   padding-bottom: $ofh-size-8;
   padding-top: $ofh-size-8;
@@ -34,16 +36,17 @@
 
 .ofh-task-list__name-and-hint {
   color: $ofh-color-foreground-primary;
-  display: table-cell;
-  vertical-align: top;
+  display: flex;
+  flex: 1 0 0;
+  flex-direction: column;
+  gap: $ofh-size-4;
+  min-width: 0;
 }
 
 .ofh-task-list__status {
   color: $ofh-color-foreground-primary;
-  display: table-cell;
-  padding-left: 10px;
+  flex-shrink: 0;
   text-align: right;
-  vertical-align: top;
 }
 
 // This adds an empty transparent box covering the whole row, including the task status and
@@ -58,5 +61,4 @@
 
 .ofh-task-list__hint {
   color: $ofh-color-foreground-secondary;
-  margin-top: 5px;
 }

--- a/packages/toolkit/components/task-list/_task-list.scss
+++ b/packages/toolkit/components/task-list/_task-list.scss
@@ -19,19 +19,16 @@
 }
 
 .ofh-task-list__item {
+  align-items: flex-start;
   border-bottom: 1px solid $ofh-color-border-primary;
   display: flex;
-  gap: $ofh-size-24;
-  align-items: flex-start;
   margin-bottom: 0;
   padding-bottom: $ofh-size-8;
   padding-top: $ofh-size-8;
   position: relative;
   width: 100%;
-}
 
-.ofh-task-list__item:first-child {
-  border-top: 1px solid $ofh-color-border-primary;
+  @include ofh-responsive-gap-x(24);
 }
 
 .ofh-task-list__name-and-hint {

--- a/packages/toolkit/components/task-list/template.njk
+++ b/packages/toolkit/components/task-list/template.njk
@@ -35,7 +35,7 @@
   </li>
 {%- endmacro %}
 
-<ul class="ofh-task-list {%- if params.classes %} {{ params.classes }}{% endif %}"
+<ul class="ofh-task-list {%- if params.classes %} {{ params.classes }}{% endif %}">
   {% for item in params.items %}
     {{- _taskListItem(params, item, loop.index) }}
   {% endfor %}

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/toolkit",
-  "version": "4.14.0",
+  "version": "4.15.0",
   "description": "Our Future Health design system toolkit contains the code you need to start building user interfaces for Our Future Health websites and services.",
   "repository": {
     "type": "git",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/toolkit",
-  "version": "4.9.0",
+  "version": "4.15.0",
   "description": "Our Future Health design system toolkit contains the code you need to start building user interfaces for Our Future Health websites and services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
This PR delivers **DSE-334 task list refresh** across toolkit, React, the docs site, and Storybook.

It aligns the toolkit task list with the current Figma treatment, introduces the public React `TaskList` component, adds docs-site examples for the main task-list variants, and brings Storybook into the newer `Docs` / `Default` / `Builder` / showcase teaching pattern.

Ticket: DSE-334

## Release scope
- `@ourfuturehealth/toolkit` -> `4.15.0`
- `@ourfuturehealth/react-components` -> `0.14.0`
- updates release metadata in `CHANGELOG.md`, `UPGRADING.md`, `docs/release-versioning-strategy.md`, `docs/consuming-react-components.md`, and `packages/react-components/README.md`

## Breaking Changes
- None.

## Key Changes
- refreshes the toolkit `task-list` component to the current Figma-aligned row structure and spacing
- removes the legacy first-row top divider so the rendered task list matches the design reference more closely
- uses responsive row gap spacing in the toolkit task list instead of a fixed gap
- adds the public React `TaskList` component using the shared `Tag` component for the status column
- adds docs-site examples for `Task list with hints` and `Status variants`
- updates Storybook so `TaskList` follows the newer docs/default/builder/showcase pattern
- improves the Task List Storybook docs page with a real usage example, `items` shape guidance, and a clearer separation between real props and Builder-only helpers
- adds inline prop descriptions in the React component source so the generated docs are easier for consumers to understand

## Validation
- `npm test`
- `pnpm lint`
- `pnpm build`
- `pnpm docs:release-contract`
- `pnpm smoke:release-artifacts`
- manual QA on Task List docs and Storybook stories

## Reviewer Focus
- toolkit task-list row spacing and divider treatment should now match the current design more closely
- the React `TaskList` API should be easy to understand through the docs page and copyable examples
- Storybook should now teach the component using the newer docs/default/builder/showcase pattern
- release metadata should line up on `toolkit-v4.15.0` / `react-v0.14.0`
