### PR TITLE
DSE-427 :: Table FE update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ### 2026-04-30
 
+#### @ourfuturehealth/toolkit 4.18.0 (`toolkit-v4.18.0`)
+
+##### Added
+
+- Expanded docs-site coverage for the `table` component, including:
+  - responsive multi-column tables
+  - first-cell row headers
+  - numeric columns
+  - column and row spans
+
+##### Changed
+
+- Refined the toolkit `table` component to match the current Figma responsive/mobile treatment more closely
+- Updated the responsive table rows to use clearer label/value columns and a Figma-aligned `2px` closing border
+- Expanded the table docs page and macro guidance so the current table patterns are easier to understand and adopt
+
+#### @ourfuturehealth/react-components 0.17.0 (`react-v0.17.0`)
+
+##### Added
+
+- New public `Table` component with caption, head, rows, responsive stacking, numeric cells, and merged-cell support
+- Storybook coverage for `Table`, including `Default`, `Builder`, `ResponsiveMultiColumn`, `FirstCellIsHeader`, `NumericValues`, and `ColSpanAndRowSpan`
+
+##### Changed
+
+- Refined the Table Storybook docs page so it teaches the React API clearly and separates Builder-only helpers from real props
+
 #### @ourfuturehealth/toolkit 4.17.0 (`toolkit-v4.17.0`)
 
 ##### Added
@@ -190,17 +217,6 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
   - `LinkIcon`
   - `LinkSkip`
 
-### 2026-04-15
-
-#### @ourfuturehealth/react-components 0.8.0 (`react-v0.8.0`)
-
-##### ⚠️ BREAKING CHANGES
-
-- React `Icon` and `Card` icon configuration no longer accept `spritePath`. React icons now always render from bundled toolkit SVG data.
-
-##### Fixed
-
-- React icons now render correctly in published-consumer installs by inlining the requested bundled SVG symbol instead of referencing a bundled `data:` sprite URL.
 
 #### @ourfuturehealth/toolkit 4.9.0 (`toolkit-v4.9.0`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,8 +102,6 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 - Refined the Task List Storybook docs page so it teaches the React API, `items` shape, and Builder-only helper controls more clearly
 
-### 2026-04-28
-
 #### @ourfuturehealth/toolkit 4.14.0 (`toolkit-v4.14.0`)
 
 ##### Changed
@@ -229,6 +227,7 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 - React icons now render correctly in published-consumer installs by inlining the requested bundled SVG symbol instead of referencing a bundled `data:` sprite URL.
 
+### 2026-04-09
 
 #### @ourfuturehealth/toolkit 4.9.0 (`toolkit-v4.9.0`)
 
@@ -264,7 +263,7 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 - Updated the public React `Icon` stories/tests and current component consumers to use the renamed icon surface
 
-### 2026-03-30
+### 2026-04-08
 
 #### @ourfuturehealth/toolkit 4.8.0 (`toolkit-v4.8.0`)
 
@@ -352,8 +351,6 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 - Refined Card-family Storybook docs, controls behaviour, and examples for easier manual QA
 - Updated Card icon stories to expose glyph and colour controls that match the current component behavior
 
-### 2026-03-24
-
 #### @ourfuturehealth/toolkit 4.6.0 (`toolkit-v4.6.0`)
 
 ##### ⚠️ BREAKING CHANGES
@@ -383,7 +380,7 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 - Storybook coverage for default, variant showcase, and usage-example Tag stories
 - Unit and accessibility coverage for variant mapping, children rendering, passthrough props, and ref support
 
-### 2026-03-19
+### 2026-03-24
 
 #### @ourfuturehealth/toolkit 4.5.0 (`toolkit-v4.5.0`)
 
@@ -409,7 +406,7 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 - Direct typography alias support for legacy keys such as `h1`, `lead`, `paragraph`, and `list-small`
 - Legacy direct typography utility aliases such as `.ofh-u-font-size-h1`; use numeric override classes such as `.ofh-u-font-size-64` instead
 
-### 2026-03-11
+### 2026-03-16
 
 #### @ourfuturehealth/toolkit 4.4.0 (`toolkit-v4.4.0`)
 
@@ -446,7 +443,7 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 - React Storybook examples now isolate link targets per story so docs previews do not jump into unrelated story content
 - In-form and multiple-errors stories were expanded to make focus and scroll behaviour easier to validate manually
 
-### 2026-03-10
+### 2026-03-11
 
 #### @ourfuturehealth/toolkit 4.3.0 (`toolkit-v4.3.0`)
 
@@ -480,6 +477,8 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 - Updated Button component variant types, stories, tests, example app, and docs to use the renamed button variants
 - `Button` now renders an anchor automatically when `href` is provided, with ref support for both button and anchor paths
 - Expanded story and test coverage for link rendering, keyboard navigation, and form usage
+
+### 2026-03-10
 
 #### @ourfuturehealth/toolkit 4.2.0 (`toolkit-v4.2.0`)
 
@@ -558,7 +557,7 @@ The 14 legacy `icon-*.svg` files have been replaced with a comprehensive Materia
 - For decorative icons, omit the `title` parameter (automatically sets `aria-hidden="true"`)
 - For semantic icons, include a `title` parameter for accessibility
 
-### 2026-02-26
+### 2026-03-02
 
 #### @ourfuturehealth/toolkit 4.1.0 (`toolkit-v4.1.0`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,6 +217,18 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
   - `LinkIcon`
   - `LinkSkip`
 
+### 2026-04-15
+
+#### @ourfuturehealth/react-components 0.8.0 (`react-v0.8.0`)
+
+##### ⚠️ BREAKING CHANGES
+
+- React `Icon` and `Card` icon configuration no longer accept `spritePath`. React icons now always render from bundled toolkit SVG data.
+
+##### Fixed
+
+- React icons now render correctly in published-consumer installs by inlining the requested bundled SVG symbol instead of referencing a bundled `data:` sprite URL.
+
 
 #### @ourfuturehealth/toolkit 4.9.0 (`toolkit-v4.9.0`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,32 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ### Unreleased
 
-#### @ourfuturehealth/react-components 0.8.0 (`react-v0.8.0`)
+#### @ourfuturehealth/toolkit 4.18.0 (`toolkit-v4.18.0`)
 
-##### ⚠️ BREAKING CHANGES
+##### Added
 
-- React `Icon` and `Card` icon configuration no longer accept `spritePath`. React icons now always render from bundled toolkit SVG data.
+- Expanded docs-site coverage for the `table` component, including:
+  - responsive multi-column tables
+  - first-cell row headers
+  - numeric columns
+  - column and row spans
 
-##### Fixed
+##### Changed
 
-- React icons now render correctly in published-consumer installs by inlining the requested bundled SVG symbol instead of referencing a bundled `data:` sprite URL.
+- Refined the toolkit `table` component to match the current Figma responsive/mobile treatment more closely
+- Updated the responsive table rows to use clearer label/value columns and a Figma-aligned `2px` closing border
+- Expanded the table docs page and macro guidance so the current table patterns are easier to understand and adopt
+
+#### @ourfuturehealth/react-components 0.17.0 (`react-v0.17.0`)
+
+##### Added
+
+- New public `Table` component with caption, head, rows, responsive stacking, numeric cells, and merged-cell support
+- Storybook coverage for `Table`, including `Default`, `Builder`, `ResponsiveMultiColumn`, `FirstCellIsHeader`, `NumericValues`, and `ColSpanAndRowSpan`
+
+##### Changed
+
+- Refined the Table Storybook docs page so it teaches the React API clearly and separates Builder-only helpers from real props
 
 ### 2026-04-09
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,6 +8,7 @@ This guide provides detailed migration instructions for upgrading between versio
 
 | Version                                                 | Date          | Breaking Changes           | Migration Complexity                     |
 | ------------------------------------------------------- | ------------- | -------------------------- | ---------------------------------------- |
+| [v4.18.0 / React v0.17.0](#upgrading-to-v4180--react-v0170) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React Table if needed and use the refreshed toolkit table APIs when relevant |
 | [v4.17.0 / React v0.16.0](#upgrading-to-v4170--react-v0160) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React Image if needed and use the refreshed toolkit image APIs when relevant |
 | [v4.16.0 / React v0.15.0](#upgrading-to-v4160--react-v0150) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React InsetText if needed and use the refreshed toolkit inset-text APIs when relevant |
 | [v4.15.0 / React v0.14.0](#upgrading-to-v4150--react-v0140) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React TaskList if needed and use the refreshed toolkit task-list APIs when relevant |
@@ -25,6 +26,59 @@ This guide provides detailed migration instructions for upgrading between versio
 | [v4.3.0 / React v0.2.0](#upgrading-to-v430--react-v020) | March 2026    | Button variant naming      | 🟡 Medium - Find/replace required        |
 | [v4.1.0](#upgrading-to-v410)                            | February 2026 | Spacing scale indices      | 🟡 Medium - Index updates required       |
 | [v4.0.0](#upgrading-to-v400-monorepo-restructure)       | 2025          | Monorepo restructure       | 🔴 High - Installation & paths change    |
+
+---
+
+## Upgrading to v4.18.0 / React v0.17.0
+
+**Released:** April 2026
+**Affected packages:**
+
+- `@ourfuturehealth/toolkit` v4.18.0+
+- `@ourfuturehealth/react-components` v0.17.0+
+
+### Breaking Changes
+
+None.
+
+### Release Overview
+
+This release refreshes the toolkit `table` component to the current design-system treatment and introduces the first public React `Table` component.
+
+- Toolkit consumers should review the refreshed responsive/mobile stacked-row treatment, the `2px` closing border, and the expanded docs examples for row headers, numeric values, and merged cells.
+- React consumers can now adopt the public `Table` component when they need toolkit-parity content tables with optional captions, responsive stacking, row headers, numeric cells, and merged cells.
+
+### Migration Steps
+
+1. Adopt the public React `Table` component where you need toolkit-parity content tables in React.
+2. Prefer the refreshed toolkit table API, docs examples, and canonical usage when touching existing Nunjucks templates.
+3. Re-run visual QA if you have local table overrides, especially around responsive stacked rows, row-header emphasis, numeric alignment, and merged-cell layouts.
+
+#### React example
+
+**New in `react-v0.17.0`:**
+
+```tsx
+import { Table } from '@ourfuturehealth/react-components';
+
+<Table
+  caption="Symptoms and self-care"
+  head={[
+    { content: 'Symptom' },
+    { content: 'Self-care' },
+  ]}
+  rows={[
+    [
+      { content: 'Dry eyes' },
+      { content: 'Use artificial tears' },
+    ],
+    [
+      { content: 'Headache' },
+      { content: 'Rest and keep hydrated' },
+    ],
+  ]}
+/>;
+```
 
 ---
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,7 +8,7 @@ This guide provides detailed migration instructions for upgrading between versio
 
 | Version                                                 | Date          | Breaking Changes           | Migration Complexity                     |
 | ------------------------------------------------------- | ------------- | -------------------------- | ---------------------------------------- |
-| [React v0.8.0](#upgrading-to-react-v080)                | April 2026    | React `spritePath` removal | 🟢 Low - Remove the deprecated prop      |
+| [v4.18.0 / React v0.17.0](#upgrading-to-v4180--react-v0170) | April 2026    | No breaking changes        | 🟢 Low - adopt the new Table APIs only if relevant |
 | [v4.9.0 / React v0.7.0](#upgrading-to-v490--react-v070) | April 2026    | Icon naming sync           | 🟡 Medium - Search/replace icon names    |
 | [v4.8.0 / React v0.6.0](#upgrading-to-v480--react-v060) | March 2026    | No breaking changes        | 🟢 Low - only relevant if you adopted the earlier TextInput prototype |
 | [v4.7.0 / React v0.5.0](#upgrading-to-v470--react-v050) | March 2026    | Card family realignment    | 🟡 Medium - API migration recommended    |
@@ -20,55 +20,80 @@ This guide provides detailed migration instructions for upgrading between versio
 
 ---
 
-## Upgrading to React v0.8.0
+## Upgrading to v4.18.0 / React v0.17.0
 
 **Planned:** April 2026
 **Affected packages:**
 
-- `@ourfuturehealth/react-components` v0.8.0+
+- `@ourfuturehealth/toolkit` v4.18.0+
+- `@ourfuturehealth/react-components` v0.17.0+
 
-### Breaking Changes
+### Release Overview
 
-`@ourfuturehealth/react-components` removes the `spritePath` prop from the public `Icon` API and from `Card` icon configuration. React icons now always render from bundled toolkit SVG data.
+This release does not introduce a supported breaking API change.
 
-### Migration Steps
+Toolkit consumers should review the refreshed `table` component responsive treatment and the expanded docs-site examples if they already use content tables.
 
-1. Remove any `spritePath` prop from `Icon` usage.
-2. Remove any `spritePath` field from `Card` icon configuration objects.
-3. Re-run visual checks for icon-bearing surfaces such as `Icon`, `Select`, `Card`, and `Checkboxes`.
+React consumers can now adopt the public `Table` component when they need a structured content table with optional caption, responsive stacking, row headers, numeric cells, and merged cells.
+
+### Table
+
+- Toolkit `table` now matches the current Figma responsive/mobile treatment more closely, including the stacked label/value layout and `2px` closing border
+- React now exposes `Table` as a public component with `caption`, `head`, `rows`, `responsive`, and `firstCellIsHeader` support
+- Storybook and docs-site examples now cover default, responsive, row-header, numeric, and merged-cell table usage
 
 #### React example
 
-**Before:**
-
 ```tsx
-<Icon name="Search" spritePath="/assets/icons/icon-sprite.svg" />
+import { Table } from '@ourfuturehealth/react-components';
 
-<Card
-  icon={{
-    name: 'Search',
-    spritePath: '/assets/icons/icon-sprite.svg',
-  }}
-/>
+<Table
+  caption="Symptoms and self-care"
+  head={[
+    { content: 'Symptom' },
+    { content: 'Self-care' },
+  ]}
+  rows={[
+    [
+      { content: 'Dry eyes' },
+      { content: 'Use artificial tears' },
+    ],
+    [
+      { content: 'Headache' },
+      { content: 'Rest and keep hydrated' },
+    ],
+  ]}
+/>;
 ```
 
-**After:**
+#### Responsive example
 
 ```tsx
-<Icon name="Search" />
-
-<Card
-  icon={{
-    name: 'Search',
-  }}
+<Table
+  caption="Clinic availability by day"
+  responsive
+  head={[
+    { content: 'Day' },
+    { content: 'Morning clinic' },
+    { content: 'Afternoon clinic' },
+    { content: 'Notes' },
+  ]}
+  rows={[
+    [
+      { content: 'Monday' },
+      { content: 'Children' },
+      { content: 'Adults' },
+      { content: 'Walk-ins available' },
+    ],
+    [
+      { content: 'Tuesday' },
+      { content: 'Respiratory' },
+      { content: 'Diabetes' },
+      { content: 'Pre-booked only' },
+    ],
+  ]}
 />
 ```
-
-If an application previously passed `spritePath` in React, that prop should now be removed.
-
-### Toolkit reminder
-
-Toolkit/Nunjucks icon consumers are unchanged. They must still serve `icon-sprite.svg` at a public URL, default `/assets/icons/icon-sprite.svg`, or override that URL with `spritePath`.
 
 ## Upgrading to v4.9.0 / React v0.7.0
 

--- a/docs/consuming-react-components.md
+++ b/docs/consuming-react-components.md
@@ -57,10 +57,25 @@ Import components and styles in your React application:
 
 ```tsx
 import React from 'react';
-import { Button, Image, TextInput } from '@ourfuturehealth/react-components';
+import { Button, Table, TextInput } from '@ourfuturehealth/react-components';
 import '@ourfuturehealth/react-components/styles/participant';
 
 function App() {
+  const symptomsHead = [
+    { content: 'Symptom' },
+    { content: 'Self-care' },
+  ];
+  const symptomsRows = [
+    [
+      { content: 'Dry eyes' },
+      { content: 'Use artificial tears' },
+    ],
+    [
+      { content: 'Headache' },
+      { content: 'Rest and keep hydrated' },
+    ],
+  ];
+
   return (
     <div>
       <TextInput
@@ -70,11 +85,7 @@ function App() {
         inputWidth={20}
         onChange={(e) => console.log(e.target.value)}
       />
-      <Image
-        src="https://assets.nhs.uk/prod/images/S_0318_Bullous_pemphigoid_lesions_.2e16d0ba.fill-320x213.jpg"
-        alt="Lots of sore red patches with small blisters spread across white skin on a woman's chest."
-        caption="It can affect large areas of the body or limbs."
-      />
+      <Table caption="Symptoms and self-care" head={symptomsHead} rows={symptomsRows} />
       <Button onClick={() => console.log('Clicked')}>Submit</Button>
     </div>
   );
@@ -139,6 +150,7 @@ The React components package currently provides the following components:
 - `Radios` - Grouped radio inputs with hints and conditional reveals
 - `Icon` - Toolkit icon component with fixed and responsive sizing using bundled SVG data
 - `SummaryList` - Review-answer and key-value summary rows with optional actions
+- `Table` - Structured content tables with caption, responsive stacking, row headers, numeric cells, and merged-cell support
 - `ErrorSummary` - Page-level validation summaries with linked errors
 - `Tag` - Status tags aligned with toolkit Tag variants
 - `TaskList` - Ordered service tasks with optional hint text and shared Tag-based statuses

--- a/docs/consuming-react-components.md
+++ b/docs/consuming-react-components.md
@@ -57,10 +57,25 @@ Import components and styles in your React application:
 
 ```tsx
 import React from 'react';
-import { Button, TextInput } from '@ourfuturehealth/react-components';
+import { Button, Table, TextInput } from '@ourfuturehealth/react-components';
 import '@ourfuturehealth/react-components/styles/participant';
 
 function App() {
+  const symptomsHead = [
+    { content: 'Symptom' },
+    { content: 'Self-care' },
+  ];
+  const symptomsRows = [
+    [
+      { content: 'Dry eyes' },
+      { content: 'Use artificial tears' },
+    ],
+    [
+      { content: 'Headache' },
+      { content: 'Rest and keep hydrated' },
+    ],
+  ];
+
   return (
     <div>
       <TextInput
@@ -70,6 +85,7 @@ function App() {
         inputWidth={20}
         onChange={(e) => console.log(e.target.value)}
       />
+      <Table caption="Symptoms and self-care" head={symptomsHead} rows={symptomsRows} />
       <Button onClick={() => console.log('Clicked')}>Submit</Button>
     </div>
   );
@@ -136,6 +152,7 @@ The React components package currently provides the following components:
 - `Card` - Content presentation cards for summaries, status, and next steps
 - `CardCallout` - Feedback-style callout cards for informational, warning, success, and error messages
 - `CardDoDont` - Positive and negative recommendation lists
+- `Table` - Structured content tables with caption, responsive stacking, numeric cells, row headers, and merged-cell support
 
 For complete component documentation and live examples, run Storybook locally from this repository:
 

--- a/docs/release-versioning-strategy.md
+++ b/docs/release-versioning-strategy.md
@@ -31,8 +31,8 @@ For consumer migration instructions, use [Upgrading Guide](../UPGRADING.md).
 
 | Package                             | Canonical tag pattern | Example tag      |
 | ----------------------------------- | --------------------- | ---------------- |
-| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.17.0` |
-| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.16.0`   |
+| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.18.0` |
+| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.17.0`   |
 
 The release workflow still accepts legacy toolkit tags in the `v*` format for backward compatibility, but new toolkit releases should use `toolkit-v*`.
 

--- a/docs/release-versioning-strategy.md
+++ b/docs/release-versioning-strategy.md
@@ -126,9 +126,8 @@ This table is a visual aid for pre-monorepo versus post-monorepo releases.
 | 17    | `react-v0.5.0`   | N/A             | `0.5.0`       | Monorepo       | Released               |
 | 18    | `toolkit-v4.8.0` | `4.8.0`         | N/A           | Monorepo       | Released               |
 | 19    | `react-v0.6.0`   | N/A             | `0.6.0`       | Monorepo       | Released               |
-| 20    | `toolkit-v4.9.0` | `4.9.0`         | N/A           | Monorepo       | Released               |
-| 21    | `react-v0.7.0`   | N/A             | `0.7.0`       | Monorepo       | Released               |
-| 22    | `react-v0.8.0`   | N/A             | `0.8.0`       | Monorepo       | Planned in this branch |
+| 20    | `toolkit-v4.18.0` | `4.18.0`       | N/A           | Monorepo       | Planned in this branch |
+| 21    | `react-v0.17.0`   | N/A            | `0.17.0`      | Monorepo       | Planned in this branch |
 
 ## References
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -9,7 +9,7 @@ Install the packaged GitHub release artifact:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.16.0/ourfuturehealth-react-components-0.16.0.tgz",
+    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v{version}/ourfuturehealth-react-components-{version}.tgz",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   }
@@ -64,6 +64,7 @@ import {
   Radios,
   Select,
   SummaryList,
+  Table,
   TaskList,
   Tag,
   Textarea,
@@ -82,6 +83,20 @@ function App() {
     { value: 'email', label: 'Email' },
     { value: 'phone', label: 'Phone' },
     { value: 'post', label: 'Post' },
+  ];
+  const symptomsHead = [
+    { content: 'Symptom' },
+    { content: 'Self-care' },
+  ];
+  const symptomsRows = [
+    [
+      { content: 'Dry eyes' },
+      { content: 'Use artificial tears' },
+    ],
+    [
+      { content: 'Headache' },
+      { content: 'Rest and keep hydrated' },
+    ],
   ];
   const summaryRows = [
     {
@@ -210,6 +225,7 @@ function App() {
         legend="Preferred contact method"
         name="preferred-contact-method"
       />
+      <Table caption="Symptoms and self-care" head={symptomsHead} rows={symptomsRows} />
     </div>
   );
 }
@@ -269,6 +285,7 @@ The package also provides:
 - `Icon`
 - `Pagination`
 - `SummaryList`
+- `Table`
 
 ### ErrorSummary
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -55,6 +55,7 @@ import {
   Radios,
   Select,
   Tag,
+  Table,
   Textarea,
   TextInput,
 } from '@ourfuturehealth/react-components';
@@ -71,6 +72,20 @@ function App() {
     { value: 'email', label: 'Email' },
     { value: 'phone', label: 'Phone' },
     { value: 'post', label: 'Post' },
+  ];
+  const symptomsHead = [
+    { content: 'Symptom' },
+    { content: 'Self-care' },
+  ];
+  const symptomsRows = [
+    [
+      { content: 'Dry eyes' },
+      { content: 'Use artificial tears' },
+    ],
+    [
+      { content: 'Headache' },
+      { content: 'Rest and keep hydrated' },
+    ],
   ];
 
   return (
@@ -136,6 +151,7 @@ function App() {
         legend="Preferred contact method"
         name="preferred-contact-method"
       />
+      <Table caption="Symptoms and self-care" head={symptomsHead} rows={symptomsRows} />
     </div>
   );
 }
@@ -189,6 +205,7 @@ The package also provides:
 - `Checkboxes`
 - `Radios`
 - `Icon`
+- `Table`
 
 ### ErrorSummary
 

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/react-components",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "type": "module",
   "description": "React component library for OFH Design System",
   "packageManager": "pnpm@10.29.2",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/react-components",
-  "version": "0.8.0",
+  "version": "0.17.0",
   "type": "module",
   "description": "React component library for OFH Design System",
   "packageManager": "pnpm@10.29.2",

--- a/packages/react-components/src/components/Table/Table.stories.tsx
+++ b/packages/react-components/src/components/Table/Table.stories.tsx
@@ -1,0 +1,666 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  ArgTypes,
+  Description,
+  Source,
+  Stories,
+  Title,
+} from '@storybook/addon-docs/blocks';
+import {
+  Table,
+  type TableCell,
+  type TableHeadCell,
+  type TableProps,
+} from './Table';
+
+const symptomsHead: TableHeadCell[] = [
+  { content: 'Skin symptoms' },
+  { content: 'Possible cause' },
+];
+
+const symptomsRows: TableCell[][] = [
+  [
+    { content: 'Blisters on lips or around the mouth' },
+    { content: 'Cold sores' },
+  ],
+  [
+    { content: 'Itchy, dry, cracked, sore' },
+    { content: 'Eczema' },
+  ],
+  [
+    { content: 'Itchy blisters' },
+    { content: 'Shingles, chickenpox' },
+  ],
+];
+
+const dosageHead: TableHeadCell[] = [
+  { content: 'Age' },
+  { content: 'How much?' },
+  { content: 'How often?' },
+];
+
+const dosageRows: TableCell[][] = [
+  [
+    { content: '7 to 9 years' },
+    { content: '200mg' },
+    { content: 'Max 3 times in 24 hours' },
+  ],
+  [
+    { content: '10 to 11 years' },
+    { content: '200mg to 300mg' },
+    { content: 'Max 3 times in 24 hours' },
+  ],
+  [
+    { content: '12 to 17 years' },
+    { content: '200mg to 400mg' },
+    { content: 'Max 3 times in 24 hours' },
+  ],
+];
+
+const numericHead: TableHeadCell[] = [
+  { content: 'Month' },
+  { content: 'Appointments', format: 'numeric' },
+  { content: 'Participants', format: 'numeric' },
+];
+
+const numericRows: TableCell[][] = [
+  [
+    { content: 'January' },
+    { content: '128', format: 'numeric' },
+    { content: '942', format: 'numeric' },
+  ],
+  [
+    { content: 'February' },
+    { content: '156', format: 'numeric' },
+    { content: '1,084', format: 'numeric' },
+  ],
+  [
+    { content: 'March' },
+    { content: '149', format: 'numeric' },
+    { content: '1,031', format: 'numeric' },
+  ],
+];
+
+const spansHead: TableHeadCell[] = [
+  { content: 'Day' },
+  { content: 'Morning clinic' },
+  { content: 'Afternoon clinic' },
+  { content: 'Notes' },
+];
+
+const spansRows: TableCell[][] = [
+  [
+    { content: 'Monday', rowSpan: 2 },
+    { content: 'Children' },
+    { content: 'Adults' },
+    { content: 'Walk-ins available' },
+  ],
+  [
+    { content: 'Urgent care', colSpan: 2 },
+    { content: 'Limited appointments' },
+  ],
+  [
+    { content: 'Tuesday' },
+    { content: 'Respiratory' },
+    { content: 'Diabetes' },
+    { content: 'Pre-booked only' },
+  ],
+];
+
+type TablePreset = 'two-column' | 'responsive-multi-column' | 'numeric';
+
+type TableStoryArgs = TableProps & {
+  tablePreset?: TablePreset;
+  captionText?: string;
+  useRowHeaders?: boolean;
+};
+
+const getPresetConfig = (
+  tablePreset: TablePreset,
+): Pick<TableProps, 'caption' | 'head' | 'rows' | 'responsive'> => {
+  switch (tablePreset) {
+    case 'responsive-multi-column':
+      return {
+        caption: 'Ibuprofen tablet dosages for children',
+        head: dosageHead,
+        rows: dosageRows,
+        responsive: true,
+      };
+    case 'numeric':
+      return {
+        caption: 'Monthly appointment summary',
+        head: numericHead,
+        rows: numericRows,
+        responsive: false,
+      };
+    case 'two-column':
+    default:
+      return {
+        caption: 'Skin symptoms and possible causes',
+        head: symptomsHead,
+        rows: symptomsRows,
+        responsive: false,
+      };
+  }
+};
+
+const defaultSource = `import { Table } from '@ourfuturehealth/react-components';
+
+const head = [
+  { content: 'Skin symptoms' },
+  { content: 'Possible cause' },
+];
+
+const rows = [
+  [
+    { content: 'Blisters on lips or around the mouth' },
+    { content: 'Cold sores' },
+  ],
+  [
+    { content: 'Itchy, dry, cracked, sore' },
+    { content: 'Eczema' },
+  ],
+];
+
+<Table
+  caption="Skin symptoms and possible causes"
+  head={head}
+  rows={rows}
+/>;
+`;
+
+const responsiveSource = `import { Table } from '@ourfuturehealth/react-components';
+
+const head = [
+  { content: 'Age' },
+  { content: 'How much?' },
+  { content: 'How often?' },
+];
+
+const rows = [
+  [
+    { content: '7 to 9 years' },
+    { content: '200mg' },
+    { content: 'Max 3 times in 24 hours' },
+  ],
+  [
+    { content: '10 to 11 years' },
+    { content: '200mg to 300mg' },
+    { content: 'Max 3 times in 24 hours' },
+  ],
+];
+
+<Table
+  caption="Ibuprofen tablet dosages for children"
+  head={head}
+  rows={rows}
+  responsive
+/>;
+`;
+
+const rowHeaderSource = `import { Table } from '@ourfuturehealth/react-components';
+
+const head = [
+  { content: 'Treatment' },
+  { content: 'Uses' },
+];
+
+const rows = [
+  [
+    { content: 'Antibiotics' },
+    { content: 'Treat bacterial infections' },
+  ],
+  [
+    { content: 'Antihistamines' },
+    { content: 'Ease allergic symptoms' },
+  ],
+];
+
+<Table
+  caption="Treatment types and uses"
+  head={head}
+  rows={rows}
+  firstCellIsHeader
+/>;
+`;
+
+const numericSource = `import { Table } from '@ourfuturehealth/react-components';
+
+const head = [
+  { content: 'Month' },
+  { content: 'Appointments', format: 'numeric' },
+  { content: 'Participants', format: 'numeric' },
+];
+
+const rows = [
+  [
+    { content: 'January' },
+    { content: '128', format: 'numeric' },
+    { content: '942', format: 'numeric' },
+  ],
+  [
+    { content: 'February' },
+    { content: '156', format: 'numeric' },
+    { content: '1,084', format: 'numeric' },
+  ],
+];
+
+<Table
+  caption="Monthly appointment summary"
+  head={head}
+  rows={rows}
+/>;
+`;
+
+const spansSource = `import { Table } from '@ourfuturehealth/react-components';
+
+const head = [
+  { content: 'Day' },
+  { content: 'Morning clinic' },
+  { content: 'Afternoon clinic' },
+  { content: 'Notes' },
+];
+
+const rows = [
+  [
+    { content: 'Monday', rowSpan: 2 },
+    { content: 'Children' },
+    { content: 'Adults' },
+    { content: 'Walk-ins available' },
+  ],
+  [
+    { content: 'Urgent care', colSpan: 2 },
+    { content: 'Limited appointments' },
+  ],
+];
+
+<Table
+  caption="Clinic availability by day"
+  head={head}
+  rows={rows}
+/>;
+`;
+
+const renderBuilder = ({
+  tablePreset = 'two-column',
+  captionText,
+  useRowHeaders = false,
+  ...args
+}: TableStoryArgs) => {
+  const preset = getPresetConfig(tablePreset);
+
+  return (
+    <Table
+      {...preset}
+      {...args}
+      caption={captionText || preset.caption}
+      firstCellIsHeader={!preset.responsive && useRowHeaders}
+    />
+  );
+};
+
+const meta: Meta<TableStoryArgs> = {
+  title: 'Components/Table',
+  component: Table,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Use Table to present data users need to compare or scan. In React, pass `head` and `rows` as arrays of objects with `content`, then add `responsive` when you need the stacked mobile layout for larger tables.',
+      },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+
+          <h2>How to use the React component</h2>
+          <p>
+            Pass a visible <code>caption</code>, an optional <code>head</code>{' '}
+            array for column headers, and a required <code>rows</code> array for
+            the body data. Each cell uses a simple <code>content</code> field so
+            you can pass plain text or richer React content.
+          </p>
+          <p>
+            Keep captions visible wherever possible. They act as the table title
+            for both visual users and assistive technology, so this component
+            supports omitting them but the normal path should be to provide one.
+          </p>
+          <p>
+            Use <code>responsive</code> for the stacked multi-column layout used
+            on smaller screens. When you do that, the component will use string
+            content from the matching <code>head</code> cell as the mobile
+            labels, or you can override a label per cell with{' '}
+            <code>header</code>.
+          </p>
+          <Source code={defaultSource} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes
+            of={Default}
+            include={[
+              'caption',
+              'head',
+              'rows',
+              'firstCellIsHeader',
+              'responsive',
+              'classes',
+              'className',
+            ]}
+          />
+
+          <h2>Head shape</h2>
+          <p>
+            Each head item represents a column header. Use{' '}
+            <code>format: &apos;numeric&apos;</code> when a column should be
+            right aligned.
+          </p>
+          <Source
+            code={`const head = [
+  { content: 'Month' },
+  { content: 'Appointments', format: 'numeric' },
+  { content: 'Participants', format: 'numeric' },
+];`}
+            language="tsx"
+          />
+
+          <h2>Rows shape</h2>
+          <p>
+            Each row is an array of cells. In responsive tables, add an optional{' '}
+            <code>header</code> when you want to override the mobile label for a
+            specific cell. Use <code>colSpan</code> and <code>rowSpan</code>{' '}
+            when a cell genuinely needs to span across neighbouring columns or
+            rows.
+          </p>
+          <Source
+            code={`const rows = [
+  [
+    { content: 'January' },
+    { content: '128', format: 'numeric' },
+    { content: '942', format: 'numeric' },
+  ],
+  [
+    { content: 'February', header: 'Month' },
+    { content: '156', header: 'Appointments', format: 'numeric' },
+    { content: '1,084', header: 'Participants', format: 'numeric' },
+  ],
+];`}
+            language="tsx"
+          />
+
+          <h2>Merged cells</h2>
+          <p>
+            Use <code>colSpan</code> and <code>rowSpan</code> sparingly. They
+            are useful for schedule-style or grouped data, but simple comparison
+            tables are usually easier to scan without merged cells.
+          </p>
+          <Source code={spansSource} language="tsx" />
+
+          <h2>Storybook builder helpers</h2>
+          <p>
+            <code>tablePreset</code>, <code>captionText</code>, and{' '}
+            <code>useRowHeaders</code> are only used by the Storybook{' '}
+            <code>Builder</code> story to keep the controls easy to use. They
+            are not props accepted by <code>Table</code>.
+          </p>
+
+          <Stories title="Examples" />
+
+          <h2>Example source</h2>
+          <Source code={defaultSource} language="tsx" />
+          <Source code={responsiveSource} language="tsx" />
+          <Source code={rowHeaderSource} language="tsx" />
+          <Source code={numericSource} language="tsx" />
+          <Source code={spansSource} language="tsx" />
+        </>
+      ),
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    tablePreset: {
+      control: 'radio',
+      options: ['two-column', 'responsive-multi-column', 'numeric'],
+      description:
+        'Builder-only Storybook helper. Switches between realistic table presets.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
+    captionText: {
+      control: 'text',
+      description:
+        'Builder-only Storybook helper. Overrides the visible caption for the selected preset.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
+    useRowHeaders: {
+      control: 'boolean',
+      description:
+        'Builder-only Storybook helper. Turns the first column into row headers for non-responsive presets.',
+      if: {
+        arg: 'tablePreset',
+        neq: 'responsive-multi-column',
+      },
+      table: {
+        category: 'Builder story only',
+      },
+    },
+    caption: {
+      control: false,
+      description:
+        'Visible caption shown above the table and announced as the table title.',
+      table: {
+        category: 'TableProps',
+      },
+    },
+    head: {
+      control: false,
+      description:
+        'Optional column-header array. In responsive tables, string content from `head` is used for the stacked mobile labels when a cell does not provide `header`.',
+      table: {
+        category: 'TableProps',
+      },
+    },
+    rows: {
+      control: false,
+      description:
+        'Required row data. Each row is an array of cell objects with `content`, plus optional `header`, `format`, `colSpan`, and `rowSpan`.',
+      table: {
+        category: 'TableProps',
+      },
+    },
+    firstCellIsHeader: {
+      control: 'boolean',
+      description:
+        'When true, the first cell in each non-responsive body row is rendered as a row header.',
+      table: {
+        category: 'TableProps',
+      },
+    },
+    responsive: {
+      control: false,
+      description:
+        'Enables the stacked multi-column mobile layout used for larger tables.',
+      table: {
+        category: 'TableProps',
+      },
+    },
+    classes: {
+      control: false,
+      description:
+        'Toolkit-parity escape hatch for extra root classes. Most React consumers should prefer `className`.',
+      table: {
+        category: 'TableProps',
+      },
+    },
+    className: {
+      control: false,
+      description:
+        'Adds extra classes to the root `<table>` element for layout or integration hooks.',
+      table: {
+        category: 'TableProps',
+      },
+    },
+    ref: {
+      control: false,
+      description:
+        'React ref for the root `<table>` element. Use this only when you need direct DOM access.',
+      table: {
+        category: 'TableProps',
+      },
+    },
+  },
+  args: {
+    tablePreset: 'two-column',
+    captionText: '',
+    useRowHeaders: false,
+  },
+  render: renderBuilder,
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Table
+      caption="Skin symptoms and possible causes"
+      head={symptomsHead}
+      rows={symptomsRows}
+    />
+  ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'A realistic default two-column table for comparing labels and values.',
+      },
+      source: {
+        code: defaultSource,
+      },
+    },
+  },
+};
+
+export const Builder: Story = {
+  parameters: {
+    controls: {
+      include: ['tablePreset', 'captionText', 'useRowHeaders'],
+    },
+  },
+};
+
+export const ResponsiveMultiColumn: Story = {
+  render: () => (
+    <Table
+      caption="Ibuprofen tablet dosages for children"
+      head={dosageHead}
+      rows={dosageRows}
+      responsive
+    />
+  ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'A fixed example showing the responsive multi-column pattern that collapses into stacked rows on smaller screens.',
+      },
+      source: {
+        code: responsiveSource,
+      },
+    },
+  },
+};
+
+export const FirstCellIsHeader: Story = {
+  render: () => (
+    <Table
+      caption="Treatment types and uses"
+      head={[
+        { content: 'Treatment' },
+        { content: 'Uses' },
+      ]}
+      rows={[
+        [
+          { content: 'Antibiotics' },
+          { content: 'Treat bacterial infections' },
+        ],
+        [
+          { content: 'Antihistamines' },
+          { content: 'Ease allergic symptoms' },
+        ],
+      ]}
+      firstCellIsHeader
+    />
+  ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'A fixed example where the first cell in each row becomes a row header for stronger row-to-value associations.',
+      },
+      source: {
+        code: rowHeaderSource,
+      },
+    },
+  },
+};
+
+export const NumericValues: Story = {
+  render: () => (
+    <Table
+      caption="Monthly appointment summary"
+      head={numericHead}
+      rows={numericRows}
+    />
+  ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'A fixed example using the numeric alignment modifier for columns that contain numbers.',
+      },
+      source: {
+        code: numericSource,
+      },
+    },
+  },
+};
+
+export const ColSpanAndRowSpan: Story = {
+  render: () => (
+    <Table
+      caption="Clinic availability by day"
+      head={spansHead}
+      rows={spansRows}
+    />
+  ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      description: {
+        story:
+          'A fixed example showing how to use `colSpan` and `rowSpan` for grouped schedule data when merged cells are genuinely needed.',
+      },
+      source: {
+        code: spansSource,
+      },
+    },
+  },
+};

--- a/packages/react-components/src/components/Table/Table.test.tsx
+++ b/packages/react-components/src/components/Table/Table.test.tsx
@@ -1,0 +1,149 @@
+import { createRef } from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { axe } from 'vitest-axe';
+import { describe, expect, it } from 'vitest';
+import { Table } from './Table';
+
+const defaultHead = [
+  { content: 'Skin symptoms' },
+  { content: 'Possible cause' },
+];
+
+const defaultRows = [
+  [
+    { content: 'Blisters on lips or around the mouth' },
+    { content: 'Cold sores' },
+  ],
+  [
+    { content: 'Itchy, dry, cracked, sore' },
+    { content: 'Eczema' },
+  ],
+];
+
+describe('Table', () => {
+  it('renders a standard table with caption, headings, and rows', () => {
+    render(
+      <Table
+        caption="Skin symptoms and possible causes"
+        head={defaultHead}
+        rows={defaultRows}
+      />,
+    );
+
+    expect(screen.getByText('Skin symptoms and possible causes')).toBeVisible();
+    expect(screen.getByRole('columnheader', { name: 'Skin symptoms' })).toBeVisible();
+    expect(screen.getByRole('cell', { name: 'Cold sores' })).toBeVisible();
+  });
+
+  it('renders row headers when firstCellIsHeader is enabled', () => {
+    render(
+      <Table
+        caption="Treatments by type"
+        firstCellIsHeader
+        head={[
+          { content: 'Treatment' },
+          { content: 'Uses' },
+        ]}
+        rows={[
+          [
+            { content: 'Antibiotics' },
+            { content: 'Treat bacterial infections' },
+          ],
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole('rowheader', { name: 'Antibiotics' })).toBeVisible();
+  });
+
+  it('renders responsive cell headings using explicit headers or head text fallbacks', () => {
+    const { container } = render(
+      <Table
+        responsive
+        caption="Ibuprofen tablet dosages for children"
+        head={[
+          { content: 'Age' },
+          { content: 'How much?' },
+          { content: 'How often?' },
+        ]}
+        rows={[
+          [
+            { content: '7 to 9 years' },
+            { content: '200mg', header: 'Dose' },
+            { content: 'Max 3 times in 24 hours' },
+          ],
+        ]}
+      />,
+    );
+
+    const responsiveHeadings = Array.from(
+      container.querySelectorAll('.ofh-table-responsive__heading'),
+    ).map((element) => element.textContent);
+
+    expect(responsiveHeadings).toEqual(['Age', 'Dose', 'How often?']);
+    expect(
+      within(container).getByText('7 to 9 years', {
+        selector: '.ofh-table-responsive__content',
+      }),
+    ).toBeVisible();
+  });
+
+  it('forwards ref and supports custom classes', () => {
+    const ref = createRef<HTMLTableElement>();
+
+    render(
+      <Table
+        ref={ref}
+        classes="custom-table"
+        className="layout-hook"
+        head={defaultHead}
+        rows={defaultRows}
+      />,
+    );
+
+    expect(ref.current).toBeInstanceOf(HTMLTableElement);
+    expect(ref.current).toHaveClass('ofh-table', 'custom-table', 'layout-hook');
+  });
+
+  it('passes colSpan and rowSpan through to rendered cells', () => {
+    render(
+      <Table
+        caption="Clinic availability by day"
+        head={[
+          { content: 'Day' },
+          { content: 'Morning clinic' },
+          { content: 'Afternoon clinic' },
+          { content: 'Notes' },
+        ]}
+        rows={[
+          [
+            { content: 'Monday', rowSpan: 2 },
+            { content: 'Children' },
+            { content: 'Adults' },
+            { content: 'Walk-ins available' },
+          ],
+          [
+            { content: 'Urgent care', colSpan: 2 },
+            { content: 'Limited appointments' },
+          ],
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Monday').closest('td')).toHaveAttribute('rowspan', '2');
+    expect(screen.getByText('Urgent care').closest('td')).toHaveAttribute('colspan', '2');
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <Table
+        caption="Skin symptoms and possible causes"
+        head={defaultHead}
+        rows={defaultRows}
+      />,
+    );
+
+    const results = await axe(container);
+    expect(results.violations).toHaveLength(0);
+  });
+});

--- a/packages/react-components/src/components/Table/Table.tsx
+++ b/packages/react-components/src/components/Table/Table.tsx
@@ -1,0 +1,197 @@
+import React from 'react';
+import { joinClasses } from '../../internal/ofhUtils';
+
+export type TableCellFormat = 'numeric';
+
+type BaseTableCell = {
+  /**
+   * Cell content rendered inside the table.
+   */
+  content: React.ReactNode;
+  /**
+   * Optional numeric alignment modifier.
+   */
+  format?: TableCellFormat;
+  /**
+   * Optional colspan passed to the rendered cell.
+   */
+  colSpan?: number;
+  /**
+   * Optional rowspan passed to the rendered cell.
+   */
+  rowSpan?: number;
+};
+
+export type TableHeadCell = BaseTableCell;
+
+export interface TableCell extends BaseTableCell {
+  /**
+   * Optional label used for the stacked mobile presentation in responsive tables.
+   * If omitted, string content from the matching `head` cell is used when possible.
+   */
+  header?: string;
+}
+
+export interface TableProps
+  extends Omit<React.TableHTMLAttributes<HTMLTableElement>, 'children' | 'ref'> {
+  /**
+   * Visible caption shown above the table and announced as the table title.
+   */
+  caption?: React.ReactNode;
+  /**
+   * Optional header row content for the table.
+   */
+  head?: TableHeadCell[];
+  /**
+   * Required row data for the table body.
+   */
+  rows: TableCell[][];
+  /**
+   * When true, the first cell in each non-responsive body row is rendered as a row header.
+   */
+  firstCellIsHeader?: boolean;
+  /**
+   * When true, the table uses the stacked multi-column mobile layout from the toolkit.
+   */
+  responsive?: boolean;
+  /**
+   * Additional toolkit-style classes for the table element.
+   */
+  classes?: string;
+  /**
+   * Ref forwarding for the underlying table element.
+   */
+  ref?: React.Ref<HTMLTableElement>;
+}
+
+const getResponsiveHeader = (
+  cell: TableCell,
+  headCell?: TableHeadCell,
+) => {
+  if (cell.header) {
+    return cell.header;
+  }
+
+  if (
+    typeof headCell?.content === 'string' ||
+    typeof headCell?.content === 'number'
+  ) {
+    return String(headCell.content);
+  }
+
+  return '';
+};
+
+const getCellClassName = (format?: TableCellFormat) =>
+  joinClasses('ofh-table__cell', format && `ofh-table__cell--${format}`);
+
+const getHeaderClassName = (format?: TableCellFormat) =>
+  joinClasses('ofh-table__header', format && `ofh-table__header--${format}`);
+
+export const Table = ({
+  caption,
+  head,
+  rows,
+  firstCellIsHeader = false,
+  responsive = false,
+  classes = '',
+  className = '',
+  ref,
+  ...props
+}: TableProps) => {
+  return (
+    <table
+      {...props}
+      ref={ref}
+      role={responsive ? 'table' : undefined}
+      className={joinClasses(
+        responsive ? 'ofh-table-responsive' : 'ofh-table',
+        classes,
+        className,
+      )}
+    >
+      {caption !== undefined && caption !== null ? (
+        <caption className="ofh-table__caption">{caption}</caption>
+      ) : null}
+      {head?.length ? (
+        <thead
+          className="ofh-table__head"
+          role={responsive ? 'rowgroup' : undefined}
+        >
+          <tr
+            className="ofh-table__row"
+            role={responsive ? 'row' : undefined}
+          >
+            {head.map((cell, index) => (
+              <th
+                key={`head-${index}`}
+                role={responsive ? 'columnheader' : undefined}
+                className={getHeaderClassName(cell.format)}
+                scope="col"
+                colSpan={cell.colSpan}
+                rowSpan={cell.rowSpan}
+              >
+                {cell.content}
+              </th>
+            ))}
+          </tr>
+        </thead>
+      ) : null}
+      <tbody className="ofh-table__body">
+        {rows.map((row, rowIndex) => (
+          <tr
+            key={`row-${rowIndex}`}
+            className="ofh-table__row"
+            role={responsive ? 'row' : undefined}
+          >
+            {responsive
+              ? row.map((cell, cellIndex) => (
+                  <td
+                    key={`row-${rowIndex}-cell-${cellIndex}`}
+                    role="cell"
+                    className={getCellClassName(cell.format)}
+                    colSpan={cell.colSpan}
+                    rowSpan={cell.rowSpan}
+                  >
+                    <span className="ofh-table-responsive__heading">
+                      {getResponsiveHeader(cell, head?.[cellIndex])}
+                    </span>
+                    <span className="ofh-table-responsive__content">
+                      {cell.content}
+                    </span>
+                  </td>
+                ))
+              : row.map((cell, cellIndex) => {
+                  if (cellIndex === 0 && firstCellIsHeader) {
+                    return (
+                      <th
+                        key={`row-${rowIndex}-cell-${cellIndex}`}
+                        className={getHeaderClassName(cell.format)}
+                        scope="row"
+                        colSpan={cell.colSpan}
+                        rowSpan={cell.rowSpan}
+                      >
+                        {cell.content}
+                      </th>
+                    );
+                  }
+
+                  return (
+                    <td
+                      key={`row-${rowIndex}-cell-${cellIndex}`}
+                      className={getCellClassName(cell.format)}
+                      colSpan={cell.colSpan}
+                      rowSpan={cell.rowSpan}
+                    >
+                      {cell.content}
+                    </td>
+                  );
+                })}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+Table.displayName = 'Table';

--- a/packages/react-components/src/components/Table/index.ts
+++ b/packages/react-components/src/components/Table/index.ts
@@ -1,0 +1,7 @@
+export { Table } from './Table';
+export type {
+  TableCell,
+  TableCellFormat,
+  TableHeadCell,
+  TableProps,
+} from './Table';

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -66,3 +66,11 @@ export type { CardDoDontItem, CardDoDontProps } from './components/CardDoDont';
 
 export { Tag } from './components/Tag';
 export type { TagProps, TagVariant } from './components/Tag';
+
+export { Table } from './components/Table';
+export type {
+  TableCell,
+  TableCellFormat,
+  TableHeadCell,
+  TableProps,
+} from './components/Table';

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -97,7 +97,6 @@ export type { PaginationProps } from './components/Pagination';
 export { Tag } from './components/Tag';
 export type { TagProps, TagVariant } from './components/Tag';
 
-<<<<<<< HEAD
 export { SummaryList } from './components/SummaryList';
 export type {
   SummaryListActionItem,
@@ -127,12 +126,3 @@ export type {
   TableHeadCell,
   TableProps,
 } from './components/Table';
-=======
-export { Table } from './components/Table';
-export type {
-  TableCell,
-  TableCellFormat,
-  TableHeadCell,
-  TableProps,
-} from './components/Table';
->>>>>>> 8bb6ee11 (feat: add table react parity)

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -97,6 +97,7 @@ export type { PaginationProps } from './components/Pagination';
 export { Tag } from './components/Tag';
 export type { TagProps, TagVariant } from './components/Tag';
 
+<<<<<<< HEAD
 export { SummaryList } from './components/SummaryList';
 export type {
   SummaryListActionItem,
@@ -118,3 +119,20 @@ export type {
 
 export { Image } from './components/Image';
 export type { ImageProps } from './components/Image';
+
+export { Table } from './components/Table';
+export type {
+  TableCell,
+  TableCellFormat,
+  TableHeadCell,
+  TableProps,
+} from './components/Table';
+=======
+export { Table } from './components/Table';
+export type {
+  TableCell,
+  TableCellFormat,
+  TableHeadCell,
+  TableProps,
+} from './components/Table';
+>>>>>>> 8bb6ee11 (feat: add table react parity)

--- a/packages/site/views/design-system/components/table/first-cell-is-header/index.njk
+++ b/packages/site/views/design-system/components/table/first-cell-is-header/index.njk
@@ -1,0 +1,32 @@
+{% from 'tables/macro.njk' import table %}
+
+{{ table({
+  caption: "Treatment types and uses",
+  firstCellIsHeader: true,
+  head: [
+    {
+      text: "Treatment"
+    },
+    {
+      text: "Uses"
+    }
+  ],
+  rows: [
+    [
+      {
+        text: "Antibiotics"
+      },
+      {
+        text: "Treat bacterial infections"
+      }
+    ],
+    [
+      {
+        text: "Antihistamines"
+      },
+      {
+        text: "Ease allergic symptoms"
+      }
+    ]
+  ]
+}) }}

--- a/packages/site/views/design-system/components/table/index.njk
+++ b/packages/site/views/design-system/components/table/index.njk
@@ -14,7 +14,11 @@
 
 {% block bodyContent %}
 
+  <p>Use a table when users need to compare or scan related data. Do not use tables for page layout.</p>
+  <p>If you are working in React instead of Nunjucks, use the React <code>Table</code> component in Storybook. This page is the toolkit/Nunjucks usage guide.</p>
+
   <h2 id="2-column-table">2 column table</h2>
+  <p>Use a simple 2 column table when each row compares a label with a value.</p>
 
   {{ designExample({
     group: "components",
@@ -30,7 +34,7 @@
   </ul>
 
   <h2 id="3-or-more-column-table">3 or more column table</h2>
-  <p>On large screens this table looks like a 2 column table. However, on smaller screens it collapses.</p>
+  <p>Use <code>responsive: true</code> when a table has 3 or more columns and needs to collapse into a stacked layout on smaller screens.</p>
 
   {{ designExample({
     group: "components",
@@ -38,14 +42,46 @@
     type: "responsive"
   }) }}
 
-  <h3 id="when-not-to-use-a-3-or-more-column-table">When not to use a 3 or more column table</h3>
-  <p>Do not use a 3 or more column table:</p>
-  <ul>
-    <li>to layout content on a page, use the <a href="/design-system/styles/layout#grid">grid system</a> instead</li>
-    <li>if you have 2 columns, use the <a href="#2-column-table">2 column table</a> instead</li>
-  </ul>
+  <h2 id="first-cell-as-a-row-header">First cell as a row header</h2>
+  <p>Use <code>firstCellIsHeader: true</code> when the first cell in each body row is acting as the row label.</p>
+
+  {{ designExample({
+    group: "components",
+    item: "table",
+    type: "first-cell-is-header"
+  }) }}
+
+  <h2 id="numeric-values">Numeric values</h2>
+  <p>Use <code>format: "numeric"</code> on matching head and row cells when a column contains numbers that should align to the right.</p>
+
+  {{ designExample({
+    group: "components",
+    item: "table",
+    type: "numeric-values"
+  }) }}
+
+  <h2 id="column-and-row-spans">Column and row spans</h2>
+  <p>Use <code>colspan</code> and <code>rowspan</code> sparingly. They are useful for grouped schedule-style data, but simple comparison tables are easier to scan without merged cells.</p>
+
+  {{ designExample({
+    group: "components",
+    item: "table",
+    type: "spans"
+  }) }}
 
   <h2 id="how-it-works">How tables work</h2>
+  <p>Use these options when configuring the table macro:</p>
+  <ul>
+    <li><code>caption</code>: the visible title of the table. Always include one where possible.</li>
+    <li><code>head</code>: the column headers shown in the <code>&lt;thead&gt;</code>.</li>
+    <li><code>rows</code>: the table body data. Each row is an array of cells.</li>
+    <li><code>firstCellIsHeader</code>: changes the first body cell in each row from a <code>&lt;td&gt;</code> to a row header <code>&lt;th scope="row"&gt;</code>.</li>
+    <li><code>responsive</code>: uses the stacked mobile layout for wider tables.</li>
+    <li><code>header</code> on a row cell: overrides the mobile label shown for that cell in a responsive table.</li>
+    <li><code>format: "numeric"</code>: right aligns numeric columns.</li>
+    <li><code>colspan</code> and <code>rowspan</code>: merge cells across neighbouring columns or rows.</li>
+  </ul>
+
   <h3>Accessibility</h3>
   <p>Follow <a href="https://webaim.org/techniques/tables/data">WebAIM's guidance for tables</a> and</p>
   <ul>
@@ -59,15 +95,5 @@
 
   <h3 id="table-headers">Table headers</h3>
   <p>Use table headers to tell users what the rows and columns represent.</p>
-
-  <h2 id="reseach">Research</h2>
-  <h3>2 column table</h3>
-  <p>This table tested well with users of health information on the NHS website.</p>
-
-  <h3>3 or more column table</h3>
-  <p>This table was tested at HM Revenue &amp; Customs.</p>
-
-  <h3>Table with panel</h3>
-  <p>We have also designed a table with a panel. You can see <a href="https://nhsuk.github.io/nhsuk-frontend/components/tables/tables-panel.html">an example in the frontend library</a>. We haven't included it in this list of components yet because it needs more testing.</p>
 
 {% endblock %}

--- a/packages/site/views/design-system/components/table/macro-options.json
+++ b/packages/site/views/design-system/components/table/macro-options.json
@@ -4,37 +4,43 @@
       "name": "rows",
       "type": "array",
       "required": true,
-      "description": "Array of table rows and cells.",
+      "description": "Required body rows for the table. Each row is an array of cell objects.",
       "params": [
+        {
+          "name": "header",
+          "type": "string",
+          "required": false,
+          "description": "Optional responsive label override for a cell. If omitted in a responsive table, the matching `head[].text` value is used when available."
+        },
         {
           "name": "text",
           "type": "string",
           "required": true,
-          "description": "If `html` is set, this is not required. Text for cells in table rows. If `html` is provided, the `text` argument will be ignored."
+          "description": "Plain text cell content. If `html` is provided, `text` is ignored."
         },
         {
           "name": "html",
           "type": "string",
           "required": true,
-          "description": "If `text` is set, this is not required. HTML for cells in table rows. If `html` is provided, the `text` argument will be ignored."
+          "description": "Trusted HTML cell content. If provided, it replaces `text`."
         },
         {
           "name": "format",
           "type": "string",
           "required": false,
-          "description": "Specify format of a cell. Currently we only use \"numeric\"."
+          "description": "Cell format modifier. Use `numeric` to right align numeric values."
         },
         {
           "name": "colspan",
           "type": "integer",
           "required": false,
-          "description": "Specify how many columns a cell extends."
+          "description": "How many columns this cell should span."
         },
         {
           "name": "rowspan",
           "type": "integer",
           "required": false,
-          "description": "Specify how many rows a cell extends."
+          "description": "How many rows this cell should span."
         }
       ]
     },
@@ -42,37 +48,37 @@
       "name": "head",
       "type": "array",
       "required": false,
-      "description": "Array of table head cells.",
+      "description": "Optional header row. Each item becomes a column header.",
       "params": [
         {
           "name": "text",
           "type": "string",
           "required": false,
-          "description": "If `html` is set, this is not required. Text for table head cells. If `html` is provided, the `text` argument will be ignored."
+          "description": "Plain text header content. If `html` is provided, `text` is ignored."
         },
         {
           "name": "html",
           "type": "string",
           "required": false,
-          "description": "If `text` is set, this is not required. HTML for table head cells. If `html` is provided, the `text` argument will be ignored."
+          "description": "Trusted HTML header content. If provided, it replaces `text`."
         },
         {
           "name": "format",
           "type": "string",
           "required": false,
-          "description": "Specify format of a cell. Currently we only use \"numeric\"."
+          "description": "Header format modifier. Use `numeric` to right align numeric columns."
         },
         {
           "name": "colspan",
           "type": "integer",
           "required": false,
-          "description": "Specify how many columns a cell extends."
+          "description": "How many columns this header cell should span."
         },
         {
           "name": "rowspan",
           "type": "integer",
           "required": false,
-          "description": "Specify how many rows a cell extends."
+          "description": "How many rows this header cell should span."
         }
       ]
     },
@@ -92,37 +98,37 @@
       "name": "caption",
       "type": "string",
       "required": false,
-      "description": "Caption text."
+      "description": "Visible table title shown in the `<caption>` element."
     },
     {
       "name": "captionClasses",
       "type": "string",
       "required": false,
-      "description": "Classes for caption text size. Classes should correspond to the available typography heading classes."
+      "description": "Extra classes added to the caption element."
     },
     {
       "name": "firstCellIsHeader",
       "type": "boolean",
       "required": false,
-      "description": "If set to true, first cell in table row will be a TH instead of a TD."
+      "description": "When true, the first body cell in each row is rendered as a row header (`<th scope=\"row\">`)."
     },
     {
       "name": "responsive",
       "type": "boolean",
       "required": false,
-      "description": "If set to true, responsive table classes will be applied."
+      "description": "When true, the table uses the stacked mobile layout for wider tables."
     },
     {
       "name": "tableClasses",
       "type": "string",
       "required": false,
-      "description": "Classes to add to the table container."
+      "description": "Extra classes added to the root `<table>` element."
     },
     {
       "name": "attributes",
       "type": "object",
       "required": false,
-      "description": "HTML attributes (for example data attributes) to add to the table container."
+      "description": "HTML attributes, such as `data-*` or `aria-*`, added to the root `<table>` element."
     }
   ]
 }

--- a/packages/site/views/design-system/components/table/macro-options.json
+++ b/packages/site/views/design-system/components/table/macro-options.json
@@ -10,19 +10,19 @@
           "name": "header",
           "type": "string",
           "required": false,
-          "description": "Optional responsive label override for a cell. If omitted in a responsive table, the matching `head[].text` value is used when available."
+          "description": "Optional responsive label override for a cell. If omitted in a responsive table, the matching `head[].text` value is used when available, otherwise plain text is derived from `head[].html`."
         },
         {
           "name": "text",
           "type": "string",
-          "required": true,
-          "description": "Plain text cell content. If `html` is provided, `text` is ignored."
+          "required": false,
+          "description": "Plain text cell content. Optional when `html` is provided."
         },
         {
           "name": "html",
           "type": "string",
-          "required": true,
-          "description": "Trusted HTML cell content. If provided, it replaces `text`."
+          "required": false,
+          "description": "Trusted HTML cell content. Optional when `text` is provided."
         },
         {
           "name": "format",
@@ -34,13 +34,13 @@
           "name": "colspan",
           "type": "integer",
           "required": false,
-          "description": "How many columns this cell should span."
+          "description": "How many columns this cell should span. Supported in standard and responsive table markup."
         },
         {
           "name": "rowspan",
           "type": "integer",
           "required": false,
-          "description": "How many rows this cell should span."
+          "description": "How many rows this cell should span. Supported in standard and responsive table markup."
         }
       ]
     },

--- a/packages/site/views/design-system/components/table/numeric-values/index.njk
+++ b/packages/site/views/design-system/components/table/numeric-values/index.njk
@@ -1,0 +1,59 @@
+{% from 'tables/macro.njk' import table %}
+
+{{ table({
+  caption: "Monthly appointment summary",
+  head: [
+    {
+      text: "Month"
+    },
+    {
+      text: "Appointments",
+      format: "numeric"
+    },
+    {
+      text: "Participants",
+      format: "numeric"
+    }
+  ],
+  rows: [
+    [
+      {
+        text: "January"
+      },
+      {
+        text: "128",
+        format: "numeric"
+      },
+      {
+        text: "942",
+        format: "numeric"
+      }
+    ],
+    [
+      {
+        text: "February"
+      },
+      {
+        text: "156",
+        format: "numeric"
+      },
+      {
+        text: "1,084",
+        format: "numeric"
+      }
+    ],
+    [
+      {
+        text: "March"
+      },
+      {
+        text: "149",
+        format: "numeric"
+      },
+      {
+        text: "1,031",
+        format: "numeric"
+      }
+    ]
+  ]
+}) }}

--- a/packages/site/views/design-system/components/table/spans/index.njk
+++ b/packages/site/views/design-system/components/table/spans/index.njk
@@ -1,0 +1,59 @@
+{% from 'tables/macro.njk' import table %}
+
+{{ table({
+  caption: "Clinic availability by day",
+  head: [
+    {
+      text: "Day"
+    },
+    {
+      text: "Morning clinic"
+    },
+    {
+      text: "Afternoon clinic"
+    },
+    {
+      text: "Notes"
+    }
+  ],
+  rows: [
+    [
+      {
+        text: "Monday",
+        rowspan: 2
+      },
+      {
+        text: "Children"
+      },
+      {
+        text: "Adults"
+      },
+      {
+        text: "Walk-ins available"
+      }
+    ],
+    [
+      {
+        text: "Urgent care",
+        colspan: 2
+      },
+      {
+        text: "Limited appointments"
+      }
+    ],
+    [
+      {
+        text: "Tuesday"
+      },
+      {
+        text: "Respiratory"
+      },
+      {
+        text: "Diabetes"
+      },
+      {
+        text: "Pre-booked only"
+      }
+    ]
+  ]
+}) }}

--- a/packages/toolkit/components/tables/README.md
+++ b/packages/toolkit/components/tables/README.md
@@ -218,7 +218,7 @@ Find out more about the table component and when to use it in the [design system
       </td>
       <td role="cell" class="ofh-table__cell">
         <span class="ofh-table-responsive__heading">How much?</span>
-        <span class="ofh-table-responsive__content">2.5l</span>
+        <span class="ofh-table-responsive__content">2.5ml</span>
       </td>
       <td role="cell" class="ofh-table__cell">
         <span class="ofh-table-responsive__heading">How often?</span>

--- a/packages/toolkit/components/tables/README.md
+++ b/packages/toolkit/components/tables/README.md
@@ -185,13 +185,13 @@ Find out more about the table component and when to use it in the [design system
   <caption class="ofh-table__caption">Ibuprofen syrup dosages for children</caption>
   <thead role="rowgroup" class="ofh-table__head">
     <tr role="row">
-      <th role="columnheader" class="" scope="col">
-        Age
-      </th>
-      <th role="columnheader" class="" scope="col">
+        <th role="columnheader" class="ofh-table__header" scope="col">
+          Age
+        </th>
+      <th role="columnheader" class="ofh-table__header" scope="col">
         How much?
       </th>
-      <th role="columnheader" class="" scope="col">
+      <th role="columnheader" class="ofh-table__header" scope="col">
         How often?
       </th>
     </tr>
@@ -199,35 +199,44 @@ Find out more about the table component and when to use it in the [design system
   <tbody class="ofh-table__body">
     <tr role="row" class="ofh-table__row" >
       <td role="cell" class="ofh-table__cell">
-        <span class="ofh-table-responsive__heading">Age </span>3 to 5 months (weighing more than 5kg)
+        <span class="ofh-table-responsive__heading">Age</span>
+        <span class="ofh-table-responsive__content">3 to 5 months (weighing more than 5kg)</span>
       </td>
       <td role="cell" class="ofh-table__cell">
-        <span class="ofh-table-responsive__heading">How much? </span>2.5ml
+        <span class="ofh-table-responsive__heading">How much?</span>
+        <span class="ofh-table-responsive__content">2.5ml</span>
       </td>
       <td role="cell" class="ofh-table__cell">
-        <span class="ofh-table-responsive__heading">How often? </span>Max 3 times in 24 hours
-      </td>
-    </tr>
-    <tr role="row" class="ofh-table__row" >
-      <td role="cell" class="ofh-table__cell">
-        <span class="ofh-table-responsive__heading">Age </span>6 to 11 months
-      </td>
-      <td role="cell" class="ofh-table__cell">
-        <span class="ofh-table-responsive__heading">How much? </span>2.5l
-      </td>
-      <td role="cell" class="ofh-table__cell">
-        <span class="ofh-table-responsive__heading">How often? </span>Max 3 to 4 times in 24 hours
+        <span class="ofh-table-responsive__heading">How often?</span>
+        <span class="ofh-table-responsive__content">Max 3 times in 24 hours</span>
       </td>
     </tr>
     <tr role="row" class="ofh-table__row" >
       <td role="cell" class="ofh-table__cell">
-        <span class="ofh-table-responsive__heading">Age </span>1 to 3 years
+        <span class="ofh-table-responsive__heading">Age</span>
+        <span class="ofh-table-responsive__content">6 to 11 months</span>
       </td>
       <td role="cell" class="ofh-table__cell">
-        <span class="ofh-table-responsive__heading">How much? </span>5ml
+        <span class="ofh-table-responsive__heading">How much?</span>
+        <span class="ofh-table-responsive__content">2.5l</span>
       </td>
       <td role="cell" class="ofh-table__cell">
-        <span class="ofh-table-responsive__heading">How often? </span>Max 3 times in 24 hours
+        <span class="ofh-table-responsive__heading">How often?</span>
+        <span class="ofh-table-responsive__content">Max 3 to 4 times in 24 hours</span>
+      </td>
+    </tr>
+    <tr role="row" class="ofh-table__row" >
+      <td role="cell" class="ofh-table__cell">
+        <span class="ofh-table-responsive__heading">Age</span>
+        <span class="ofh-table-responsive__content">1 to 3 years</span>
+      </td>
+      <td role="cell" class="ofh-table__cell">
+        <span class="ofh-table-responsive__heading">How much?</span>
+        <span class="ofh-table-responsive__content">5ml</span>
+      </td>
+      <td role="cell" class="ofh-table__cell">
+        <span class="ofh-table-responsive__heading">How often?</span>
+        <span class="ofh-table-responsive__content">Max 3 times in 24 hours</span>
       </td>
     </tr>
   </tbody>

--- a/packages/toolkit/components/tables/_tables.scss
+++ b/packages/toolkit/components/tables/_tables.scss
@@ -29,7 +29,7 @@
  * Table row hover is used to aid readability for users.
  */
 
-.ofh-table__row {
+.ofh-table__body .ofh-table__row {
   &:hover {
     background-color: $ofh-color-greyscale-6;
   }
@@ -70,10 +70,10 @@
  * 2. Displaying the thead on desktop
  * 3. Removing default screen reader behaviour
  * 4. Assigning role of table-row on desktop to give default screen reader behaviour
- * 5. Using justify content to space out elements in the row on mobile
+ * 5. Aligning the mobile row content vertically
  * 6. Assigning a minimum width in case of black cell
  * 7. Aligning content to the right on mobile
- * 8. Aligning mobile header to left to split it from the data
+ * 8. Splitting mobile headings and content into equal columns
  * 9. Hiding mobile specific header from desktop view
  * 10. Adding a display block value due to IE 11 not having full flex support
  */
@@ -122,9 +122,9 @@
       }
 
       td {
+        align-items: center;
         display: block; // For browsers that don't support flexbox
         display: flex;
-        justify-content: space-between; /* [5] */
         min-width: 1px; /* [6] */
 
         @media all and (-ms-high-contrast: none) {
@@ -137,10 +137,21 @@
         }
 
         @include mq($until: desktop) {
+          border-bottom: 1px solid $ofh-color-border-primary;
           padding-right: 0;
-          text-align: right; /* [7] */
+
+          .ofh-table-responsive__content,
+          .ofh-table-responsive__heading {
+            flex: 1 0 0;
+            min-width: 1px;
+          }
+
+          .ofh-table-responsive__content {
+            text-align: right; /* [7] */
+          }
+
           &:last-child {
-            border-bottom: 3px solid $ofh-color-greyscale-5;
+            border-bottom-width: 2px;
           }
         }
       }

--- a/packages/toolkit/components/tables/template.njk
+++ b/packages/toolkit/components/tables/template.njk
@@ -30,8 +30,10 @@
       <tr role="row" class="ofh-table__row" >
         {%- if params.responsive %}
           {%- for cell in row %}
-            {%- set responsiveHeader = cell.header if cell.header else (params.head[loop.index0].text if params.head and params.head[loop.index0] and params.head[loop.index0].text else '') %}
-            <td role="cell" class="ofh-table__cell{% if cell.format %} ofh-table__cell--{{ cell.format }}{% endif %}">
+            {%- set responsiveHeader = cell.header if cell.header else (params.head[loop.index0].text if params.head and params.head[loop.index0] and params.head[loop.index0].text else (params.head[loop.index0].html | striptags if params.head and params.head[loop.index0] and params.head[loop.index0].html else '')) %}
+            <td role="cell" class="ofh-table__cell{% if cell.format %} ofh-table__cell--{{ cell.format }}{% endif %}"
+                {%- if cell.colspan %} colspan="{{ cell.colspan }}"{% endif %}
+                {%- if cell.rowspan %} rowspan="{{ cell.rowspan }}"{% endif %}>
               <span class="ofh-table-responsive__heading">{{ responsiveHeader }}</span>
               <span class="ofh-table-responsive__content">{{ cell.html | safe if cell.html else cell.text }}</span>
             </td>

--- a/packages/toolkit/components/tables/template.njk
+++ b/packages/toolkit/components/tables/template.njk
@@ -17,7 +17,7 @@
     <thead role="rowgroup" class="ofh-table__head">
     <tr role="row">
       {%- for item in params.head %}
-        <th role="columnheader" class="
+        <th role="columnheader" class="ofh-table__header
       {%- if item.format %} ofh-table__header--{{ item.format }}{% endif %}" scope="col">
           {{ item.html |safe if item.html else item.text }}
         </th>
@@ -30,8 +30,10 @@
       <tr role="row" class="ofh-table__row" >
         {%- if params.responsive %}
           {%- for cell in row %}
+            {%- set responsiveHeader = cell.header if cell.header else (params.head[loop.index0].text if params.head and params.head[loop.index0] and params.head[loop.index0].text else '') %}
             <td role="cell" class="ofh-table__cell{% if cell.format %} ofh-table__cell--{{ cell.format }}{% endif %}">
-              <span class="ofh-table-responsive__heading">{{cell.header}} </span>{{ cell.html | safe if cell.html else cell.text }}
+              <span class="ofh-table-responsive__heading">{{ responsiveHeader }}</span>
+              <span class="ofh-table-responsive__content">{{ cell.html | safe if cell.html else cell.text }}</span>
             </td>
           {%- endfor %}
         {%- else %}

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/toolkit",
-  "version": "4.17.0",
+  "version": "4.18.0",
   "description": "Our Future Health design system toolkit contains the code you need to start building user interfaces for Our Future Health websites and services.",
   "repository": {
     "type": "git",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/toolkit",
-  "version": "4.9.0",
+  "version": "4.18.0",
   "description": "Our Future Health design system toolkit contains the code you need to start building user interfaces for Our Future Health websites and services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
This PR delivers **DSE-427 table refresh** across toolkit, React, the docs site, and Storybook.

It audits the existing toolkit table implementation against the current Figma component, aligns the responsive/mobile table treatment more closely with the design, introduces the public React `Table` component, and brings the docs site and Storybook into the same teaching pattern for the main table variants.

Ticket: DSE-427

## Release scope
- `@ourfuturehealth/toolkit` -> `4.18.0`
- `@ourfuturehealth/react-components` -> `0.17.0`
- updates release metadata in `CHANGELOG.md`, `UPGRADING.md`, `docs/release-versioning-strategy.md`, `docs/consuming-react-components.md`, and `packages/react-components/README.md`

## Breaking Changes
- None.

## Key Changes
- refines the toolkit responsive table rendering to match the current Figma mobile pattern more closely, including clearer heading/content columns and a `2px` closing border on each stacked row group
- keeps the default toolkit two-column table visually stable while tightening the responsive/mobile behaviour
- expands toolkit docs-site coverage for table with examples for:
  - default
  - responsive
  - first cell as row header
  - numeric values
  - column and row spans
- adds the public React `Table` component with support for:
  - `caption`
  - `head`
  - `rows`
  - `responsive`
  - `firstCellIsHeader`
  - numeric cells
  - `colSpan` / `rowSpan`
- adds unit and accessibility coverage for the new React `Table`
- updates Storybook so `Table` follows the newer `Docs` / `Default` / `Builder` / showcase teaching pattern
- keeps the Builder story friendly by using story-only helpers instead of exposing raw nested `head` / `rows` editing, and limits row-header toggling to presets that actually support it

## Validation
- `npm test`
- `pnpm lint`
- `pnpm --filter=@ourfuturehealth/react-components build:storybook`
- `pnpm --filter=site build:eleventy`
- `pnpm build`
- `pnpm docs:release-contract`
- `pnpm smoke:release-artifacts`
- manual QA against current/main docs-site routes and branch routes for default and responsive toolkit table behaviour
- manual QA on the new React Storybook docs, Builder, and showcase stories

## Reviewer Focus
- responsive/mobile toolkit tables should now feel closer to the current Figma structure, especially the stacked label/value treatment and closing border weight
- toolkit docs site and React Storybook should now teach the same table pattern family
- the React `Table` API should feel idiomatic for this library while still covering toolkit parity features
- release metadata should line up on `toolkit-v4.18.0` / `react-v0.17.0`
