### PR TITLE
DSE-428 :: Breadcrumb FE update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ### 2026-04-30
 
+#### @ourfuturehealth/toolkit 4.19.0 (`toolkit-v4.19.0`)
+
+##### Added
+
+- Expanded docs-site coverage for the `breadcrumb` component, including a deeper trail example and clearer macro guidance
+
+##### Changed
+
+- Refined the toolkit `breadcrumb` component to match the current Figma chevron sizing, spacing, color tokens, and responsive collapse behaviour more closely
+- Updated the tablet/mobile collapsed breadcrumb to use the breadcrumb label directly instead of `Back to ...`
+- Improved the breadcrumb docs page so it teaches the toolkit/Nunjucks usage more clearly and points React consumers to Storybook
+
+#### @ourfuturehealth/react-components 0.18.0 (`react-v0.18.0`)
+
+##### Added
+
+- New public `Breadcrumb` component with ancestor `items`, optional `current`, mobile back-link behaviour, and anchor passthrough support
+- Storybook coverage for `Breadcrumb`, including `Default`, `Builder`, `DeepTrail`, and `WithoutCurrent`
+
+##### Changed
+
+- Refined the Breadcrumb Storybook docs page so it teaches the React API clearly and separates Builder-only helpers from real props
+
 #### @ourfuturehealth/toolkit 4.18.0 (`toolkit-v4.18.0`)
 
 ##### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ### Unreleased
 
+#### @ourfuturehealth/toolkit 4.19.0 (`toolkit-v4.19.0`)
+
+##### Added
+
+- Expanded docs-site coverage for the `breadcrumb` component, including a deeper trail example and clearer macro guidance
+
+##### Changed
+
+- Refined the toolkit `breadcrumb` component to match the current Figma chevron sizing, spacing, and responsive collapse behaviour more closely
+- Updated the tablet/mobile collapsed breadcrumb to use the breadcrumb label directly instead of `Back to ...`
+- Improved the breadcrumb docs page so it teaches the toolkit/Nunjucks usage more clearly and points React consumers to Storybook
+
+#### @ourfuturehealth/react-components 0.18.0 (`react-v0.18.0`)
+
+##### Added
+
+- New public `Breadcrumb` component with ancestor `items`, optional `current`, mobile back-link behaviour, and anchor passthrough support
+- Storybook coverage for `Breadcrumb`, including `Default`, `Builder`, `DeepTrail`, and `WithoutCurrent`
+
+##### Changed
+
+- Refined the Breadcrumb Storybook docs page so it teaches the React API clearly and separates Builder-only helpers from real props
+
 #### @ourfuturehealth/react-components 0.8.0 (`react-v0.8.0`)
 
 ##### ⚠️ BREAKING CHANGES

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,6 +8,7 @@ This guide provides detailed migration instructions for upgrading between versio
 
 | Version                                                 | Date          | Breaking Changes           | Migration Complexity                     |
 | ------------------------------------------------------- | ------------- | -------------------------- | ---------------------------------------- |
+| [v4.19.0 / React v0.18.0](#upgrading-to-v4190--react-v0180) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React Breadcrumb if needed and use the refreshed toolkit breadcrumb APIs when relevant |
 | [v4.18.0 / React v0.17.0](#upgrading-to-v4180--react-v0170) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React Table if needed and use the refreshed toolkit table APIs when relevant |
 | [v4.17.0 / React v0.16.0](#upgrading-to-v4170--react-v0160) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React Image if needed and use the refreshed toolkit image APIs when relevant |
 | [v4.16.0 / React v0.15.0](#upgrading-to-v4160--react-v0150) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React InsetText if needed and use the refreshed toolkit inset-text APIs when relevant |
@@ -26,6 +27,54 @@ This guide provides detailed migration instructions for upgrading between versio
 | [v4.3.0 / React v0.2.0](#upgrading-to-v430--react-v020) | March 2026    | Button variant naming      | 🟡 Medium - Find/replace required        |
 | [v4.1.0](#upgrading-to-v410)                            | February 2026 | Spacing scale indices      | 🟡 Medium - Index updates required       |
 | [v4.0.0](#upgrading-to-v400-monorepo-restructure)       | 2025          | Monorepo restructure       | 🔴 High - Installation & paths change    |
+
+---
+## Upgrading to v4.19.0 / React v0.18.0
+
+**Released:** April 2026
+**Affected packages:**
+
+- `@ourfuturehealth/toolkit` v4.19.0+
+- `@ourfuturehealth/react-components` v0.18.0+
+
+### Breaking Changes
+
+None.
+
+### Release Overview
+
+This release refreshes the toolkit `breadcrumb` component to the current design-system treatment and introduces the first public React `Breadcrumb` component.
+
+- Toolkit consumers should review the refreshed breadcrumb chevron sizing, spacing, color tokens, and responsive collapse behaviour, especially if local overrides depend on the older treatment.
+- Toolkit docs now show explicit default and deep-trail examples.
+- React consumers can now adopt the public `Breadcrumb` component when they need toolkit-parity breadcrumb navigation that collapses to a single back link on tablet and mobile.
+
+### Migration Steps
+
+1. Adopt the public React `Breadcrumb` component where you need toolkit-parity breadcrumb navigation in React.
+2. Prefer the refreshed toolkit breadcrumb API, docs examples, and canonical usage when touching existing Nunjucks templates.
+3. Re-run visual QA if you have local breadcrumb overrides, especially around chevron sizing, color state treatment, and responsive collapse behaviour.
+
+#### React example
+
+**New in `react-v0.18.0`:**
+
+```tsx
+import { Breadcrumb } from '@ourfuturehealth/react-components';
+
+const items = [
+  { text: 'Health A to Z', href: '/health-a-to-z' },
+  { text: 'Conditions', href: '/health-a-to-z/conditions' },
+];
+
+<Breadcrumb
+  items={items}
+  current={{
+    text: 'Eczema',
+    href: '/health-a-to-z/conditions/eczema',
+  }}
+/>;
+```
 
 ---
 
@@ -505,7 +554,6 @@ import {
   LinkSkip,
 } from '@ourfuturehealth/react-components';
 ```
-
 ## Upgrading to React v0.8.0
 
 **Released:** April 2026

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,6 +8,7 @@ This guide provides detailed migration instructions for upgrading between versio
 
 | Version                                                 | Date          | Breaking Changes           | Migration Complexity                     |
 | ------------------------------------------------------- | ------------- | -------------------------- | ---------------------------------------- |
+| [v4.19.0 / React v0.18.0](#upgrading-to-v4190--react-v0180) | April 2026    | No breaking changes        | 🟢 Low - adopt the new Breadcrumb APIs only if relevant |
 | [React v0.8.0](#upgrading-to-react-v080)                | April 2026    | React `spritePath` removal | 🟢 Low - Remove the deprecated prop      |
 | [v4.9.0 / React v0.7.0](#upgrading-to-v490--react-v070) | April 2026    | Icon naming sync           | 🟡 Medium - Search/replace icon names    |
 | [v4.8.0 / React v0.6.0](#upgrading-to-v480--react-v060) | March 2026    | No breaking changes        | 🟢 Low - only relevant if you adopted the earlier TextInput prototype |
@@ -17,6 +18,60 @@ This guide provides detailed migration instructions for upgrading between versio
 | [v4.3.0 / React v0.2.0](#upgrading-to-v430--react-v020) | March 2026    | Button variant naming      | 🟡 Medium - Find/replace required        |
 | [v4.1.0](#upgrading-to-v410)                            | February 2026 | Spacing scale indices      | 🟡 Medium - Index updates required       |
 | [v4.0.0](#upgrading-to-v400-monorepo-restructure)       | 2025          | Monorepo restructure       | 🔴 High - Installation & paths change    |
+
+---
+
+## Upgrading to v4.19.0 / React v0.18.0
+
+**Planned:** April 2026
+**Affected packages:**
+
+- `@ourfuturehealth/toolkit` v4.19.0+
+- `@ourfuturehealth/react-components` v0.18.0+
+
+### Release Overview
+
+This release does not introduce a supported breaking API change.
+
+Toolkit consumers should review the refreshed `breadcrumb` component spacing, chevron treatment, and responsive collapse behaviour if they already use breadcrumb navigation.
+
+React consumers can now adopt the public `Breadcrumb` component when they need a desktop breadcrumb trail that collapses to a single back link on tablet and mobile.
+
+### Breadcrumb
+
+- Toolkit `breadcrumb` now matches the current Figma chevron sizing, spacing, and mobile collapse behaviour more closely
+- React now exposes `Breadcrumb` as a public component with `items`, optional `current`, and anchor passthrough support
+- Storybook and docs-site examples now cover default, deep-trail, and no-current breadcrumb usage
+
+#### React example
+
+```tsx
+import { Breadcrumb } from '@ourfuturehealth/react-components';
+
+const items = [
+  { text: 'Health A to Z', href: '/health-a-to-z' },
+  { text: 'Conditions', href: '/health-a-to-z/conditions' },
+];
+
+<Breadcrumb
+  items={items}
+  current={{
+    text: 'Eczema',
+    href: '/health-a-to-z/conditions/eczema',
+  }}
+/>;
+```
+
+#### Ancestors-only example
+
+```tsx
+<Breadcrumb
+  items={[
+    { text: 'Health A to Z', href: '/health-a-to-z' },
+    { text: 'Conditions', href: '/health-a-to-z/conditions' },
+  ]}
+/>
+```
 
 ---
 

--- a/docs/consuming-react-components.md
+++ b/docs/consuming-react-components.md
@@ -57,12 +57,24 @@ Import components and styles in your React application:
 
 ```tsx
 import React from 'react';
-import { Button, TextInput } from '@ourfuturehealth/react-components';
+import { Breadcrumb, Button, TextInput } from '@ourfuturehealth/react-components';
 import '@ourfuturehealth/react-components/styles/participant';
 
 function App() {
+  const breadcrumbItems = [
+    { text: 'Health A to Z', href: '/health-a-to-z' },
+    { text: 'Conditions', href: '/health-a-to-z/conditions' },
+  ];
+
   return (
     <div>
+      <Breadcrumb
+        items={breadcrumbItems}
+        current={{
+          text: 'Eczema',
+          href: '/health-a-to-z/conditions/eczema',
+        }}
+      />
       <TextInput
         id="name"
         label="Your name"
@@ -122,6 +134,7 @@ The React components package currently provides the following components:
 
 - `Button` - Call-to-action buttons and links
 - `TextInput` - Text input fields with toolkit-parity hint, error, and width support
+- `Breadcrumb` - Breadcrumb trails that collapse to a single back link on tablet and mobile
 - `Fieldset` - Semantic fieldset wrapper for grouped form questions and legends
 - `Textarea` - Multi-line text input fields
 - `Select` - Native select inputs with toolkit styling and icon affordance

--- a/docs/consuming-react-components.md
+++ b/docs/consuming-react-components.md
@@ -57,10 +57,14 @@ Import components and styles in your React application:
 
 ```tsx
 import React from 'react';
-import { Button, Table, TextInput } from '@ourfuturehealth/react-components';
+import { Breadcrumb, Button, Table, TextInput } from '@ourfuturehealth/react-components';
 import '@ourfuturehealth/react-components/styles/participant';
 
 function App() {
+  const breadcrumbItems = [
+    { text: 'Health A to Z', href: '/health-a-to-z' },
+    { text: 'Conditions', href: '/health-a-to-z/conditions' },
+  ];
   const symptomsHead = [
     { content: 'Symptom' },
     { content: 'Self-care' },
@@ -78,6 +82,13 @@ function App() {
 
   return (
     <div>
+      <Breadcrumb
+        items={breadcrumbItems}
+        current={{
+          text: 'Eczema',
+          href: '/health-a-to-z/conditions/eczema',
+        }}
+      />
       <TextInput
         id="name"
         label="Your name"
@@ -138,6 +149,7 @@ The React components package currently provides the following components:
 
 - `Button` - Call-to-action buttons and links
 - `TextInput` - Text input fields with toolkit-parity hint, error, and width support
+- `Breadcrumb` - Breadcrumb trails that collapse to a single back link on tablet and mobile
 - `Fieldset` - Semantic fieldset wrapper for grouped form questions and legends
 - `Footer` - Page footer with support links, optional small print and legal copy, and optional social links
 - `Textarea` - Multi-line text input fields

--- a/docs/release-versioning-strategy.md
+++ b/docs/release-versioning-strategy.md
@@ -31,8 +31,8 @@ For consumer migration instructions, use [Upgrading Guide](../UPGRADING.md).
 
 | Package                             | Canonical tag pattern | Example tag      |
 | ----------------------------------- | --------------------- | ---------------- |
-| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.18.0` |
-| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.17.0`   |
+| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.19.0` |
+| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.18.0`   |
 
 The release workflow still accepts legacy toolkit tags in the `v*` format for backward compatibility, but new toolkit releases should use `toolkit-v*`.
 

--- a/docs/release-versioning-strategy.md
+++ b/docs/release-versioning-strategy.md
@@ -126,9 +126,8 @@ This table is a visual aid for pre-monorepo versus post-monorepo releases.
 | 17    | `react-v0.5.0`   | N/A             | `0.5.0`       | Monorepo       | Released               |
 | 18    | `toolkit-v4.8.0` | `4.8.0`         | N/A           | Monorepo       | Released               |
 | 19    | `react-v0.6.0`   | N/A             | `0.6.0`       | Monorepo       | Released               |
-| 20    | `toolkit-v4.9.0` | `4.9.0`         | N/A           | Monorepo       | Released               |
-| 21    | `react-v0.7.0`   | N/A             | `0.7.0`       | Monorepo       | Released               |
-| 22    | `react-v0.8.0`   | N/A             | `0.8.0`       | Monorepo       | Planned in this branch |
+| 20    | `toolkit-v4.19.0` | `4.19.0`       | N/A           | Monorepo       | Planned in this branch |
+| 21    | `react-v0.18.0`   | N/A            | `0.18.0`      | Monorepo       | Planned in this branch |
 
 ## References
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -42,6 +42,7 @@ Install the resulting local `.tgz` in the consumer application.
 ```tsx
 import {
   Autocomplete,
+  Breadcrumb,
   Button,
   Card,
   CardCallout,
@@ -62,6 +63,10 @@ import '@ourfuturehealth/react-components/styles/participant';
 
 function App() {
   const countryOptions = ['England', 'Scotland', 'Wales', 'Northern Ireland'];
+  const breadcrumbItems = [
+    { text: 'Health A to Z', href: '/health-a-to-z' },
+    { text: 'Conditions', href: '/health-a-to-z/conditions' },
+  ];
   const contactCheckboxItems = [
     { value: 'email', label: 'Email' },
     { value: 'phone', label: 'Phone' },
@@ -75,6 +80,13 @@ function App() {
 
   return (
     <div>
+      <Breadcrumb
+        items={breadcrumbItems}
+        current={{
+          text: 'Eczema',
+          href: '/health-a-to-z/conditions/eczema',
+        }}
+      />
       <ErrorSummary
         titleText="There is a problem"
         errorList={[
@@ -181,6 +193,7 @@ A form input component with toolkit-parity label, hint, error, and width support
 The package also provides:
 
 - `Fieldset`
+- `Breadcrumb`
 - `Textarea`
 - `Select`
 - `DateInput`

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -42,6 +42,7 @@ Install the resulting local `.tgz` in the consumer application.
 ```tsx
 import {
   Autocomplete,
+  Breadcrumb,
   Button,
   Card,
   CardCallout,
@@ -74,6 +75,10 @@ import '@ourfuturehealth/react-components/styles/participant';
 
 function App() {
   const countryOptions = ['England', 'Scotland', 'Wales', 'Northern Ireland'];
+  const breadcrumbItems = [
+    { text: 'Health A to Z', href: '/health-a-to-z' },
+    { text: 'Conditions', href: '/health-a-to-z/conditions' },
+  ];
   const contactCheckboxItems = [
     { value: 'email', label: 'Email' },
     { value: 'phone', label: 'Phone' },
@@ -110,6 +115,13 @@ function App() {
 
   return (
     <div>
+      <Breadcrumb
+        items={breadcrumbItems}
+        current={{
+          text: 'Eczema',
+          href: '/health-a-to-z/conditions/eczema',
+        }}
+      />
       <ErrorSummary
         titleText="There is a problem"
         errorList={[
@@ -271,6 +283,7 @@ A form input component with toolkit-parity label, hint, error, and width support
 The package also provides:
 
 - `Fieldset`
+- `Breadcrumb`
 - `Footer`
 - `Textarea`
 - `Select`

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/react-components",
-  "version": "0.8.0",
+  "version": "0.18.0",
   "type": "module",
   "description": "React component library for OFH Design System",
   "packageManager": "pnpm@10.29.2",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/react-components",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "type": "module",
   "description": "React component library for OFH Design System",
   "packageManager": "pnpm@10.29.2",

--- a/packages/react-components/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/react-components/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,0 +1,397 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Source, Stories, Title } from '@storybook/addon-docs/blocks';
+import { Breadcrumb, type BreadcrumbItem, type BreadcrumbProps } from './Breadcrumb';
+
+type BreadcrumbPreset = 'default' | 'deep-trail' | 'ancestors-only';
+
+type BreadcrumbStoryArgs = BreadcrumbProps & {
+  trailPreset?: BreadcrumbPreset;
+  currentText?: string;
+  showCurrent?: boolean;
+};
+
+const defaultItems: BreadcrumbItem[] = [
+  {
+    text: 'Health A to Z',
+    href: '/health-a-to-z',
+  },
+  {
+    text: 'Conditions',
+    href: '/health-a-to-z/conditions',
+  },
+];
+
+const deepTrailItems: BreadcrumbItem[] = [
+  {
+    text: 'Health A to Z',
+    href: '/health-a-to-z',
+  },
+  {
+    text: 'Conditions',
+    href: '/health-a-to-z/conditions',
+  },
+  {
+    text: 'Skin problems',
+    href: '/health-a-to-z/conditions/skin-problems',
+  },
+  {
+    text: 'Dry skin',
+    href: '/health-a-to-z/conditions/skin-problems/dry-skin',
+  },
+  {
+    text: 'Treatments',
+    href: '/health-a-to-z/conditions/skin-problems/dry-skin/treatments',
+  },
+];
+
+const presetItems: Record<BreadcrumbPreset, BreadcrumbItem[]> = {
+  default: defaultItems,
+  'deep-trail': deepTrailItems,
+  'ancestors-only': defaultItems,
+};
+
+const usageExample = `import { Breadcrumb } from '@ourfuturehealth/react-components';
+
+const items = [
+  {
+    text: 'Health A to Z',
+    href: '/health-a-to-z',
+  },
+  {
+    text: 'Conditions',
+    href: '/health-a-to-z/conditions',
+  },
+];
+
+<Breadcrumb
+  items={items}
+  current={{
+    text: 'Eczema',
+    href: '/health-a-to-z/conditions/eczema',
+  }}
+/>;
+`;
+
+const itemsShapeExample = `type BreadcrumbItem = {
+  text: React.ReactNode;
+  href?: string;
+  anchorProps?: Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'children' | 'href'>;
+};
+`;
+
+const currentShapeExample = `type BreadcrumbProps = {
+  items: BreadcrumbItem[];
+  current?: BreadcrumbItem;
+  classes?: string;
+  className?: string;
+};
+`;
+
+const defaultSource = `import { Breadcrumb } from '@ourfuturehealth/react-components';
+
+const items = [
+  {
+    text: 'Health A to Z',
+    href: '/health-a-to-z',
+  },
+  {
+    text: 'Conditions',
+    href: '/health-a-to-z/conditions',
+  },
+];
+
+<Breadcrumb
+  items={items}
+  current={{
+    text: 'Eczema',
+    href: '/health-a-to-z/conditions/eczema',
+  }}
+/>;
+`;
+
+const deepTrailSource = `import { Breadcrumb } from '@ourfuturehealth/react-components';
+
+const items = [
+  {
+    text: 'Health A to Z',
+    href: '/health-a-to-z',
+  },
+  {
+    text: 'Conditions',
+    href: '/health-a-to-z/conditions',
+  },
+  {
+    text: 'Skin problems',
+    href: '/health-a-to-z/conditions/skin-problems',
+  },
+  {
+    text: 'Dry skin',
+    href: '/health-a-to-z/conditions/skin-problems/dry-skin',
+  },
+  {
+    text: 'Treatments',
+    href: '/health-a-to-z/conditions/skin-problems/dry-skin/treatments',
+  },
+];
+
+<Breadcrumb
+  items={items}
+  current={{
+    text: 'Ointments',
+    href: '/health-a-to-z/conditions/skin-problems/dry-skin/treatments/ointments',
+  }}
+/>;
+`;
+
+const ancestorsOnlySource = `import { Breadcrumb } from '@ourfuturehealth/react-components';
+
+const items = [
+  {
+    text: 'Health A to Z',
+    href: '/health-a-to-z',
+  },
+  {
+    text: 'Conditions',
+    href: '/health-a-to-z/conditions',
+  },
+];
+
+<Breadcrumb items={items} />;
+`;
+
+const renderBreadcrumb = ({
+  trailPreset = 'default',
+  showCurrent = true,
+  currentText = 'Eczema',
+  items,
+  current,
+  ...props
+}: BreadcrumbStoryArgs) => {
+  const resolvedItems = items ?? presetItems[trailPreset];
+  const resolvedCurrent =
+    current ??
+    (showCurrent
+      ? {
+          text: currentText,
+          href: `/health-a-to-z/conditions/${currentText.toLowerCase().replace(/\s+/g, '-')}`,
+        }
+      : undefined);
+
+  return (
+    <Breadcrumb
+      {...props}
+      items={resolvedItems}
+      current={resolvedCurrent}
+    />
+  );
+};
+
+const meta: Meta<BreadcrumbStoryArgs> = {
+  title: 'Components/Breadcrumb',
+  component: Breadcrumb,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      page: () => (
+        <>
+          <Title />
+          <p>
+            Use Breadcrumb to show the path back through related content pages.
+            It matches the toolkit breadcrumb structure, keeps the full trail on desktop,
+            and collapses to a single back link on tablet and mobile.
+          </p>
+
+          <h2>How to use the React component</h2>
+          <p>
+            Pass ancestor links through the <code>items</code> prop. If you want a
+            final breadcrumb item as well, pass it through <code>current</code>.
+            On tablet and mobile, the component will collapse to a single back link
+            using <code>current</code> when it is available, or the last linked
+            ancestor when it is not.
+          </p>
+          <Source code={usageExample} language="tsx" />
+
+          <h2>Items shape</h2>
+          <p>
+            Each breadcrumb item needs visible text and can optionally include an
+            <code>href</code>. Use <code>anchorProps</code> when you need extra
+            anchor attributes such as <code>target</code>, <code>rel</code>, or
+            <code>data-*</code> hooks.
+          </p>
+          <Source code={itemsShapeExample} language="tsx" />
+
+          <h2>Current item shape</h2>
+          <p>
+            <code>current</code> uses the same item shape as <code>items</code>.
+            This keeps the desktop final crumb and the tablet/mobile back link aligned
+            without needing separate props for the label and href.
+          </p>
+          <Source code={currentShapeExample} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes />
+
+          <h2>Storybook builder helpers</h2>
+          <p>
+            <code>trailPreset</code>, <code>showCurrent</code>, and
+            <code>currentText</code> are Storybook Builder helpers only. They make
+            the interactive story easier to use, but they are not real
+            <code>Breadcrumb</code> props.
+          </p>
+
+          <Stories includePrimary={false} />
+        </>
+      ),
+    },
+  },
+  argTypes: {
+    items: {
+      control: false,
+      description:
+        'Ancestor breadcrumb items shown in the full desktop trail.',
+      table: {
+        type: { summary: 'BreadcrumbItem[]' },
+      },
+    },
+    current: {
+      control: false,
+      description:
+        'Optional final breadcrumb item. When provided, it is also used for the tablet/mobile back link.',
+      table: {
+        type: { summary: 'BreadcrumbItem' },
+      },
+    },
+    classes: {
+      control: 'text',
+      description:
+        'Additional toolkit-style classes added to the root breadcrumb element.',
+    },
+    className: {
+      control: 'text',
+      description:
+        'Additional React classes added alongside the toolkit classes.',
+    },
+    trailPreset: {
+      control: 'radio',
+      options: ['default', 'deep-trail', 'ancestors-only'],
+      description:
+        'Builder helper that swaps between a short trail, a deeper trail, and an ancestors-only example.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
+    showCurrent: {
+      control: 'boolean',
+      description:
+        'Builder helper that toggles the final breadcrumb item on and off.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
+    currentText: {
+      control: 'text',
+      description:
+        'Builder helper that changes the final breadcrumb label.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
+  },
+  args: {
+    trailPreset: 'default',
+    showCurrent: true,
+    currentText: 'Eczema',
+    classes: '',
+    className: '',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: renderBreadcrumb,
+  args: {
+    items: defaultItems,
+    current: {
+      text: 'Eczema',
+      href: '/health-a-to-z/conditions/eczema',
+    },
+  },
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      source: {
+        code: defaultSource,
+      },
+      description: {
+        story:
+          'Realistic fixed example showing a short breadcrumb trail with a final breadcrumb item.',
+      },
+    },
+  },
+};
+
+export const Builder: Story = {
+  render: renderBreadcrumb,
+  args: {
+    trailPreset: 'default',
+    showCurrent: true,
+    currentText: 'Eczema',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Interactive surface for trying the main breadcrumb options without editing raw item arrays.',
+      },
+    },
+  },
+};
+
+export const DeepTrail: Story = {
+  render: () => (
+    <Breadcrumb
+      items={deepTrailItems}
+      current={{
+        text: 'Ointments',
+        href: '/health-a-to-z/conditions/skin-problems/dry-skin/treatments/ointments',
+      }}
+    />
+  ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      source: {
+        code: deepTrailSource,
+      },
+      description: {
+        story:
+          'Fixed showcase example for a deeper breadcrumb trail that can wrap on larger breakpoints.',
+      },
+    },
+  },
+};
+
+export const WithoutCurrent: Story = {
+  render: () => <Breadcrumb items={defaultItems} />,
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      source: {
+        code: ancestorsOnlySource,
+      },
+      description: {
+        story:
+          'Fixed showcase example showing only ancestor breadcrumbs. On tablet and mobile, the last linked ancestor is used as the back link.',
+      },
+    },
+  },
+};

--- a/packages/react-components/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/packages/react-components/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import { Breadcrumb, type BreadcrumbItem } from './Breadcrumb';
+
+const ancestorItems: BreadcrumbItem[] = [
+  {
+    text: 'Health A to Z',
+    href: '/health-a-to-z',
+  },
+  {
+    text: 'Conditions',
+    href: '/health-a-to-z/conditions',
+  },
+];
+
+describe('Breadcrumb', () => {
+  it('renders the breadcrumb trail and current item', () => {
+    render(
+      <Breadcrumb
+        items={ancestorItems}
+        current={{
+          text: 'Eczema',
+          href: '/health-a-to-z/conditions/eczema',
+        }}
+      />,
+    );
+
+    expect(screen.getByLabelText('Breadcrumb')).toBeInTheDocument();
+    expect(screen.getAllByText('Health A to Z')).toHaveLength(1);
+    expect(screen.getAllByText('Conditions')).toHaveLength(1);
+    expect(screen.getAllByText('Eczema')).toHaveLength(2);
+  });
+
+  it('renders text-only items when href is not provided', () => {
+    render(
+      <Breadcrumb
+        items={[
+          {
+            text: 'Health A to Z',
+            href: '/health-a-to-z',
+          },
+          {
+            text: 'Conditions',
+          },
+        ]}
+      />,
+    );
+
+    const textOnlyItem = screen.getByText('Conditions');
+
+    expect(textOnlyItem.tagName).toBe('SPAN');
+  });
+
+  it('uses the final current item as the mobile back-link label without the Back to prefix', () => {
+    const { container } = render(
+      <Breadcrumb
+        items={ancestorItems}
+        current={{
+          text: 'Eczema',
+          href: '/health-a-to-z/conditions/eczema',
+        }}
+      />,
+    );
+
+    const backLink = container.querySelector('.ofh-breadcrumb__backlink');
+
+    expect(backLink).not.toBeNull();
+    expect(backLink?.textContent?.trim()).toBe('Eczema');
+  });
+
+  it('falls back to the last linked ancestor for the mobile back link when current is not provided', () => {
+    const { container } = render(<Breadcrumb items={ancestorItems} />);
+
+    const backLink = container.querySelector('.ofh-breadcrumb__backlink');
+
+    expect(backLink).not.toBeNull();
+    expect(backLink?.textContent?.trim()).toBe('Conditions');
+    expect(backLink).toHaveAttribute('href', '/health-a-to-z/conditions');
+  });
+
+  it('forwards refs and combines toolkit classes with className', () => {
+    const ref = { current: null as HTMLElement | null };
+
+    render(
+      <Breadcrumb
+        ref={ref}
+        items={ancestorItems}
+        classes="app-breadcrumb"
+        className="qa-breadcrumb"
+      />,
+    );
+
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+    expect(ref.current).toHaveClass('ofh-breadcrumb');
+    expect(ref.current).toHaveClass('app-breadcrumb');
+    expect(ref.current).toHaveClass('qa-breadcrumb');
+  });
+
+  it('has no detectable accessibility violations', async () => {
+    const { container } = render(
+      <Breadcrumb
+        items={ancestorItems}
+        current={{
+          text: 'Eczema',
+          href: '/health-a-to-z/conditions/eczema',
+        }}
+      />,
+    );
+
+    const results = await axe(container);
+
+    expect(results.violations).toHaveLength(0);
+  });
+});

--- a/packages/react-components/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/react-components/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { Icon } from '../Icon';
+import { joinClasses } from '../../internal/ofhUtils';
+
+export interface BreadcrumbItem {
+  /**
+   * Visible breadcrumb label.
+   */
+  text: React.ReactNode;
+  /**
+   * Link target for the breadcrumb item.
+   * If omitted, the item is rendered as text only.
+   */
+  href?: string;
+  /**
+   * Additional props for the breadcrumb anchor element.
+   */
+  anchorProps?: Omit<
+    React.AnchorHTMLAttributes<HTMLAnchorElement>,
+    'children' | 'href'
+  >;
+}
+
+export interface BreadcrumbProps
+  extends Omit<React.HTMLAttributes<HTMLElement>, 'children' | 'ref'> {
+  /**
+   * Ancestor breadcrumb items shown in the full desktop trail.
+   */
+  items: BreadcrumbItem[];
+  /**
+   * Optional final breadcrumb item.
+   * When provided, it is shown at the end of the desktop trail and used for
+   * the tablet/mobile back link.
+   */
+  current?: BreadcrumbItem;
+  /**
+   * Additional toolkit-style classes for the root element.
+   */
+  classes?: string;
+  /**
+   * Ref forwarding for the underlying nav element.
+   */
+  ref?: React.Ref<HTMLElement>;
+}
+
+const renderDesktopItem = (
+  item: BreadcrumbItem,
+  key: string,
+  showSeparator: boolean,
+) => {
+  const { className: itemAnchorClassName, ...itemAnchorProps } =
+    item.anchorProps ?? {};
+  const anchorClassName = joinClasses(
+    'ofh-breadcrumb__link',
+    itemAnchorClassName,
+  );
+  const content = item.href ? (
+    <a
+      className={anchorClassName}
+      href={item.href}
+      {...itemAnchorProps}
+    >
+      {item.text}
+    </a>
+  ) : (
+    <span className="ofh-breadcrumb__link">{item.text}</span>
+  );
+
+  return (
+    <li className="ofh-breadcrumb__item" key={key}>
+      {content}
+      {showSeparator ? (
+        <Icon
+          name="ChevronRight"
+          size={16}
+          className="ofh-breadcrumb__separator"
+        />
+      ) : null}
+    </li>
+  );
+};
+
+export const Breadcrumb = ({
+  items,
+  current,
+  classes = '',
+  className = '',
+  ref,
+  'aria-label': ariaLabel = 'Breadcrumb',
+  ...props
+}: BreadcrumbProps) => {
+  const visibleItems = items.filter((item) => item.text !== undefined && item.text !== null);
+  const mobileItem =
+    current?.href
+      ? current
+      : [...visibleItems].reverse().find((item) => item.href);
+  const rootClasses = joinClasses('ofh-breadcrumb', classes, className);
+  const { className: mobileAnchorClassName, ...mobileAnchorProps } =
+    mobileItem?.anchorProps ?? {};
+  const mobileBackLinkClassName = joinClasses(
+    'ofh-breadcrumb__backlink',
+    mobileAnchorClassName,
+  );
+
+  return (
+    <nav
+      {...props}
+      ref={ref}
+      className={rootClasses}
+      aria-label={ariaLabel}
+    >
+      <div className="ofh-width-container">
+        <ol className="ofh-breadcrumb__list">
+          {visibleItems.map((item, index) =>
+            renderDesktopItem(
+              item,
+              `ancestor-${index}`,
+              index < visibleItems.length - 1 || Boolean(current?.text),
+            ),
+          )}
+          {current?.text
+            ? renderDesktopItem(current, 'current', false)
+            : null}
+        </ol>
+        {mobileItem?.href && mobileItem.text ? (
+          <p className="ofh-breadcrumb__back">
+            <a
+              className={mobileBackLinkClassName}
+              href={mobileItem.href}
+              {...mobileAnchorProps}
+            >
+              <Icon
+                name="ChevronLeft"
+                size={16}
+                className="ofh-breadcrumb__back-icon"
+              />
+              {mobileItem.text}
+            </a>
+          </p>
+        ) : null}
+      </div>
+    </nav>
+  );
+};
+
+Breadcrumb.displayName = 'Breadcrumb';

--- a/packages/react-components/src/components/Breadcrumb/index.ts
+++ b/packages/react-components/src/components/Breadcrumb/index.ts
@@ -1,0 +1,2 @@
+export { Breadcrumb } from './Breadcrumb';
+export type { BreadcrumbItem, BreadcrumbProps } from './Breadcrumb';

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -126,3 +126,6 @@ export type {
   TableHeadCell,
   TableProps,
 } from './components/Table';
+
+export { Breadcrumb } from './components/Breadcrumb';
+export type { BreadcrumbItem, BreadcrumbProps } from './components/Breadcrumb';

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -66,3 +66,6 @@ export type { CardDoDontItem, CardDoDontProps } from './components/CardDoDont';
 
 export { Tag } from './components/Tag';
 export type { TagProps, TagVariant } from './components/Tag';
+
+export { Breadcrumb } from './components/Breadcrumb';
+export type { BreadcrumbItem, BreadcrumbProps } from './components/Breadcrumb';

--- a/packages/site/views/_includes/_side-nav.njk
+++ b/packages/site/views/_includes/_side-nav.njk
@@ -64,7 +64,7 @@
 ] %}
 
 {% set navigation = [
-  { title: "Breadcrumbs", url: "/design-system/components/breadcrumbs" },
+  { title: "Breadcrumb", url: "/design-system/components/breadcrumbs" },
   { title: "Contents list", url: "/design-system/components/contents-list" },
   { title: "Footer", url: "/design-system/components/footer" },
   { title: "Header", url: "/design-system/components/header" },

--- a/packages/site/views/_includes/_side-nav.njk
+++ b/packages/site/views/_includes/_side-nav.njk
@@ -66,7 +66,7 @@
 {% set navigation = [
   { title: "Action link", url: "/design-system/components/action-link" },
   { title: "Back link", url: "/design-system/components/back-link" },
-  { title: "Breadcrumbs", url: "/design-system/components/breadcrumbs" },
+  { title: "Breadcrumb", url: "/design-system/components/breadcrumbs" },
   { title: "Contents list", url: "/design-system/components/contents-list" },
   { title: "Footer", url: "/design-system/components/footer" },
   { title: "Header", url: "/design-system/components/header" },

--- a/packages/site/views/design-system/components/breadcrumbs/deep-trail/index.njk
+++ b/packages/site/views/design-system/components/breadcrumbs/deep-trail/index.njk
@@ -1,0 +1,28 @@
+{% from 'breadcrumb/macro.njk' import breadcrumb %}
+
+{{ breadcrumb({
+  items: [
+    {
+      href: "/health-a-to-z",
+      text: "Health A to Z"
+    },
+    {
+      href: "/health-a-to-z/conditions",
+      text: "Conditions"
+    },
+    {
+      href: "/health-a-to-z/conditions/skin-problems",
+      text: "Skin problems"
+    },
+    {
+      href: "/health-a-to-z/conditions/skin-problems/dry-skin",
+      text: "Dry skin"
+    },
+    {
+      href: "/health-a-to-z/conditions/skin-problems/dry-skin/treatments",
+      text: "Treatments"
+    }
+  ],
+  href: "/health-a-to-z/conditions/skin-problems/dry-skin/treatments/ointments",
+  text: "Ointments"
+}) }}

--- a/packages/site/views/design-system/components/breadcrumbs/index.njk
+++ b/packages/site/views/design-system/components/breadcrumbs/index.njk
@@ -1,9 +1,9 @@
-{% set pageTitle = "Breadcrumbs" %}
+{% set pageTitle = "Breadcrumb" %}
 {% set pageSection = "Design system" %}
 {% set subSection = "Components" %}
-{% set pageDescription = "Use breadcrumbs to help users understand where they are in the website." %}
+{% set pageDescription = "Use breadcrumb navigation to help users understand where they are in the website." %}
 {% set theme = "Navigation" %}
-{% set dateUpdated = "January 2019" %}
+{% set dateUpdated = "April 2026" %}
 {% set backlog_issue_id = "6" %}
 
 {% extends "app-layout.njk" %}
@@ -14,23 +14,45 @@
 
 {% block bodyContent %}
 
+  <p>Use breadcrumb navigation to show where a page sits in a wider content structure and help users move back up through related pages.</p>
+  <p>If you are working in React instead of Nunjucks, use the React <code>Breadcrumb</code> component in Storybook. This page is the toolkit/Nunjucks usage guide.</p>
+
+  <h2 id="default-breadcrumb">Default breadcrumb</h2>
+  <p>Use a short breadcrumb trail when users need to understand where they are in a content hierarchy and move back through parent pages.</p>
+
   {{ designExample({
     group: "components",
     item: "breadcrumbs",
     type: "default"
   }) }}
 
-  <h2>When to use breadcrumbs</h2>
-  <p>Use breadcrumbs to give users context and let them move back or up a level if they can't find what they want on the page.</p>
+  <h2 id="deep-breadcrumb-trail">Deep breadcrumb trail</h2>
+  <p>Longer breadcrumb trails can wrap across 2 lines on larger breakpoints. On tablet and mobile, the full trail collapses to a single back link so the component stays compact.</p>
 
-  <h2>When not to use breadcrumbs</h2>
+  {{ designExample({
+    group: "components",
+    item: "breadcrumbs",
+    type: "deep-trail"
+  }) }}
+
+  <h2 id="when-to-use-breadcrumbs">When to use breadcrumbs</h2>
+  <p>Use breadcrumb navigation to give users context and let them move back or up a level if they can't find what they want on the page.</p>
+
+  <h2 id="when-not-to-use-breadcrumbs">When not to use breadcrumbs</h2>
   <p>Don’t use breadcrumbs in transactional journeys as they can get in the way of the user completing the task.</p>
 
-  <h2>How to use breadcrumbs</h2>
-  <p>If the full breadcrumb trail doesn't fit the screen size, it can wrap onto 2 lines, but don't break a breadcrumb if it doesn't fit the line.</p>
-  <p>You don't need to show the current page in the breadcrumb because this information is in the H1.</p>
-  <p>On mobile, we replace the full breadcrumb trail with a "Back to [parent]" link.</p>
-  <p>Use these breadcrumbs on either white or OFH Brand Yellow (see Accessibility section below).</p>
+  <h2 id="how-breadcrumbs-work">How breadcrumbs work</h2>
+  <p>Use these options when configuring the breadcrumb macro:</p>
+  <ul>
+    <li><code>items</code>: the linked ancestor pages shown in the full desktop breadcrumb trail</li>
+    <li><code>text</code>: the final breadcrumb label, which is also used as the tablet/mobile back-link label when provided</li>
+    <li><code>href</code>: the final breadcrumb link destination, used with <code>text</code></li>
+    <li><code>classes</code>: extra classes added to the root breadcrumb element when you need layout-specific hooks</li>
+    <li><code>attributes</code>: extra HTML attributes added to the root breadcrumb element</li>
+  </ul>
+  <p>If the full breadcrumb trail does not fit the available width, it can wrap onto 2 lines on larger breakpoints. Keep each breadcrumb item on one line so the label and separator stay together.</p>
+  <p>On tablet and mobile, the full trail is replaced with a single back link showing just the label text, rather than the full trail.</p>
+  <p>Use this component on either white or OFH Brand Yellow backgrounds (see Accessibility section below).</p>
 
   <h3>Accessibility</h3>
   <p class="rich-text">We use <code>aria-label="breadcrumb"</code> as a label in the nav element to let people who use screen readers know what it is.</p>
@@ -43,6 +65,6 @@
   <p>They have not been tested or implemented on other colour backgrounds.</p>
 
   <h2>Research</h2>
-  <p>To see more about how breadcrumbs were researched and used by the NHS, <a href="https://designsystem.ourfuturehealth.org.uk/design-system/components/breadcrumbs">refer to their documentation on breadcrumbs.</a></p>
+  <p>To see more about how breadcrumb navigation was researched and used by the NHS, <a href="https://designsystem.ourfuturehealth.org.uk/design-system/components/breadcrumbs">refer to their documentation on breadcrumbs.</a></p>
 
 {% endblock %}

--- a/packages/site/views/design-system/components/breadcrumbs/index.njk
+++ b/packages/site/views/design-system/components/breadcrumbs/index.njk
@@ -55,7 +55,7 @@
   <p>Use this component on either white or OFH Brand Yellow backgrounds (see Accessibility section below).</p>
 
   <h3>Accessibility</h3>
-  <p class="rich-text">We use <code>aria-label="breadcrumb"</code> as a label in the nav element to let people who use screen readers know what it is.</p>
+  <p class="rich-text">We use <code>aria-label="Breadcrumb"</code> as a label in the nav element to let people who use screen readers know what it is.</p>
   <p class="rich-text">We add <code>aria-hidden="true"</code> to the svg <a href="/design-system/styles/icons">icons</a> to hide them from people who use screen readers.</p>
   <p>These breadcrumbs have been tested and pass accessibility on the following backgrounds:</p>
   <ul>

--- a/packages/site/views/design-system/components/breadcrumbs/macro-options.json
+++ b/packages/site/views/design-system/components/breadcrumbs/macro-options.json
@@ -4,19 +4,19 @@
 			"name": "items",
 			"type": "array",
 			"required": true,
-			"description": "Array of breadcrumbs item objects.",
+			"description": "Array of breadcrumb item objects shown in the full desktop trail.",
 			"params": [
 				{
 					"name": "text",
 					"type": "string",
 					"required": true,
-					"description": "Text to use within the breadcrumbs item."
+					"description": "Text to use within the breadcrumb item."
 				},
 				{
 					"name": "href",
 					"type": "string",
 					"required": false,
-					"description": "The value of the breadcrumb item link href attribute."
+					"description": "Link for the breadcrumb item. If omitted, the item is rendered as text only."
 				},
 				{
 					"name": "attributes",
@@ -29,20 +29,20 @@
     {
       "name": "text",
       "type": "string",
-      "required": true,
-      "description": "Text to use for the current page."
+      "required": false,
+      "description": "Text for the final breadcrumb item and the tablet/mobile back link label."
     },
     {
       "name": "href",
       "type": "string",
-      "required": true,
-      "description": "The value of the current page link href attribute."
+      "required": false,
+      "description": "Link for the final breadcrumb item and the tablet/mobile back link target."
     },
     {
       "name": "classes",
       "type": "string",
       "required": false,
-      "description": "Classes to add to the container."
+      "description": "Classes to add to the breadcrumb container."
     },
     {
       "name": "attributes",

--- a/packages/site/views/site-map.njk
+++ b/packages/site/views/site-map.njk
@@ -46,7 +46,7 @@
             <li><a href="/design-system/components/action-link">Action link</a></li>
             <li><a href="/design-system/components/auto-complete">Autocomplete</a></li>
             <li><a href="/design-system/components/back-link">Back link</a></li>
-            <li><a href="/design-system/components/breadcrumbs">Breadcrumbs</a></li>
+            <li><a href="/design-system/components/breadcrumbs">Breadcrumb</a></li>
             <li><a href="/design-system/components/button">Button</a></li>
             <li><a href="/design-system/components/card">Card</a></li>
             <li><a href="/design-system/components/card-callout">Card / Callout</a></li>

--- a/packages/site/views/site-map.njk
+++ b/packages/site/views/site-map.njk
@@ -45,7 +45,7 @@
           <ul class="ofh-u-nested-list">
             <li><a href="/design-system/components/link-action">Link action</a></li>
             <li><a href="/design-system/components/auto-complete">Autocomplete</a></li>
-            <li><a href="/design-system/components/breadcrumbs">Breadcrumbs</a></li>
+            <li><a href="/design-system/components/breadcrumbs">Breadcrumb</a></li>
             <li><a href="/design-system/components/button">Button</a></li>
             <li><a href="/design-system/components/card">Card</a></li>
             <li><a href="/design-system/components/card-callout">Card / Callout</a></li>

--- a/packages/toolkit/components/breadcrumb/README.md
+++ b/packages/toolkit/components/breadcrumb/README.md
@@ -21,7 +21,7 @@ Find out more about the breadcrumb component and when to use it in the [design s
       <li class="ofh-breadcrumb__item"><a class="ofh-breadcrumb__link" href="/level-one/level-two">Level two</a></li>
       <li class="ofh-breadcrumb__item"><a class="ofh-breadcrumb__link" href="/level-one/level-two/level-three">Level three</a></li>
     </ol>
-    <p class="ofh-breadcrumb__back"><a class="ofh-breadcrumb__backlink" href="/level-one/level-two/level-three">Back to Level three</a></p>
+    <p class="ofh-breadcrumb__back"><a class="ofh-breadcrumb__backlink" href="/level-one/level-two/level-three">Level three</a></p>
   </div>
 </nav>
 ```
@@ -53,13 +53,13 @@ The breadcrumb Nunjucks macro takes the following arguments:
 
 | Name                | Type     | Required  | Description  |
 | --------------------|----------|-----------|--------------|
-| items               | array    | Yes       | Array of breadcrumbs item objects. |
-| items[].text       | string   | Yes       | Text to use within the breadcrumbs item. |
-| items[].href	      | string   | Yes       | Link for the breadcrumbs item. |
-| items[].attributes	| object   | No        | Any extra HTML attributes (for example data attributes) to add to the breadcrumb anchor item. |
-| href                | string   | Yes       | Link of the current page  |
-| text                | string   | Yes       | Text for the current page |
-| classes             | string   | No        | Optional additional classes to add to the breadcrumbs container. Separate each class with a space. |
-| attributes          | object   | No        | Any extra HTML attributes (for example data attributes) to add to the breadcrumbs container. |
+| items               | array    | Yes       | Array of breadcrumb item objects shown in the full desktop trail. |
+| items[].text        | string   | Yes       | Text to use within the breadcrumb item. |
+| items[].href        | string   | No        | Link for the breadcrumb item. If omitted, the item is rendered as text only. |
+| items[].attributes  | object   | No        | Any extra HTML attributes (for example data attributes) to add to the breadcrumb anchor item. |
+| href                | string   | No        | Link for the final breadcrumb item and the tablet/mobile back link target. |
+| text                | string   | No        | Text for the final breadcrumb item and the tablet/mobile back link label. |
+| classes             | string   | No        | Optional additional classes to add to the breadcrumb container. Separate each class with a space. |
+| attributes          | object   | No        | Any extra HTML attributes (for example data attributes) to add to the breadcrumb container. |
 
 If you are using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `html` can be a [security risk](https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting). Read more about this in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).

--- a/packages/toolkit/components/breadcrumb/_breadcrumb.scss
+++ b/packages/toolkit/components/breadcrumb/_breadcrumb.scss
@@ -17,16 +17,16 @@
   padding-top: $ofh-size-12;
 
   .ofh-breadcrumb__separator {
-    color: $ofh-color-greyscale-2;
-    fill: $ofh-color-greyscale-2;
+    color: $ofh-color-foreground-breadcrumb-default;
+    fill: $ofh-color-foreground-breadcrumb-default;
     flex: 0 0 auto;
     height: $ofh-size-16;
     width: $ofh-size-16;
   }
 
   .ofh-breadcrumb__back-icon {
-    color: $ofh-color-greyscale-2;
-    fill: $ofh-color-greyscale-2;
+    color: $ofh-color-foreground-breadcrumb-default;
+    fill: $ofh-color-foreground-breadcrumb-default;
     flex: 0 0 auto;
     height: $ofh-size-16;
     width: $ofh-size-16;

--- a/packages/toolkit/components/breadcrumb/_breadcrumb.scss
+++ b/packages/toolkit/components/breadcrumb/_breadcrumb.scss
@@ -3,73 +3,63 @@
    ========================================================================== */
 
 /**
- * 1. Bespoke spacing numbers used as there is no 12px
- *    spacing mapped in settings/spacing.
- * 2. Hide the breadcrumb on print stylesheets.
- * 3. Don't show the full breadcrumb below tablet size.
- * 4. Typography sizing mixin, see core/tools/_typography
- * 5. and core/settings/_typography for size maps.
- * 5. .. but show a back to index page link.
- * 6. Remove spacing between back icon and label.
- * 7. Custom padding for the chevron separator icon.
+ * 1. Hide the breadcrumb on print stylesheets.
+ * 2. Don't show the full breadcrumb below tablet size.
+ * 3. Typography sizing mixin, see core/tools/_typography
+ * 4. and core/settings/_typography for size maps.
+ * 5. .. but show a single back link.
  */
 
 .ofh-breadcrumb {
   @include print-hide();
 
-  padding-bottom: 12px; /* [1] */
-  padding-top: 12px; /* [1] */
+  padding-bottom: $ofh-size-12;
+  padding-top: $ofh-size-12;
 
   .ofh-breadcrumb__separator {
+    color: $ofh-color-greyscale-2;
     fill: $ofh-color-greyscale-2;
-    height: 24px;
-    position: relative;
-    top: 1px;
-    width: 24px;
-
-    @include mq($from: large-desktop) {
-      margin: 0 3px 0 5px;
-    }
+    flex: 0 0 auto;
+    height: $ofh-size-16;
+    width: $ofh-size-16;
   }
 
   .ofh-breadcrumb__back-icon {
-    height: 24px;
-    left: -2px;
-    margin-right: 2px;
-    position: relative;
-    top: -1px;
-    vertical-align: middle;
-    width: 24px;
+    color: $ofh-color-greyscale-2;
+    fill: $ofh-color-greyscale-2;
+    flex: 0 0 auto;
+    height: $ofh-size-16;
+    width: $ofh-size-16;
   }
 }
 
 .ofh-breadcrumb__list {
-  @include mq($until: tablet) {
-    display: none; /* [3] */
-  }
-
+  align-items: center;
+  column-gap: $ofh-size-8;
+  display: flex;
+  flex-wrap: wrap;
   list-style: none;
   margin: 0;
   padding: 0;
+
+  @include mq($until: tablet) {
+    display: none; /* [2] */
+  }
 }
 
 .ofh-breadcrumb__item {
-  @include ofh-font('paragraph-sm'); /* [4] */
+  @include ofh-font('paragraph-sm'); /* [3] */
 
-  display: inline-block;
+  align-items: center;
+  column-gap: $ofh-size-8;
+  display: flex;
   margin-bottom: 0;
-
-  .ofh-breadcrumb__separator {
-    color: $ofh-color-greyscale-2;
-    display: inline-block;
-    margin-left: 10px;
-    margin-right: 2px;
-    vertical-align: middle;
-  }
+  white-space: nowrap;
 }
 
 .ofh-breadcrumb__link {
   color: $ofh-color-foreground-breadcrumb-default;
+  white-space: nowrap;
 
   &:visited {
     color: $ofh-color-foreground-breadcrumb-visited;
@@ -91,11 +81,9 @@
 }
 
 .ofh-breadcrumb__back {
-  @include ofh-font('paragraph-sm'); /* [4] */
+  @include ofh-font('paragraph-sm'); /* [3] */
 
   margin: 0;
-  padding-left: 0;
-  position: relative;
 
   @include mq($from: tablet) {
     display: none; /* [5] */
@@ -103,7 +91,11 @@
 }
 
 .ofh-breadcrumb__backlink {
+  align-items: center;
   color: $ofh-color-foreground-breadcrumb-default;
+  column-gap: $ofh-size-8;
+  display: inline-flex;
+  white-space: nowrap;
 
   &:visited {
     color: $ofh-color-foreground-breadcrumb-visited;

--- a/packages/toolkit/components/breadcrumb/template.njk
+++ b/packages/toolkit/components/breadcrumb/template.njk
@@ -4,7 +4,11 @@
 {% if params.href and params.text %}
   {% set mobileItem = { "href": params.href, "text": params.text } %}
 {% elif params.items and params.items.length %}
-  {% set mobileItem = params.items[params.items.length - 1] %}
+  {% for item in params.items | reverse %}
+    {% if not mobileItem and item.href and item.text %}
+      {% set mobileItem = item %}
+    {% endif %}
+  {% endfor %}
 {% endif %}
 
 <nav class="ofh-breadcrumb{% if params.classes %} {{ params.classes }}{% endif %}" aria-label="Breadcrumb"

--- a/packages/toolkit/components/breadcrumb/template.njk
+++ b/packages/toolkit/components/breadcrumb/template.njk
@@ -1,23 +1,34 @@
 {% from '../icon/macro.njk' import icon %}
 
+{% set mobileItem = null %}
+{% if params.href and params.text %}
+  {% set mobileItem = { "href": params.href, "text": params.text } %}
+{% elif params.items and params.items.length %}
+  {% set mobileItem = params.items[params.items.length - 1] %}
+{% endif %}
+
 <nav class="ofh-breadcrumb{% if params.classes %} {{ params.classes }}{% endif %}" aria-label="Breadcrumb"
 {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   <div class="ofh-width-container">
     <ol class="ofh-breadcrumb__list">
   {%- for item in params.items %}
-    {%- if item.href %}
+    {%- if item.text %}
       <li class="ofh-breadcrumb__item">
-        <a class="ofh-breadcrumb__link" href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ item.text }}</a>
-        {% if not loop.last or params.href %}{{ icon({ "name": "ChevronRight", "size": 24, "classes": "ofh-breadcrumb__separator" }) }}{% endif %}
+        {% if item.href %}
+          <a class="ofh-breadcrumb__link" href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ item.text }}</a>
+        {% else %}
+          <span class="ofh-breadcrumb__link">{{ item.text }}</span>
+        {% endif %}
+        {% if not loop.last or (params.href and params.text) %}{{ icon({ "name": "ChevronRight", "size": 16, "classes": "ofh-breadcrumb__separator" }) }}{% endif %}
       </li>
     {%- endif -%}
   {% endfor %}
       {%- if params.href and params.text %}
-      <li class="ofh-breadcrumb__item"><a class="ofh-breadcrumb__link" href="{{ params.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ params.text}}</a></li>
+      <li class="ofh-breadcrumb__item"><a class="ofh-breadcrumb__link" href="{{ params.href }}">{{ params.text}}</a></li>
       {%- endif %}
     </ol>
-    {%- if params.href and params.text %}
-    <p class="ofh-breadcrumb__back"><a class="ofh-breadcrumb__backlink" href="{{ params.href }}">{{ icon({ "name": "ChevronLeft", "size": 24, "classes": "ofh-breadcrumb__back-icon" }) }}Back to {{ params.text }}</a></p>
+    {%- if mobileItem and mobileItem.href and mobileItem.text %}
+    <p class="ofh-breadcrumb__back"><a class="ofh-breadcrumb__backlink" href="{{ mobileItem.href }}"{% for attribute, value in mobileItem.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ icon({ "name": "ChevronLeft", "size": 16, "classes": "ofh-breadcrumb__back-icon" }) }}{{ mobileItem.text }}</a></p>
     {%- endif %}
   </div>
 </nav>

--- a/packages/toolkit/core/settings/_tokens-static.scss
+++ b/packages/toolkit/core/settings/_tokens-static.scss
@@ -145,10 +145,10 @@ $ofh-color-foreground-link-visited-inverted: $ofh-color-feedback-interactive-5;
 $ofh-color-foreground-link-active-inverted: $ofh-color-greyscale-5;
 
 // Breadcrumb foreground colors
-$ofh-color-foreground-breadcrumb-default: $ofh-color-brand-blue-navy-3-main;
-$ofh-color-foreground-breadcrumb-hover: $ofh-color-feedback-info-1;
-$ofh-color-foreground-breadcrumb-visited: $ofh-color-feedback-interactive-1;
-$ofh-color-foreground-breadcrumb-active: $ofh-color-feedback-info-2-main;
+$ofh-color-foreground-breadcrumb-default: $ofh-color-feedback-interactive-3-main;
+$ofh-color-foreground-breadcrumb-hover: $ofh-color-feedback-interactive-2;
+$ofh-color-foreground-breadcrumb-visited: $ofh-color-feedback-interactive-3-main;
+$ofh-color-foreground-breadcrumb-active: $ofh-color-feedback-interactive-2;
 
 // Semantic Colors - Border
 // ==========================================================================

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/toolkit",
-  "version": "4.9.0",
+  "version": "4.19.0",
   "description": "Our Future Health design system toolkit contains the code you need to start building user interfaces for Our Future Health websites and services.",
   "repository": {
     "type": "git",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/toolkit",
-  "version": "4.18.0",
+  "version": "4.19.0",
   "description": "Our Future Health design system toolkit contains the code you need to start building user interfaces for Our Future Health websites and services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
This PR delivers **DSE-428 breadcrumb refresh** across toolkit, React, the docs site, and Storybook.

It audits the existing toolkit breadcrumb implementation against the current Figma component, aligns the desktop and mobile behaviour more closely with the design, introduces the public React `Breadcrumb` component, and updates the docs site and Storybook to teach the component more clearly.

Ticket: DSE-428

## Release scope
- `@ourfuturehealth/toolkit` -> `4.19.0`
- `@ourfuturehealth/react-components` -> `0.18.0`
- updates release metadata in `CHANGELOG.md`, `UPGRADING.md`, `docs/release-versioning-strategy.md`, `docs/consuming-react-components.md`, and `packages/react-components/README.md`

## Breaking Changes
- None.

## Key Changes
- refines the toolkit breadcrumb to match the current Figma component more closely, including smaller cleaner chevrons and the mobile/tablet collapsed back-link behaviour
- removes the old `Back to ...` prefix from the collapsed mobile/tablet breadcrumb so the back link now follows the Figma wording
- adds a `Deep breadcrumb trail` docs-site example and refreshes the toolkit docs page to explain the component and macro options more clearly
- updates docs-site labels from `Breadcrumbs` to `Breadcrumb` while keeping the existing route structure
- adds the public React `Breadcrumb` component and exports it from the React package
- keeps the React API idiomatic for this library, with structured `items` / `current` data and anchor-prop passthrough where needed
- adds unit and accessibility coverage for the new React component
- updates Storybook so `Breadcrumb` follows the newer `Docs` / `Default` / `Builder` / showcase teaching pattern

## Validation
- `npm test`
- `pnpm lint`
- `pnpm --filter=@ourfuturehealth/react-components build:storybook`
- `pnpm --filter=site build:eleventy`
- `pnpm build`
- `pnpm docs:release-contract`
- `pnpm smoke:release-artifacts`
- manual QA against current/main and branch toolkit breadcrumb routes
- manual QA on the new React Storybook docs, Builder, and showcase stories

## Reviewer Focus
- mobile/tablet breadcrumb collapse should now match the Figma wording and behaviour more closely
- toolkit docs site and React Storybook should now teach the same breadcrumb patterns more clearly
- the new React `Breadcrumb` API should feel straightforward to adopt
- release metadata should line up on `toolkit-v4.19.0` / `react-v0.18.0`
