### PR TITLE
DSE-330 :: Inset Text FE update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ## Monorepo Package Releases (`toolkit-v*`, `react-v*`)
 
+### Unreleased
+
+#### @ourfuturehealth/toolkit 4.16.0 (`toolkit-v4.16.0`)
+
+##### Added
+
+- Inset text docs-site examples for `without-heading` and `html-content`
+
+##### Changed
+
+- Refreshed the toolkit `inset-text` component to the current Figma-aligned border, background, and content structure
+- Updated inset-text docs-site guidance so it better explains heading, rich-text, and action-link usage
+
+#### @ourfuturehealth/react-components 0.15.0 (`react-v0.15.0`)
+
+##### Added
+
+- New public `InsetText` component with support for visible headings, rich-text body content, and one action link
+- Storybook coverage for `InsetText` including `Default`, `Builder`, `WithoutHeading`, `HtmlContent`, and `AllVariants`
+
+##### Changed
+
+- Refined the Inset Text Storybook docs page so it teaches the React API, `actionLink` shape, and Builder-only helper controls more clearly
+
 ### 2026-03-30
 
 #### @ourfuturehealth/toolkit 4.8.0 (`toolkit-v4.8.0`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ### 2026-04-30
 
+#### @ourfuturehealth/toolkit 4.16.0 (`toolkit-v4.16.0`)
+
+##### Added
+
+- Inset text docs-site examples for `without-heading` and `html-content`
+
+##### Changed
+
+- Refreshed the toolkit `inset-text` component to the current Figma-aligned border, background, and content structure
+- Updated inset-text docs-site guidance so it better explains heading, rich-text, and action-link usage
+
+#### @ourfuturehealth/react-components 0.15.0 (`react-v0.15.0`)
+
+##### Added
+
+- New public `InsetText` component with support for visible headings, rich-text body content, and one action link
+- Storybook coverage for `InsetText` including `Default`, `Builder`, `WithoutHeading`, `HtmlContent`, and `AllVariants`
+
+##### Changed
+
+- Refined the Inset Text Storybook docs page so it teaches the React API, `actionLink` shape, and Builder-only helper controls more clearly
+
 #### @ourfuturehealth/toolkit 4.15.0 (`toolkit-v4.15.0`)
 
 ##### Added

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,6 +8,7 @@ This guide provides detailed migration instructions for upgrading between versio
 
 | Version                                                 | Date          | Breaking Changes      | Migration Complexity                  |
 | ------------------------------------------------------- | ------------- | --------------------- | ------------------------------------- |
+| [v4.16.0 / React v0.15.0](#upgrading-to-v4160--react-v0150) | April 2026    | No breaking changes | 🟢 Low - adopt the new InsetText APIs only if relevant |
 | [v4.8.0 / React v0.6.0](#upgrading-to-v480--react-v060) | March 2026    | No breaking changes | 🟢 Low - only relevant if you adopted the earlier TextInput prototype |
 | [v4.7.0 / React v0.5.0](#upgrading-to-v470--react-v050) | March 2026    | Card family realignment | 🟡 Medium - API migration recommended |
 | [v4.6.0 / React v0.4.0](#upgrading-to-v460--react-v040) | March 2026    | Tag default + naming  | 🟡 Medium - Search/replace recommended |
@@ -17,6 +18,45 @@ This guide provides detailed migration instructions for upgrading between versio
 | [v4.0.0](#upgrading-to-v400-monorepo-restructure)       | 2025          | Monorepo restructure  | 🔴 High - Installation & paths change |
 
 ---
+
+## Upgrading to v4.16.0 / React v0.15.0
+
+**Planned:** April 2026
+**Affected packages:**
+
+- `@ourfuturehealth/toolkit` v4.16.0+
+- `@ourfuturehealth/react-components` v0.15.0+
+
+### Release Overview
+
+This release does not introduce a supported breaking API change.
+
+Toolkit consumers should review the refreshed `inset-text` structure and docs examples if they already use inset text.
+
+React consumers can now adopt the public `InsetText` component when they need short supporting information with a semantic feedback border, optional heading, and one action link.
+
+### Inset Text
+
+- Toolkit `inset-text` now matches the current Figma treatment more closely, including the refreshed border/background combinations and content structure
+- React now exposes `InsetText` as a public component with support for `heading`, `text` or `html`, variant/background selection, and an optional `actionLink`
+- Storybook and docs-site examples now cover default, without-heading, and rich-text inset text usage
+
+#### React example
+
+```tsx
+import { InsetText } from '@ourfuturehealth/react-components';
+
+<InsetText
+  heading="Information"
+  variant="info"
+  background="grey"
+  text="You can report any suspected side effect to the Yellow Card safety scheme."
+  actionLink={{
+    text: 'Report a side effect',
+    href: '/report-side-effect',
+  }}
+/>;
+```
 
 ## Upgrading to v4.8.0 / React v0.6.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -555,47 +555,6 @@ Current toolkit component templates, docs examples, React stories, and tests hav
 <Icon name="Linkedin" size={24} />
 ```
 
----
-
-## Upgrading to v4.16.0 / React v0.15.0
-
-**Planned:** April 2026
-**Affected packages:**
-
-- `@ourfuturehealth/toolkit` v4.16.0+
-- `@ourfuturehealth/react-components` v0.15.0+
-
-### Release Overview
-
-This release does not introduce a supported breaking API change.
-
-Toolkit consumers should review the refreshed `inset-text` structure and docs examples if they already use inset text.
-
-React consumers can now adopt the public `InsetText` component when they need short supporting information with a semantic feedback border, optional heading, and one action link.
-
-### Inset Text
-
-- Toolkit `inset-text` now matches the current Figma treatment more closely, including the refreshed border/background combinations and content structure
-- React now exposes `InsetText` as a public component with support for `heading`, `text` or `html`, variant/background selection, and an optional `actionLink`
-- Storybook and docs-site examples now cover default, without-heading, and rich-text inset text usage
-
-#### React example
-
-```tsx
-import { InsetText } from '@ourfuturehealth/react-components';
-
-<InsetText
-  heading="Information"
-  variant="info"
-  background="grey"
-  text="You can report any suspected side effect to the Yellow Card safety scheme."
-  actionLink={{
-    text: 'Report a side effect',
-    href: '/report-side-effect',
-  }}
-/>;
-```
-
 ## Upgrading to v4.8.0 / React v0.6.0
 
 **Released:** March 2026

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,6 +8,7 @@ This guide provides detailed migration instructions for upgrading between versio
 
 | Version                                                 | Date          | Breaking Changes           | Migration Complexity                     |
 | ------------------------------------------------------- | ------------- | -------------------------- | ---------------------------------------- |
+| [v4.16.0 / React v0.15.0](#upgrading-to-v4160--react-v0150) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React InsetText if needed and use the refreshed toolkit inset-text APIs when relevant |
 | [v4.15.0 / React v0.14.0](#upgrading-to-v4150--react-v0140) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React TaskList if needed and use the refreshed toolkit task-list APIs when relevant |
 | [v4.14.0 / React v0.13.0](#upgrading-to-v4140--react-v0130) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React pagination if needed |
 | [v4.13.0 / React v0.12.0](#upgrading-to-v4130--react-v0120) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React footer if needed |
@@ -15,7 +16,7 @@ This guide provides detailed migration instructions for upgrading between versio
 | [v4.11.0 / React v0.10.0](#upgrading-to-v4110--react-v0100) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React details family if needed |
 | [v4.10.0 / React v0.9.0](#upgrading-to-v4100--react-v090) | April 2026    | No breaking changes        | 🟢 Low - Adopt the public link family and canonical names for new usage |
 | [React v0.8.0](#upgrading-to-react-v080)                | April 2026    | React `spritePath` removal | 🟢 Low - Remove the deprecated prop      |
-| [v4.9.0 / React v0.7.0](#upgrading-to-v490--react-v070) | April 2026    | Icon naming sync    | 🟡 Medium - Search/replace icon names  |
+| [v4.9.0 / React v0.7.0](#upgrading-to-v490--react-v070) | April 2026    | Icon naming sync           | 🟡 Medium - Search/replace icon names    |
 | [v4.8.0 / React v0.6.0](#upgrading-to-v480--react-v060) | March 2026    | No breaking changes | 🟢 Low - only relevant if you adopted the earlier TextInput prototype |
 | [v4.7.0 / React v0.5.0](#upgrading-to-v470--react-v050) | March 2026    | Card family realignment | 🟡 Medium - API migration recommended |
 | [v4.6.0 / React v0.4.0](#upgrading-to-v460--react-v040) | March 2026    | Tag default + naming  | 🟡 Medium - Search/replace recommended |
@@ -23,6 +24,51 @@ This guide provides detailed migration instructions for upgrading between versio
 | [v4.3.0 / React v0.2.0](#upgrading-to-v430--react-v020) | March 2026    | Button variant naming      | 🟡 Medium - Find/replace required        |
 | [v4.1.0](#upgrading-to-v410)                            | February 2026 | Spacing scale indices      | 🟡 Medium - Index updates required       |
 | [v4.0.0](#upgrading-to-v400-monorepo-restructure)       | 2025          | Monorepo restructure       | 🔴 High - Installation & paths change    |
+
+---
+
+## Upgrading to v4.16.0 / React v0.15.0
+
+**Released:** April 2026
+**Affected packages:**
+
+- `@ourfuturehealth/toolkit` v4.16.0+
+- `@ourfuturehealth/react-components` v0.15.0+
+
+### Breaking Changes
+
+None.
+
+### Release Overview
+
+This release refreshes the toolkit `inset-text` component to the current design-system treatment and introduces the first public React `InsetText` component.
+
+- Toolkit consumers should review the refreshed inset-text border, background, and content structure, especially where local overrides depend on the older treatment.
+- Toolkit docs now show explicit `without-heading` and `html-content` examples.
+- React consumers can now adopt the public `InsetText` component when they need supporting content blocks with optional headings, rich text, and one action link.
+
+### Migration Steps
+
+1. Adopt the public React `InsetText` component where you need toolkit-parity inset text in React.
+2. Prefer the refreshed toolkit inset-text API, docs examples, and canonical usage when touching existing Nunjucks templates.
+3. Re-run visual QA if you have local inset-text overrides, especially around borders, background color, heading visibility, and action-link spacing.
+
+#### React example
+
+**New in `react-v0.15.0`:**
+
+```tsx
+import { InsetText } from '@ourfuturehealth/react-components';
+
+<InsetText
+  heading="Information"
+  text="You can report any suspected side effect to the Yellow Card safety scheme."
+  actionLink={{
+    text: 'Report a side effect',
+    href: '/report-side-effect',
+  }}
+/>;
+```
 
 ---
 
@@ -510,6 +556,45 @@ Current toolkit component templates, docs examples, React stories, and tests hav
 ```
 
 ---
+
+## Upgrading to v4.16.0 / React v0.15.0
+
+**Planned:** April 2026
+**Affected packages:**
+
+- `@ourfuturehealth/toolkit` v4.16.0+
+- `@ourfuturehealth/react-components` v0.15.0+
+
+### Release Overview
+
+This release does not introduce a supported breaking API change.
+
+Toolkit consumers should review the refreshed `inset-text` structure and docs examples if they already use inset text.
+
+React consumers can now adopt the public `InsetText` component when they need short supporting information with a semantic feedback border, optional heading, and one action link.
+
+### Inset Text
+
+- Toolkit `inset-text` now matches the current Figma treatment more closely, including the refreshed border/background combinations and content structure
+- React now exposes `InsetText` as a public component with support for `heading`, `text` or `html`, variant/background selection, and an optional `actionLink`
+- Storybook and docs-site examples now cover default, without-heading, and rich-text inset text usage
+
+#### React example
+
+```tsx
+import { InsetText } from '@ourfuturehealth/react-components';
+
+<InsetText
+  heading="Information"
+  variant="info"
+  background="grey"
+  text="You can report any suspected side effect to the Yellow Card safety scheme."
+  actionLink={{
+    text: 'Report a side effect',
+    href: '/report-side-effect',
+  }}
+/>;
+```
 
 ## Upgrading to v4.8.0 / React v0.6.0
 

--- a/docs/consuming-react-components.md
+++ b/docs/consuming-react-components.md
@@ -141,7 +141,6 @@ The React components package currently provides the following components:
 - `Radios` - Grouped radio inputs with hints and conditional reveals
 - `Icon` - Toolkit icon component with fixed and responsive sizing using bundled SVG data
 - `SummaryList` - Review-answer and key-value summary rows with optional actions
-- `Icon` - Toolkit icon component with fixed and responsive sizing using bundled SVG data
 - `ErrorSummary` - Page-level validation summaries with linked errors
 - `Tag` - Status tags aligned with toolkit Tag variants
 - `TaskList` - Ordered service tasks with optional hint text and shared Tag-based statuses

--- a/docs/consuming-react-components.md
+++ b/docs/consuming-react-components.md
@@ -146,7 +146,6 @@ The React components package currently provides the following components:
 - `Tag` - Status tags aligned with toolkit Tag variants
 - `TaskList` - Ordered service tasks with optional hint text and shared Tag-based statuses
 - `InsetText` - Supporting content blocks with semantic feedback borders, optional headings, and one action link
-- `TaskList` - Ordered service tasks with optional hint text and shared Tag-based statuses
 - `Card` - Content presentation cards for summaries, status, and next steps
 - `CardCallout` - Feedback-style callout cards for informational, warning, success, and error messages
 - `CardDoDont` - Positive and negative recommendation lists

--- a/docs/consuming-react-components.md
+++ b/docs/consuming-react-components.md
@@ -57,7 +57,7 @@ Import components and styles in your React application:
 
 ```tsx
 import React from 'react';
-import { Button, Pagination, TextInput } from '@ourfuturehealth/react-components';
+import { Button, InsetText, TextInput } from '@ourfuturehealth/react-components';
 import '@ourfuturehealth/react-components/styles/participant';
 
 function App() {
@@ -70,11 +70,13 @@ function App() {
         inputWidth={20}
         onChange={(e) => console.log(e.target.value)}
       />
-      <Pagination
-        previousUrl="/section/treatments"
-        previousPage="Treatments"
-        nextUrl="/section/symptoms"
-        nextPage="Symptoms"
+      <InsetText
+        heading="Information"
+        text="You can report any suspected side effect to the Yellow Card safety scheme."
+        actionLink={{
+          text: 'Report a side effect',
+          href: '/report-side-effect',
+        }}
       />
       <Button onClick={() => console.log('Clicked')}>Submit</Button>
     </div>
@@ -142,6 +144,8 @@ The React components package currently provides the following components:
 - `Icon` - Toolkit icon component with fixed and responsive sizing using bundled SVG data
 - `ErrorSummary` - Page-level validation summaries with linked errors
 - `Tag` - Status tags aligned with toolkit Tag variants
+- `TaskList` - Ordered service tasks with optional hint text and shared Tag-based statuses
+- `InsetText` - Supporting content blocks with semantic feedback borders, optional headings, and one action link
 - `TaskList` - Ordered service tasks with optional hint text and shared Tag-based statuses
 - `Card` - Content presentation cards for summaries, status, and next steps
 - `CardCallout` - Feedback-style callout cards for informational, warning, success, and error messages

--- a/docs/consuming-react-components.md
+++ b/docs/consuming-react-components.md
@@ -57,7 +57,7 @@ Import components and styles in your React application:
 
 ```tsx
 import React from 'react';
-import { Button, TextInput } from '@ourfuturehealth/react-components';
+import { Button, InsetText, TextInput } from '@ourfuturehealth/react-components';
 import '@ourfuturehealth/react-components/styles/participant';
 
 function App() {
@@ -69,6 +69,14 @@ function App() {
         hint="Enter your full name"
         inputWidth={20}
         onChange={(e) => console.log(e.target.value)}
+      />
+      <InsetText
+        heading="Information"
+        text="You can report any suspected side effect to the Yellow Card safety scheme."
+        actionLink={{
+          text: 'Report a side effect',
+          href: '/report-side-effect',
+        }}
       />
       <Button onClick={() => console.log('Clicked')}>Submit</Button>
     </div>
@@ -133,6 +141,7 @@ The React components package currently provides the following components:
 - `Icon` - Toolkit sprite icon component with fixed and responsive sizing
 - `ErrorSummary` - Page-level validation summaries with linked errors
 - `Tag` - Status tags aligned with toolkit Tag variants
+- `InsetText` - Supporting content blocks with semantic feedback borders, optional headings, and one action link
 - `Card` - Content presentation cards for summaries, status, and next steps
 - `CardCallout` - Feedback-style callout cards for informational, warning, success, and error messages
 - `CardDoDont` - Positive and negative recommendation lists

--- a/docs/release-versioning-strategy.md
+++ b/docs/release-versioning-strategy.md
@@ -31,8 +31,8 @@ For consumer migration instructions, use [Upgrading Guide](../UPGRADING.md).
 
 | Package                             | Canonical tag pattern | Example tag      |
 | ----------------------------------- | --------------------- | ---------------- |
-| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.15.0` |
-| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.14.0`   |
+| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.16.0` |
+| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.15.0`   |
 
 The release workflow still accepts legacy toolkit tags in the `v*` format for backward compatibility, but new toolkit releases should use `toolkit-v*`.
 
@@ -60,7 +60,7 @@ Consumers must install the package release tarball:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/toolkit": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/toolkit-v4.15.0/ourfuturehealth-toolkit-4.15.0.tgz"
+    "@ourfuturehealth/toolkit": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/toolkit-v{version}/ourfuturehealth-toolkit-{version}.tgz"
   }
 }
 ```
@@ -70,7 +70,7 @@ React consumers follow the same contract:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.14.0/ourfuturehealth-react-components-0.14.0.tgz"
+    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v{version}/ourfuturehealth-react-components-{version}.tgz"
   }
 }
 ```

--- a/docs/release-versioning-strategy.md
+++ b/docs/release-versioning-strategy.md
@@ -31,8 +31,8 @@ For consumer migration instructions, use [Upgrading Guide](../UPGRADING.md).
 
 | Package                             | Canonical tag pattern | Example tag      |
 | ----------------------------------- | --------------------- | ---------------- |
-| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.1.0` |
-| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.6.0`   |
+| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.16.0` |
+| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.15.0`   |
 
 The release workflow still accepts legacy toolkit tags in the `v*` format for backward compatibility, but new toolkit releases should use `toolkit-v*`.
 
@@ -60,7 +60,7 @@ Consumers must install the package release tarball:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/toolkit": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/toolkit-v4.1.0/ourfuturehealth-toolkit-4.1.0.tgz"
+    "@ourfuturehealth/toolkit": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/toolkit-v{version}/ourfuturehealth-toolkit-{version}.tgz"
   }
 }
 ```
@@ -70,7 +70,7 @@ React consumers follow the same contract:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.6.0/ourfuturehealth-react-components-0.6.0.tgz"
+    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v{version}/ourfuturehealth-react-components-{version}.tgz"
   }
 }
 ```
@@ -124,8 +124,10 @@ This table is a visual aid for pre-monorepo versus post-monorepo releases.
 | 15    | `react-v0.4.0`   | N/A             | `0.4.0`       | Monorepo       | Released               |
 | 16    | `toolkit-v4.7.0` | `4.7.0`         | N/A           | Monorepo       | Released               |
 | 17    | `react-v0.5.0`   | N/A             | `0.5.0`       | Monorepo       | Released               |
-| 18    | `toolkit-v4.8.0` | `4.8.0`         | N/A           | Monorepo       | Planned in this branch |
-| 19    | `react-v0.6.0`   | N/A             | `0.6.0`       | Monorepo       | Planned in this branch |
+| 18    | `toolkit-v4.8.0` | `4.8.0`         | N/A           | Monorepo       | Released               |
+| 19    | `react-v0.6.0`   | N/A             | `0.6.0`       | Monorepo       | Released               |
+| 20    | `toolkit-v4.16.0` | `4.16.0`       | N/A           | Monorepo       | Planned in this branch |
+| 21    | `react-v0.15.0`   | N/A            | `0.15.0`      | Monorepo       | Planned in this branch |
 
 ## References
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -54,6 +54,7 @@ import {
   Expander,
   Fieldset,
   Footer,
+  InsetText,
   Icon,
   LinkAction,
   LinkIcon,
@@ -145,6 +146,11 @@ function App() {
       <Card heading="Profile complete" description="You’ve completed all the required profile details." />
       <CardCallout heading="Warning" variant="warning" text="Check this information before you continue." />
       <CardDoDont type="do" items={[{ item: 'keep points short and scannable' }]} />
+      <InsetText
+        heading="Information"
+        text="You can report any suspected side effect to the Yellow Card safety scheme."
+        actionLink={{ text: 'Report a side effect', href: '#report-a-side-effect' }}
+      />
       <Fieldset legend="Contact details" legendSize="medium">
         <TextInput id="email" label="Email address" type="email" width="three-quarters" />
         <TextInput id="phone" label="Phone number" type="tel" width="two-thirds" />
@@ -250,6 +256,7 @@ The package also provides:
 - `Autocomplete`
 - `CharacterCount`
 - `Checkboxes`
+- `InsetText`
 - `Radios`
 - `TaskList`
 - `Icon`
@@ -325,6 +332,18 @@ Commonly used props are listed below. `TaskListProps` also includes optional `cl
 - `className?`: string
 - `classes?`: styling override classes for the root task list element
 - `ref?`: React ref forwarded to the root task list element
+
+### InsetText
+
+A lightweight content callout with feedback border variants, background options, and an optional action link.
+
+**Props:**
+
+- `variant`: 'info' | 'success' | 'warning' | 'error'
+- `background`: 'grey' | 'yellow' | 'blue'
+- `heading`, `headingHtml`, `headingLevel`
+- `text` or `html`
+- `actionLink`
 
 ### Icons
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -9,7 +9,7 @@ Install the packaged GitHub release artifact:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.6.0/ourfuturehealth-react-components-0.6.0.tgz",
+    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.15.0/ourfuturehealth-react-components-0.15.0.tgz",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   }

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -9,7 +9,7 @@ Install the packaged GitHub release artifact:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.14.0/ourfuturehealth-react-components-0.14.0.tgz",
+    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.15.0/ourfuturehealth-react-components-0.15.0.tgz",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   }

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -49,6 +49,7 @@ import {
   DateInput,
   ErrorSummary,
   Fieldset,
+  InsetText,
   Icon,
   Radios,
   Select,
@@ -88,6 +89,11 @@ function App() {
       <Card heading="Profile complete" description="You’ve completed all the required profile details." />
       <CardCallout heading="Warning" variant="warning" text="Check this information before you continue." />
       <CardDoDont type="do" items={[{ item: 'keep points short and scannable' }]} />
+      <InsetText
+        heading="Information"
+        text="You can report any suspected side effect to the Yellow Card safety scheme."
+        actionLink={{ text: 'Report a side effect', href: '#report-a-side-effect' }}
+      />
       <Fieldset legend="Contact details" legendSize="medium">
         <TextInput id="email" label="Email address" type="email" width="three-quarters" />
         <TextInput id="phone" label="Phone number" type="tel" width="two-thirds" />
@@ -185,6 +191,7 @@ The package also provides:
 - `Autocomplete`
 - `CharacterCount`
 - `Checkboxes`
+- `InsetText`
 - `Radios`
 - `Icon`
 
@@ -239,6 +246,18 @@ A card for short do and don’t recommendation lists.
 - `type`: 'do' | 'dont'
 - `heading`, `headingLevel`
 - `items`
+
+### InsetText
+
+A lightweight content callout with feedback border variants, background options, and an optional action link.
+
+**Props:**
+
+- `variant`: 'info' | 'success' | 'warning' | 'error'
+- `background`: 'grey' | 'yellow' | 'blue'
+- `heading`, `headingHtml`, `headingLevel`
+- `text` or `html`
+- `actionLink`
 
 ### Icons
 

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/react-components",
-  "version": "0.6.0",
+  "version": "0.15.0",
   "type": "module",
   "description": "React component library for OFH Design System",
   "packageManager": "pnpm@10.29.2",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/react-components",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "type": "module",
   "description": "React component library for OFH Design System",
   "packageManager": "pnpm@10.29.2",

--- a/packages/react-components/src/components/InsetText/InsetText.stories.tsx
+++ b/packages/react-components/src/components/InsetText/InsetText.stories.tsx
@@ -1,0 +1,176 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  InsetText,
+  type InsetTextBackground,
+  type InsetTextProps,
+  type InsetTextVariant,
+} from './InsetText';
+
+const variants: InsetTextVariant[] = ['info', 'success', 'warning', 'error'];
+const backgrounds: InsetTextBackground[] = ['grey', 'yellow', 'blue'];
+
+const meta: Meta<InsetTextProps> = {
+  title: 'Components/InsetText',
+  component: InsetText,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Inset Text highlights short supporting information with a semantic feedback border, one of three background options, and optional heading and action-link slots.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    heading: {
+      control: 'text',
+      description: 'Optional heading shown above the body content.',
+    },
+    headingHtml: {
+      control: false,
+      description:
+        'Trusted HTML for the heading contents. When this is provided, it replaces `heading`.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+    headingLevel: {
+      control: 'select',
+      options: [2, 3, 4, 5, 6],
+      description:
+        'Semantic heading level for the optional heading. This does not change the visual styling.',
+    },
+    variant: {
+      control: 'select',
+      options: variants,
+      description: 'Feedback border variant: info, success, warning, or error.',
+    },
+    background: {
+      control: 'select',
+      options: backgrounds,
+      description: 'Background variant: grey, yellow, or blue.',
+    },
+    html: {
+      control: false,
+      description:
+        'Trusted HTML body content. When this is provided, it replaces `text`.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+    text: {
+      control: 'text',
+      description: 'Plain text body content shown inside the inset text.',
+    },
+    actionLink: {
+      control: false,
+      description:
+        'Optional action link with `text`, `href`, and optional anchor attributes.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+    visuallyHiddenText: {
+      control: 'text',
+      description:
+        'Optional override for the hidden accessible prefix. By default this is only added when there is no visible heading.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+    classes: {
+      control: false,
+      description:
+        'Toolkit-parity alias for extra root classes. Prefer `className` in React-first usage.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+    className: {
+      control: false,
+      description: 'Adds extra classes to the root `<div>` element.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+    ref: {
+      control: false,
+      description: 'React ref for the root `<div>` element.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+  },
+  args: {
+    heading: 'Information',
+    variant: 'info',
+    background: 'grey',
+    text: 'You can report any suspected side effect to the Yellow Card safety scheme.',
+    actionLink: {
+      text: 'Report a side effect',
+      href: '#report-a-side-effect',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<InsetTextProps>;
+
+export const Default: Story = {};
+
+export const WithoutHeading: Story = {
+  args: {
+    heading: undefined,
+    variant: 'warning',
+    background: 'yellow',
+    text: 'Bring your invitation letter with you on the day.',
+    actionLink: {
+      text: 'View preparation guidance',
+      href: '#view-preparation-guidance',
+    },
+  },
+};
+
+export const HtmlContent: Story = {
+  args: {
+    heading: 'Information',
+    background: 'blue',
+    html: '<p>You can report any suspected side effect to the <a href="https://yellowcard.mhra.gov.uk/">Yellow Card safety scheme</a>.</p>',
+    actionLink: {
+      text: 'Read more',
+      href: '#read-more',
+    },
+  },
+};
+
+export const AllVariants: Story = {
+  parameters: {
+    controls: {
+      disable: true,
+    },
+  },
+  render: () => (
+    <div style={{ display: 'grid', gap: '1rem', maxWidth: '35rem' }}>
+      {backgrounds.flatMap((background) =>
+        variants.map((variant) => (
+          <InsetText
+            key={`${background}-${variant}`}
+            heading={
+              variant === 'info'
+                ? 'Information'
+                : variant[0].toUpperCase() + variant.slice(1)
+            }
+            variant={variant}
+            background={background}
+            text="Short supporting information that matches the selected border and background."
+            actionLink={{
+              text: 'Read more',
+              href: '#read-more',
+            }}
+          />
+        )),
+      )}
+    </div>
+  ),
+};

--- a/packages/react-components/src/components/InsetText/InsetText.stories.tsx
+++ b/packages/react-components/src/components/InsetText/InsetText.stories.tsx
@@ -65,10 +65,12 @@ const htmlContentSource = `import { InsetText } from '@ourfuturehealth/react-com
 />;
 `;
 
-const actionLinkShapeSource = `type InsetTextActionLink = {
-  text: React.ReactNode;
+const actionLinkShapeSource = `import type { AnchorHTMLAttributes, ReactNode } from 'react';
+
+type InsetTextActionLink = {
+  text: ReactNode;
   href: string;
-  attributes?: React.AnchorHTMLAttributes<HTMLAnchorElement>;
+  attributes?: AnchorHTMLAttributes<HTMLAnchorElement>;
 };
 
 const actionLink = {

--- a/packages/react-components/src/components/InsetText/InsetText.stories.tsx
+++ b/packages/react-components/src/components/InsetText/InsetText.stories.tsx
@@ -1,5 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import {
+  ArgTypes,
+  Description,
+  Source,
+  Stories,
+  Title,
+} from '@storybook/addon-docs/blocks';
+import {
   InsetText,
   type InsetTextBackground,
   type InsetTextProps,
@@ -9,30 +16,235 @@ import {
 const variants: InsetTextVariant[] = ['info', 'success', 'warning', 'error'];
 const backgrounds: InsetTextBackground[] = ['grey', 'yellow', 'blue'];
 
-const meta: Meta<InsetTextProps> = {
-  title: 'Components/InsetText',
+type InsetTextStoryArgs = InsetTextProps & {
+  showHeading?: boolean;
+  contentMode?: 'text' | 'html';
+  showActionLink?: boolean;
+  actionLinkText?: string;
+  actionLinkHref?: string;
+};
+
+const defaultInsetTextSource = `import { InsetText } from '@ourfuturehealth/react-components';
+
+<InsetText
+  heading="Information"
+  variant="info"
+  background="grey"
+  text="You can report any suspected side effect to the Yellow Card safety scheme."
+  actionLink={{
+    text: 'Report a side effect',
+    href: '#report-a-side-effect',
+  }}
+/>;
+`;
+
+const withoutHeadingSource = `import { InsetText } from '@ourfuturehealth/react-components';
+
+<InsetText
+  variant="warning"
+  background="yellow"
+  text="Bring your invitation letter with you on the day."
+  actionLink={{
+    text: 'View preparation guidance',
+    href: '#view-preparation-guidance',
+  }}
+/>;
+`;
+
+const htmlContentSource = `import { InsetText } from '@ourfuturehealth/react-components';
+
+<InsetText
+  heading="Information"
+  variant="info"
+  background="blue"
+  html='<p>You can report any suspected side effect to the <a href="https://yellowcard.mhra.gov.uk/">Yellow Card safety scheme</a>.</p>'
+  actionLink={{
+    text: 'Read more',
+    href: '#read-more',
+  }}
+/>;
+`;
+
+const actionLinkShapeSource = `type InsetTextActionLink = {
+  text: React.ReactNode;
+  href: string;
+  attributes?: React.AnchorHTMLAttributes<HTMLAnchorElement>;
+};
+
+const actionLink = {
+  text: 'Report a side effect',
+  href: '#report-a-side-effect',
+  attributes: {
+    target: '_blank',
+    rel: 'noreferrer',
+  },
+};
+`;
+
+const renderBuilderStory = ({
+  showHeading = true,
+  heading = 'Information',
+  contentMode = 'text',
+  showActionLink = true,
+  actionLinkText = 'Report a side effect',
+  actionLinkHref = '#report-a-side-effect',
+  text = 'You can report any suspected side effect to the Yellow Card safety scheme.',
+  ...args
+}: InsetTextStoryArgs) => (
+  <InsetText
+    {...args}
+    heading={showHeading ? heading : undefined}
+    text={contentMode === 'text' ? text : undefined}
+    html={
+      contentMode === 'html'
+        ? '<p>You can report any suspected side effect to the <a href="https://yellowcard.mhra.gov.uk/">Yellow Card safety scheme</a>.</p>'
+        : undefined
+    }
+    actionLink={
+      showActionLink
+        ? {
+            text: actionLinkText,
+            href: actionLinkHref,
+          }
+        : undefined
+    }
+  />
+);
+
+const meta: Meta<InsetTextStoryArgs> = {
+  title: 'Components/Inset text',
   component: InsetText,
   parameters: {
     layout: 'padded',
     docs: {
       description: {
         component:
-          'Inset Text highlights short supporting information with a semantic feedback border, one of three background options, and optional heading and action-link slots.',
+          'Inset Text highlights short supporting information with a semantic feedback border, a background option, and an optional heading and action link. In React, the common path is to pass `text` for simple copy and `actionLink` when you want one clear next step. Use `html` or `headingHtml` only when you need trusted inline markup.',
       },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Start with plain-text content by passing <code>text</code>. Add an
+            optional <code>heading</code> when the message needs a visible label,
+            choose the <code>variant</code> and <code>background</code> that fit
+            the message, and pass <code>actionLink</code> when you want one clear
+            next step below the copy.
+          </p>
+          <p>
+            Only reach for <code>html</code> or <code>headingHtml</code> when the
+            content needs trusted inline markup such as a link inside the body.
+          </p>
+          <Source code={defaultInsetTextSource} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes
+            of={Default}
+            include={[
+              'heading',
+              'headingHtml',
+              'headingLevel',
+              'variant',
+              'background',
+              'text',
+              'html',
+              'actionLink',
+              'visuallyHiddenText',
+              'classes',
+              'className',
+            ]}
+          />
+
+          <h2>
+            <code>actionLink</code> shape
+          </h2>
+          <p>
+            Pass a single action link object when the inset text should offer one
+            clear next step. The optional <code>attributes</code> field lets you
+            forward standard anchor attributes such as <code>target</code>,{' '}
+            <code>rel</code>, or analytics hooks.
+          </p>
+          <Source code={actionLinkShapeSource} language="tsx" />
+
+          <h2>Storybook builder helpers</h2>
+          <p>
+            <code>showHeading</code>, <code>contentMode</code>,{' '}
+            <code>showActionLink</code>, <code>actionLinkText</code>, and{' '}
+            <code>actionLinkHref</code> are only used by the Storybook{' '}
+            <code>Builder</code> story to make the component easier to explore.
+            They are not props accepted by <code>InsetText</code>.
+          </p>
+
+          <Stories title="Examples" />
+
+          <h2>Example source</h2>
+          <Source code={defaultInsetTextSource} language="tsx" />
+          <Source code={withoutHeadingSource} language="tsx" />
+          <Source code={htmlContentSource} language="tsx" />
+        </>
+      ),
     },
   },
   tags: ['autodocs'],
   argTypes: {
+    showHeading: {
+      control: 'boolean',
+      description:
+        'Builder-only Storybook helper. Shows or hides the visible heading.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
+    contentMode: {
+      control: 'radio',
+      options: ['text', 'html'],
+      description:
+        'Builder-only Storybook helper. Chooses between the plain-text body and the rich-text HTML example.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
+    showActionLink: {
+      control: 'boolean',
+      description:
+        'Builder-only Storybook helper. Shows or hides the action link row.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
+    actionLinkText: {
+      control: 'text',
+      description:
+        'Builder-only Storybook helper. Sets the visible label when the action link is enabled.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
+    actionLinkHref: {
+      control: 'text',
+      description:
+        'Builder-only Storybook helper. Sets the href when the action link is enabled.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
     heading: {
       control: 'text',
-      description: 'Optional heading shown above the body content.',
+      description:
+        'Optional visible heading shown above the body copy, such as Information or Warning.',
+      table: {
+        category: 'InsetTextProps',
+      },
     },
     headingHtml: {
       control: false,
       description:
-        'Trusted HTML for the heading contents. When this is provided, it replaces `heading`.',
+        'Trusted HTML for the heading contents. Use this only when the heading itself needs inline markup.',
       table: {
-        category: 'Advanced',
+        category: 'InsetTextProps',
       },
     },
     headingLevel: {
@@ -40,116 +252,212 @@ const meta: Meta<InsetTextProps> = {
       options: [2, 3, 4, 5, 6],
       description:
         'Semantic heading level for the optional heading. This does not change the visual styling.',
+      table: {
+        category: 'InsetTextProps',
+      },
     },
     variant: {
       control: 'select',
       options: variants,
-      description: 'Feedback border variant: info, success, warning, or error.',
+      description:
+        'Feedback border variant. Use info for neutral support, success for confirmation, warning for caution, and error for serious problems.',
+      table: {
+        category: 'InsetTextProps',
+      },
     },
     background: {
       control: 'select',
       options: backgrounds,
-      description: 'Background variant: grey, yellow, or blue.',
-    },
-    html: {
-      control: false,
       description:
-        'Trusted HTML body content. When this is provided, it replaces `text`.',
+        'Background variant behind the inset text body. Choose the one that fits the surrounding layout.',
       table: {
-        category: 'Advanced',
+        category: 'InsetTextProps',
       },
     },
     text: {
       control: 'text',
-      description: 'Plain text body content shown inside the inset text.',
+      description:
+        'Plain-text body content for the common case. Use this instead of `html` when the message does not need inline markup.',
+      table: {
+        category: 'InsetTextProps',
+      },
+    },
+    html: {
+      control: false,
+      description:
+        'Trusted HTML body content. Use this only when the inset text body needs inline markup such as links.',
+      table: {
+        category: 'InsetTextProps',
+      },
     },
     actionLink: {
       control: false,
       description:
-        'Optional action link with `text`, `href`, and optional anchor attributes.',
+        'Optional action link object with `text`, `href`, and optional anchor `attributes`.',
       table: {
-        category: 'Advanced',
+        category: 'InsetTextProps',
+        type: {
+          summary: 'InsetTextActionLink',
+        },
       },
     },
     visuallyHiddenText: {
       control: 'text',
       description:
-        'Optional override for the hidden accessible prefix. By default this is only added when there is no visible heading.',
+        'Optional override for the hidden accessible prefix. This is usually only needed when there is no visible heading and you want to override the default message type.',
       table: {
-        category: 'Advanced',
+        category: 'InsetTextProps',
       },
     },
     classes: {
       control: false,
       description:
-        'Toolkit-parity alias for extra root classes. Prefer `className` in React-first usage.',
+        'Toolkit-parity escape hatch for extra root classes. Most React consumers should ignore this and use `className` instead.',
       table: {
-        category: 'Advanced',
+        category: 'InsetTextProps',
       },
     },
     className: {
       control: false,
-      description: 'Adds extra classes to the root `<div>` element.',
+      description:
+        'Adds extra classes to the root `<div>` element. Use this for layout or integration hooks when you need to target the component from your app.',
       table: {
-        category: 'Advanced',
+        category: 'InsetTextProps',
       },
     },
     ref: {
       control: false,
-      description: 'React ref for the root `<div>` element.',
+      description:
+        'React ref for the root `<div>` element. Use this only when you need direct access to the rendered DOM node.',
       table: {
-        category: 'Advanced',
+        category: 'InsetTextProps',
       },
     },
   },
   args: {
+    showHeading: true,
     heading: 'Information',
+    headingLevel: 3,
     variant: 'info',
     background: 'grey',
+    contentMode: 'text',
     text: 'You can report any suspected side effect to the Yellow Card safety scheme.',
-    actionLink: {
-      text: 'Report a side effect',
-      href: '#report-a-side-effect',
+    showActionLink: true,
+    actionLinkText: 'Report a side effect',
+    actionLinkHref: '#report-a-side-effect',
+  },
+  render: renderBuilderStory,
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <InsetText
+      heading="Information"
+      variant="info"
+      background="grey"
+      text="You can report any suspected side effect to the Yellow Card safety scheme."
+      actionLink={{
+        text: 'Report a side effect',
+        href: '#report-a-side-effect',
+      }}
+    />
+  ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'A realistic default inset text example with a visible heading, plain-text body copy, and one action link.',
+      },
+      source: {
+        code: defaultInsetTextSource,
+      },
     },
   },
 };
 
-export default meta;
-type Story = StoryObj<InsetTextProps>;
-
-export const Default: Story = {};
+export const Builder: Story = {
+  parameters: {
+    controls: {
+      include: [
+        'showHeading',
+        'heading',
+        'headingLevel',
+        'variant',
+        'background',
+        'contentMode',
+        'text',
+        'showActionLink',
+        'actionLinkText',
+        'actionLinkHref',
+      ],
+    },
+  },
+};
 
 export const WithoutHeading: Story = {
-  args: {
-    heading: undefined,
-    variant: 'warning',
-    background: 'yellow',
-    text: 'Bring your invitation letter with you on the day.',
-    actionLink: {
-      text: 'View preparation guidance',
-      href: '#view-preparation-guidance',
+  render: () => (
+    <InsetText
+      variant="warning"
+      background="yellow"
+      text="Bring your invitation letter with you on the day."
+      actionLink={{
+        text: 'View preparation guidance',
+        href: '#view-preparation-guidance',
+      }}
+    />
+  ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'A fixed example without a visible heading, relying on the hidden accessible prefix instead.',
+      },
+      source: {
+        code: withoutHeadingSource,
+      },
     },
   },
 };
 
 export const HtmlContent: Story = {
-  args: {
-    heading: 'Information',
-    background: 'blue',
-    html: '<p>You can report any suspected side effect to the <a href="https://yellowcard.mhra.gov.uk/">Yellow Card safety scheme</a>.</p>',
-    actionLink: {
-      text: 'Read more',
-      href: '#read-more',
+  render: () => (
+    <InsetText
+      heading="Information"
+      variant="info"
+      background="blue"
+      html='<p>You can report any suspected side effect to the <a href="https://yellowcard.mhra.gov.uk/">Yellow Card safety scheme</a>.</p>'
+      actionLink={{
+        text: 'Read more',
+        href: '#read-more',
+      }}
+    />
+  ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'A fixed example that uses trusted HTML for inline rich-text content inside the body copy.',
+      },
+      source: {
+        code: htmlContentSource,
+      },
     },
   },
 };
 
 export const AllVariants: Story = {
-  parameters: {
-    controls: {
-      disable: true,
-    },
-  },
   render: () => (
     <div style={{ display: 'grid', gap: '1rem', maxWidth: '35rem' }}>
       {backgrounds.flatMap((background) =>
@@ -173,4 +481,15 @@ export const AllVariants: Story = {
       )}
     </div>
   ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'A fixed showcase of all border and background combinations so consumers can compare the available variants.',
+      },
+    },
+  },
 };

--- a/packages/react-components/src/components/InsetText/InsetText.test.tsx
+++ b/packages/react-components/src/components/InsetText/InsetText.test.tsx
@@ -1,0 +1,95 @@
+import { createRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import { axe } from 'vitest-axe';
+import { describe, expect, it } from 'vitest';
+import { InsetText } from './InsetText';
+
+describe('InsetText', () => {
+  it('renders the default info variant with a hidden label when no heading is provided', () => {
+    render(
+      <InsetText text="You can report any suspected side effect to the Yellow Card safety scheme." />,
+    );
+
+    expect(document.querySelector('.ofh-inset-text')).toHaveClass(
+      'ofh-inset-text--info',
+      'ofh-inset-text--background-grey',
+    );
+    expect(
+      screen.getByText('Information:', { selector: '.ofh-u-visually-hidden' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'You can report any suspected side effect to the Yellow Card safety scheme.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders heading, action link, and custom classes', () => {
+    render(
+      <InsetText
+        heading="Warning"
+        headingLevel={2}
+        variant="warning"
+        background="yellow"
+        text="Bring your invitation letter with you on the day."
+        actionLink={{
+          text: 'View preparation guidance',
+          href: '#view-preparation-guidance',
+          attributes: {
+            className: 'custom-action-link',
+          },
+        }}
+        className="custom-inset-text"
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Warning', level: 2 }),
+    ).toBeInTheDocument();
+    expect(document.querySelector('.ofh-inset-text')).toHaveClass(
+      'ofh-inset-text--warning',
+      'ofh-inset-text--background-yellow',
+      'custom-inset-text',
+    );
+    expect(
+      screen.getByRole('link', { name: 'View preparation guidance' }),
+    ).toHaveAttribute('href', '#view-preparation-guidance');
+    expect(
+      screen.queryByText('Warning:', { selector: '.ofh-u-visually-hidden' }),
+    ).toBeNull();
+  });
+
+  it('renders trusted html content and forwards ref to the root element', () => {
+    const ref = createRef<HTMLDivElement>();
+
+    render(
+      <InsetText
+        ref={ref}
+        heading="Information"
+        html="<p><strong>Keep this note visible</strong> while you complete the next step.</p>"
+      />,
+    );
+
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    expect(ref.current).toHaveClass('ofh-inset-text');
+    expect(screen.getByText('Keep this note visible')).toBeInTheDocument();
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <InsetText
+        heading="Success"
+        variant="success"
+        background="blue"
+        text="Your preferences have been updated."
+        actionLink={{
+          text: 'Manage preferences',
+          href: '#manage-preferences',
+        }}
+      />,
+    );
+
+    const results = await axe(container);
+    expect(results.violations).toHaveLength(0);
+  });
+});

--- a/packages/react-components/src/components/InsetText/InsetText.tsx
+++ b/packages/react-components/src/components/InsetText/InsetText.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import {
+  getHeadingTag,
+  joinClasses,
+  type HeadingLevel,
+} from '../../internal/ofhUtils';
+
+export type InsetTextVariant = 'info' | 'success' | 'warning' | 'error';
+export type InsetTextBackground = 'grey' | 'yellow' | 'blue';
+
+export interface InsetTextActionLink {
+  text: React.ReactNode;
+  href: string;
+  attributes?: React.AnchorHTMLAttributes<HTMLAnchorElement>;
+}
+
+export interface InsetTextProps
+  extends Omit<
+    React.HTMLAttributes<HTMLDivElement>,
+    'children' | 'dangerouslySetInnerHTML' | 'ref'
+  > {
+  heading?: React.ReactNode;
+  headingHtml?: string;
+  headingLevel?: HeadingLevel;
+  variant?: InsetTextVariant;
+  background?: InsetTextBackground;
+  html?: string;
+  text?: React.ReactNode;
+  actionLink?: InsetTextActionLink;
+  visuallyHiddenText?: string;
+  classes?: string;
+  ref?: React.Ref<HTMLDivElement>;
+}
+
+const defaultHiddenText: Record<InsetTextVariant, string> = {
+  info: 'Information',
+  success: 'Success',
+  warning: 'Warning',
+  error: 'Error',
+};
+
+const renderBodyText = (text: React.ReactNode) => {
+  if (typeof text === 'string' || typeof text === 'number') {
+    return <p>{text}</p>;
+  }
+
+  return text;
+};
+
+export const InsetText = ({
+  heading,
+  headingHtml,
+  headingLevel,
+  variant = 'info',
+  background = 'grey',
+  html,
+  text,
+  actionLink,
+  visuallyHiddenText,
+  classes = '',
+  className = '',
+  ref,
+  ...props
+}: InsetTextProps) => {
+  const hasHeading = Boolean(heading || headingHtml);
+  const resolvedVisuallyHiddenText =
+    visuallyHiddenText ?? (!hasHeading ? defaultHiddenText[variant] : undefined);
+
+  return (
+    <div
+      {...props}
+      ref={ref}
+      className={joinClasses(
+        'ofh-inset-text',
+        `ofh-inset-text--${variant}`,
+        `ofh-inset-text--background-${background}`,
+        classes,
+        className,
+      )}
+    >
+      {resolvedVisuallyHiddenText ? (
+        <span className="ofh-u-visually-hidden">
+          {resolvedVisuallyHiddenText}:
+        </span>
+      ) : null}
+
+      {hasHeading
+        ? React.createElement(
+            getHeadingTag(headingLevel, 3),
+            { className: 'ofh-inset-text__heading' },
+            headingHtml ? (
+              <span dangerouslySetInnerHTML={{ __html: headingHtml }} />
+            ) : (
+              heading
+            ),
+          )
+        : null}
+
+      {html ? (
+        <div
+          className="ofh-inset-text__body"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      ) : text ? (
+        <div className="ofh-inset-text__body">{renderBodyText(text)}</div>
+      ) : null}
+
+      {actionLink ? (
+        <p className="ofh-inset-text__action">
+          <a
+            {...actionLink.attributes}
+            className={joinClasses(
+              'ofh-inset-text__action-link',
+              actionLink.attributes?.className,
+            )}
+            href={actionLink.href}
+          >
+            {actionLink.text}
+          </a>
+        </p>
+      ) : null}
+    </div>
+  );
+};
+
+InsetText.displayName = 'InsetText';

--- a/packages/react-components/src/components/InsetText/index.ts
+++ b/packages/react-components/src/components/InsetText/index.ts
@@ -1,0 +1,7 @@
+export { InsetText } from './InsetText';
+export type {
+  InsetTextActionLink,
+  InsetTextBackground,
+  InsetTextProps,
+  InsetTextVariant,
+} from './InsetText';

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -66,3 +66,11 @@ export type { CardDoDontItem, CardDoDontProps } from './components/CardDoDont';
 
 export { Tag } from './components/Tag';
 export type { TagProps, TagVariant } from './components/Tag';
+
+export { InsetText } from './components/InsetText';
+export type {
+  InsetTextActionLink,
+  InsetTextBackground,
+  InsetTextProps,
+  InsetTextVariant,
+} from './components/InsetText';

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -107,3 +107,11 @@ export type {
 
 export { TaskList } from './components/TaskList';
 export type { TaskListItemProps, TaskListProps } from './components/TaskList';
+
+export { InsetText } from './components/InsetText';
+export type {
+  InsetTextActionLink,
+  InsetTextBackground,
+  InsetTextProps,
+  InsetTextVariant,
+} from './components/InsetText';

--- a/packages/site/views/design-system/components/inset-text/default/index.njk
+++ b/packages/site/views/design-system/components/inset-text/default/index.njk
@@ -1,5 +1,130 @@
 {% from 'inset-text/macro.njk' import insetText %}
 
-{{ insetText({
-  "HTML": "<p>You can report any suspected side effect to the <a href=\"https://yellowcard.mhra.gov.uk/\" title=\"External website\">UK safety scheme</a>.</p>"
-}) }}
+{% set examples = [
+  {
+    "heading": "Information",
+    "variant": "info",
+    "background": "grey",
+    "text": "You can report any suspected side effect to the Yellow Card safety scheme.",
+    "actionLink": {
+      "text": "Report a side effect",
+      "href": "#report-a-side-effect"
+    }
+  },
+  {
+    "heading": "Success",
+    "variant": "success",
+    "background": "grey",
+    "text": "Your contact details have been saved successfully.",
+    "actionLink": {
+      "text": "Review your details",
+      "href": "#review-your-details"
+    }
+  },
+  {
+    "heading": "Warning",
+    "variant": "warning",
+    "background": "grey",
+    "text": "Check this information before you continue.",
+    "actionLink": {
+      "text": "Read the guidance",
+      "href": "#read-the-guidance"
+    }
+  },
+  {
+    "heading": "Error",
+    "variant": "error",
+    "background": "grey",
+    "text": "There is a problem with the information in this section.",
+    "actionLink": {
+      "text": "Fix this section",
+      "href": "#fix-this-section"
+    }
+  },
+  {
+    "heading": "Information",
+    "variant": "info",
+    "background": "yellow",
+    "text": "Keep this note visible while you complete the next step.",
+    "actionLink": {
+      "text": "Read more",
+      "href": "#read-more"
+    }
+  },
+  {
+    "heading": "Success",
+    "variant": "success",
+    "background": "yellow",
+    "text": "Your appointment has been booked for next week.",
+    "actionLink": {
+      "text": "Add it to your calendar",
+      "href": "#add-it-to-your-calendar"
+    }
+  },
+  {
+    "heading": "Warning",
+    "variant": "warning",
+    "background": "yellow",
+    "text": "Bring your invitation letter with you on the day.",
+    "actionLink": {
+      "text": "View preparation guidance",
+      "href": "#view-preparation-guidance"
+    }
+  },
+  {
+    "heading": "Error",
+    "variant": "error",
+    "background": "yellow",
+    "text": "We could not verify the details you entered.",
+    "actionLink": {
+      "text": "Check your answers",
+      "href": "#check-your-answers"
+    }
+  },
+  {
+    "heading": "Information",
+    "variant": "info",
+    "background": "blue",
+    "text": "You can come back to this page later using the same link.",
+    "actionLink": {
+      "text": "Copy the link",
+      "href": "#copy-the-link"
+    }
+  },
+  {
+    "heading": "Success",
+    "variant": "success",
+    "background": "blue",
+    "text": "Your preferences have been updated.",
+    "actionLink": {
+      "text": "Manage preferences",
+      "href": "#manage-preferences"
+    }
+  },
+  {
+    "heading": "Warning",
+    "variant": "warning",
+    "background": "blue",
+    "text": "You may need to wait a few minutes before changes appear.",
+    "actionLink": {
+      "text": "Learn why",
+      "href": "#learn-why"
+    }
+  },
+  {
+    "heading": "Error",
+    "variant": "error",
+    "background": "blue",
+    "text": "We could not submit your answers right now.",
+    "actionLink": {
+      "text": "Try again",
+      "href": "#try-again"
+    }
+  }
+] %}
+
+{% for example in examples %}
+  <div class="ofh-u-margin-bottom-16">
+    {{ insetText(example) }}
+  </div>
+{% endfor %}

--- a/packages/site/views/design-system/components/inset-text/html-content/index.njk
+++ b/packages/site/views/design-system/components/inset-text/html-content/index.njk
@@ -1,0 +1,12 @@
+{% from 'inset-text/macro.njk' import insetText %}
+
+{{ insetText({
+  "heading": "Information",
+  "variant": "info",
+  "background": "blue",
+  "html": "<p>You can report any suspected side effect to the <a href=\"https://yellowcard.mhra.gov.uk/\">Yellow Card safety scheme</a>.</p>",
+  "actionLink": {
+    "text": "Read more",
+    "href": "#read-more"
+  }
+}) }}

--- a/packages/site/views/design-system/components/inset-text/index.njk
+++ b/packages/site/views/design-system/components/inset-text/index.njk
@@ -3,7 +3,7 @@
 {% set subSection = "Components" %}
 {% set pageDescription = "Use inset text to help users identify and understand important content on the page, even if they do not read the whole page." %}
 {% set theme = "Content presentation" %}
-{% set dateUpdated = "November 2021" %}
+{% set dateUpdated = "April 2026" %}
 {% set backlog_issue_id = "18" %}
 
 {% extends "app-layout.njk" %}
@@ -21,7 +21,7 @@
   }) }}
 
   <h2>When to use inset text</h2>
-  <p>Use inset text for content that needs to stand out from the rest of the page.</p>
+  <p>Use inset text for short supporting information that should stand out from surrounding content without becoming the main focus of the page.</p>
 
   <h2 id="when-not-to-use-inset-text">When not to use inset text</h2>
   <p>Do not use inset text in transactional pages. We haven't tested it there yet.</p>
@@ -35,10 +35,19 @@
 
   <h2 id="how-to-use-inset-text">How to use inset text</h2>
   <p>Don't overdo inset text. Think about whether you need it and the best place to put it.</p>
+  <p>Choose the border variant that matches the message:</p>
+  <ul>
+    <li><strong>Info</strong> for helpful context or signposting</li>
+    <li><strong>Success</strong> for positive confirmation</li>
+    <li><strong>Warning</strong> when users should pay attention before continuing</li>
+    <li><strong>Error</strong> for serious or blocking problems</li>
+  </ul>
+  <p>Use the grey, yellow, or blue background that fits the surrounding layout while keeping the feedback border colour consistent.</p>
+  <p>Optional headings work well for short labels such as “Information” or “Warning”. Optional action links should offer one clear next step, not a list of competing actions.</p>
 
   <h3>Accessibility</h3>
   <p>People with visual disabilities may not be able to see the colour that marks out inset text. Instead they may rely on hidden labels to recognise it.</p>
-  <p class="rich-text">We use <code>&lt;span class="visually-hidden"&gt;Information: &lt;/span&gt;</code> to let users with screen readers know that this is different to the body text.</p>
+  <p class="rich-text">When inset text has no visible heading, we add a hidden prefix such as <code>Information:</code>, <code>Warning:</code>, <code>Success:</code>, or <code>Error:</code> so screen reader users still get the message type.</p>
 
   <h2 id="research">Research</h2>
   <p>We've tested inset text in content pages and users understood its purpose. We haven't tested inset text in transactional pages.</p>

--- a/packages/site/views/design-system/components/inset-text/index.njk
+++ b/packages/site/views/design-system/components/inset-text/index.njk
@@ -45,6 +45,24 @@
   <p>Use the grey, yellow, or blue background that fits the surrounding layout while keeping the feedback border colour consistent.</p>
   <p>Optional headings work well for short labels such as “Information” or “Warning”. Optional action links should offer one clear next step, not a list of competing actions.</p>
 
+  <h3 id="without-a-visible-heading">Without a visible heading</h3>
+  <p>You can omit the visible heading when the surrounding context already makes the message clear. In that case the component still includes a hidden message type for screen reader users.</p>
+
+  {{ designExample({
+    group: "components",
+    item: "inset-text",
+    type: "without-heading"
+  }) }}
+
+  <h3 id="rich-text-content">Rich text content</h3>
+  <p>Use rich text when the body needs links or other inline formatting, but keep the message short and focused.</p>
+
+  {{ designExample({
+    group: "components",
+    item: "inset-text",
+    type: "html-content"
+  }) }}
+
   <h3>Accessibility</h3>
   <p>People with visual disabilities may not be able to see the colour that marks out inset text. Instead they may rely on hidden labels to recognise it.</p>
   <p class="rich-text">When inset text has no visible heading, we add a hidden prefix such as <code>Information:</code>, <code>Warning:</code>, <code>Success:</code>, or <code>Error:</code> so screen reader users still get the message type.</p>

--- a/packages/site/views/design-system/components/inset-text/macro-options.json
+++ b/packages/site/views/design-system/components/inset-text/macro-options.json
@@ -1,10 +1,64 @@
 {
   "params": [
     {
+      "name": "heading",
+      "type": "string",
+      "required": false,
+      "description": "Optional heading text shown above the body content."
+    },
+    {
+      "name": "headingHtml",
+      "type": "string",
+      "required": false,
+      "description": "Trusted HTML for the heading contents."
+    },
+    {
+      "name": "headingLevel",
+      "type": "integer",
+      "required": false,
+      "description": "Semantic heading level for the optional heading. Defaults to 3."
+    },
+    {
+      "name": "variant",
+      "type": "string",
+      "required": false,
+      "description": "Feedback border variant: info, success, warning, or error."
+    },
+    {
+      "name": "background",
+      "type": "string",
+      "required": false,
+      "description": "Background variant: grey, yellow, or blue."
+    },
+    {
       "name": "html",
       "type": "string",
-      "required": true,
-      "description": "HTML content to be used within the inset text component."
+      "required": false,
+      "description": "Trusted HTML content to be used within the inset text body."
+    },
+    {
+      "name": "HTML",
+      "type": "string",
+      "required": false,
+      "description": "Deprecated alias for html, retained for backward compatibility."
+    },
+    {
+      "name": "text",
+      "type": "string",
+      "required": false,
+      "description": "Plain text content to be used within the inset text body."
+    },
+    {
+      "name": "actionLink",
+      "type": "object",
+      "required": false,
+      "description": "Optional action link object with text, href, and attributes."
+    },
+    {
+      "name": "visuallyHiddenText",
+      "type": "string",
+      "required": false,
+      "description": "Optional override for the hidden accessible prefix."
     },
     {
       "name": "classes",

--- a/packages/site/views/design-system/components/inset-text/without-heading/index.njk
+++ b/packages/site/views/design-system/components/inset-text/without-heading/index.njk
@@ -1,0 +1,11 @@
+{% from 'inset-text/macro.njk' import insetText %}
+
+{{ insetText({
+  "variant": "warning",
+  "background": "yellow",
+  "text": "Bring your invitation letter with you on the day.",
+  "actionLink": {
+    "text": "View preparation guidance",
+    "href": "#view-preparation-guidance"
+  }
+}) }}

--- a/packages/toolkit/components/inset-text/README.md
+++ b/packages/toolkit/components/inset-text/README.md
@@ -11,9 +11,16 @@ Find out more about the inset text component and when to use it in the [design s
 ### HTML markup
 
 ```html
-<div class="ofh-inset-text">
-  <span class="ofh-u-visually-hidden">Information: </span>
-  <p>You can report any suspected side effect to the <a href="https://yellowcard.mhra.gov.uk/" title="External website">UK safety scheme</a>.</p>
+<div class="ofh-inset-text ofh-inset-text--info ofh-inset-text--background-grey">
+  <h3 class="ofh-inset-text__heading">Information</h3>
+  <div class="ofh-inset-text__body">
+    <p>You can report any suspected side effect to the <a href="https://yellowcard.mhra.gov.uk/" title="External website">UK safety scheme</a>.</p>
+  </div>
+  <p class="ofh-inset-text__action">
+    <a class="ofh-inset-text__action-link" href="https://yellowcard.mhra.gov.uk/">
+      Report a side effect
+    </a>
+  </p>
 </div>
 ```
 
@@ -25,7 +32,14 @@ If you’re using Nunjucks macros in production be aware that using `html` argum
 {% from 'components/inset-text/macro.njk' import insetText %}
 
 {{ insetText({
-  "HTML": "<p>You can report any suspected side effect to the <a href=\"https://yellowcard.mhra.gov.uk/\" title=\"External website\">UK safety scheme</a>.</p>"
+  "heading": "Information",
+  "variant": "info",
+  "background": "grey",
+  "html": "<p>You can report any suspected side effect to the <a href=\"https://yellowcard.mhra.gov.uk/\" title=\"External website\">UK safety scheme</a>.</p>",
+  "actionLink": {
+    "text": "Report a side effect",
+    "href": "https://yellowcard.mhra.gov.uk/"
+  }
 }) }}
 ```
 
@@ -35,7 +49,16 @@ The inset text Nunjucks macro takes the following arguments:
 
 | Name                    | Type     | Required  | Description  |
 | ------------------------|----------|-----------|--------------|
-| **HTML**                | string   | Yes       | HTML content to be used within the inset text component. |
+| **heading**             | string   | No        | Optional heading text shown above the body content. Ignored when `headingHtml` is provided. |
+| **headingHtml**         | string   | No        | Trusted HTML for the heading contents. |
+| **headingLevel**        | integer  | No        | Semantic heading level for the optional heading. Defaults to `3`. |
+| **variant**             | string   | No        | Feedback border variant: `info`, `success`, `warning`, or `error`. Defaults to `info`. |
+| **background**          | string   | No        | Background variant: `grey`, `yellow`, or `blue`. Defaults to `grey`. |
+| **html**                | string   | No        | Trusted HTML content for the body. When this is provided, it replaces `text`. |
+| **HTML**                | string   | No        | Deprecated alias for `html`, retained for backward compatibility. |
+| **text**                | string   | No        | Plain text content for the body. Ignored if `html` is provided. |
+| **actionLink**          | object   | No        | Optional action link shown below the body. Supports `text`, `href`, and `attributes`. |
+| **visuallyHiddenText**  | string   | No        | Override for the hidden accessible prefix. Defaults to the variant label when there is no visible heading. |
 | **classes**             | string   | No        | Optional additional classes to add to the inset text container. Separate each class with a space. |
 | **attributes**          | object   | No        | Any extra HTML attributes (for example data attributes) to add to the inset text container. |
 

--- a/packages/toolkit/components/inset-text/_inset-text.scss
+++ b/packages/toolkit/components/inset-text/_inset-text.scss
@@ -3,24 +3,66 @@
    ========================================================================== */
 
 /**
- * 1. Removes top margin from first element and bottom margin from last,
- *    to ensure correct spacing within the component.
- * 2. Restricts the width of the text to optimise the line length for
+ * 1. Restricts the width of the text to optimise the line length for
  *    readability.
  */
 
 .ofh-inset-text {
-  @include top-and-bottom(); /* [1] */
-  @include reading-width(); /* [2] */
+  @include reading-width(); /* [1] */
+  @include ofh-font('paragraph-md');
+  @include ofh-responsive-gap(16);
   @include ofh-responsive-margin(40, 'bottom');
   @include ofh-responsive-margin(40, 'top');
-  @include ofh-responsive-padding(16);
+  @include ofh-responsive-padding(24);
 
-  background-color: $ofh-color-greyscale-white;
-  border-left: $ofh-stroke-weight-8 solid
-    $ofh-color-brand-blue-royal-3-main;
+  background-color: $ofh-color-background-secondary-grey;
+  border-left: $ofh-stroke-weight-8 solid $ofh-color-border-feedback-info;
+  color: $ofh-color-foreground-primary;
+  display: flex;
+  flex-direction: column;
+
+  &.ofh-inset-text--success {
+    border-left-color: $ofh-color-border-feedback-success;
+  }
+
+  &.ofh-inset-text--warning {
+    border-left-color: $ofh-color-border-feedback-warning;
+  }
+
+  &.ofh-inset-text--error {
+    border-left-color: $ofh-color-border-feedback-error;
+  }
+
+  &.ofh-inset-text--background-yellow {
+    background-color: $ofh-color-background-secondary-yellow;
+  }
+
+  &.ofh-inset-text--background-blue {
+    background-color: $ofh-color-background-secondary-blue;
+  }
 
   @include mq($media-type: print) {
     border-color: $ofh-color-foreground-primary;
   }
+}
+
+.ofh-inset-text__heading {
+  @include ofh-font('heading-md', $weight: bold);
+
+  margin: 0;
+}
+
+.ofh-inset-text__body {
+  @include top-and-bottom();
+
+  width: 100%;
+}
+
+.ofh-inset-text__action {
+  margin: 0;
+  width: 100%;
+}
+
+.ofh-inset-text__action-link {
+  @include ofh-font('paragraph-md');
 }

--- a/packages/toolkit/components/inset-text/template.njk
+++ b/packages/toolkit/components/inset-text/template.njk
@@ -1,6 +1,58 @@
-<div class="ofh-inset-text
+{% set headingLevel = params.headingLevel if params.headingLevel else 3 %}
+{% set variant = params.variant if params.variant else 'info' %}
+{% set background = params.background if params.background else 'grey' %}
+{% set contentHtml = params.html if params.html else params.HTML %}
+{% set hasHeading = params.heading or params.headingHtml %}
+
+{% if params.visuallyHiddenText is defined %}
+  {% set visuallyHiddenText = params.visuallyHiddenText %}
+{% elif not hasHeading %}
+  {% if variant == 'error' %}
+    {% set visuallyHiddenText = 'Error' %}
+  {% elif variant == 'success' %}
+    {% set visuallyHiddenText = 'Success' %}
+  {% elif variant == 'warning' %}
+    {% set visuallyHiddenText = 'Warning' %}
+  {% else %}
+    {% set visuallyHiddenText = 'Information' %}
+  {% endif %}
+{% else %}
+  {% set visuallyHiddenText = false %}
+{% endif %}
+
+<div class="ofh-inset-text ofh-inset-text--{{ variant }} ofh-inset-text--background-{{ background }}
 {%- if params.classes %} {{ params.classes }}{% endif %}"
-{%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
-  <span class="ofh-u-visually-hidden">Information: </span>
-  {{ params.HTML | safe }}
+{%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {% if visuallyHiddenText %}
+    <span class="ofh-u-visually-hidden">{{ visuallyHiddenText }}:</span>
+  {% endif %}
+
+  {% if params.headingHtml or params.heading %}
+    <h{{ headingLevel }} class="ofh-inset-text__heading">
+      {% if params.headingHtml %}
+        <span>{{ params.headingHtml | safe }}</span>
+      {% else %}
+        {{ params.heading | safe }}
+      {% endif %}
+    </h{{ headingLevel }}>
+  {% endif %}
+
+  {% if contentHtml %}
+    <div class="ofh-inset-text__body">{{ contentHtml | safe }}</div>
+  {% elif params.text %}
+    <div class="ofh-inset-text__body">
+      <p>{{ params.text | safe }}</p>
+    </div>
+  {% endif %}
+
+  {% if params.actionLink %}
+    <p class="ofh-inset-text__action">
+      <a
+        class="ofh-inset-text__action-link"
+        href="{{ params.actionLink.href }}"
+        {%- for attribute, value in params.actionLink.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+        {{ params.actionLink.text | safe }}
+      </a>
+    </p>
+  {% endif %}
 </div>

--- a/packages/toolkit/components/inset-text/template.njk
+++ b/packages/toolkit/components/inset-text/template.njk
@@ -32,7 +32,7 @@
       {% if params.headingHtml %}
         <span>{{ params.headingHtml | safe }}</span>
       {% else %}
-        {{ params.heading | safe }}
+        {{ params.heading }}
       {% endif %}
     </h{{ headingLevel }}>
   {% endif %}
@@ -41,7 +41,7 @@
     <div class="ofh-inset-text__body">{{ contentHtml | safe }}</div>
   {% elif params.text %}
     <div class="ofh-inset-text__body">
-      <p>{{ params.text | safe }}</p>
+      <p>{{ params.text }}</p>
     </div>
   {% endif %}
 
@@ -51,7 +51,7 @@
         class="ofh-inset-text__action-link"
         href="{{ params.actionLink.href }}"
         {%- for attribute, value in params.actionLink.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
-        {{ params.actionLink.text | safe }}
+        {{ params.actionLink.text }}
       </a>
     </p>
   {% endif %}

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/toolkit",
-  "version": "4.15.0",
+  "version": "4.16.0",
   "description": "Our Future Health design system toolkit contains the code you need to start building user interfaces for Our Future Health websites and services.",
   "repository": {
     "type": "git",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/toolkit",
-  "version": "4.8.0",
+  "version": "4.16.0",
   "description": "Our Future Health design system toolkit contains the code you need to start building user interfaces for Our Future Health websites and services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
This PR delivers **DSE-330 inset text refresh** across toolkit, React, the docs site, and Storybook.

It refreshes the inset text component work in toolkit and React, expands the docs-site examples to cover the main usage patterns, and brings Storybook into the newer `Docs` / `Default` / `Builder` / showcase teaching pattern.

Ticket: DSE-330

## Release scope
- `@ourfuturehealth/toolkit` -> `4.16.0`
- `@ourfuturehealth/react-components` -> `0.15.0`
- updates release metadata in `CHANGELOG.md`, `UPGRADING.md`, `docs/release-versioning-strategy.md`, `docs/consuming-react-components.md`, and `packages/react-components/README.md`

## Breaking Changes
- None.

## Key Changes
- refreshes the toolkit `inset-text` component to the current Figma-aligned border, background, and content structure
- adds the public React `InsetText` component
- adds docs-site examples for:
  - `Without heading`
  - `HTML content`
- updates Storybook so `InsetText` follows the newer docs/default/builder/showcase pattern
- improves the Storybook docs page with:
  - a real `How to use the React component` section
  - a copyable usage snippet
  - clearer real-prop descriptions
  - an `actionLink` shape example
  - a clearer separation between real props and Builder-only helpers
- keeps `Default` as a realistic fixed example, `Builder` as the interactive surface, and showcase stories as fixed usage examples

## Validation
- `npm test`
- `pnpm lint`
- `pnpm build`
- `pnpm docs:release-contract`
- `pnpm smoke:release-artifacts`
- manual QA on the Inset Text Storybook docs page, default/builder split, and showcase stories

## Reviewer Focus
- the React `InsetText` docs page should now teach the API clearly and make the `actionLink` shape easy to adopt
- `Default`, `Builder`, `WithoutHeading`, `HtmlContent`, and `AllVariants` should each have a clear teaching purpose
- release metadata should line up on `toolkit-v4.16.0` / `react-v0.15.0`
