### PR TITLE
DSE-423 :: Contents List FE update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ## Monorepo Package Releases (`toolkit-v*`, `react-v*`)
 
+### 2026-04-17
+
+#### @ourfuturehealth/toolkit 4.20.0 (`toolkit-v4.20.0`)
+
+##### Changed
+
+- Refreshed the toolkit `contents-list` spacing, marker treatment, and typography to match the current Figma component more closely
+- Rewrote the toolkit `contents-list` docs page to better explain usage, macro options, and the React parity surface
+- Expanded toolkit docs-site coverage for `contents-list` with `Current page in the middle` and `Contents list with all links` examples
+- Updated the toolkit `contents-list` README and macro options to match the current component behavior more accurately
+
+#### @ourfuturehealth/react-components 0.19.0 (`react-v0.19.0`)
+
+##### Added
+
+- First public React release of `ContentsList`
+
+##### Changed
+
+- Added Storybook docs, builder, and showcase coverage for the new React `ContentsList` component
+- Added unit and accessibility coverage for the React `ContentsList` component
+
 ### 2026-04-09
 
 #### @ourfuturehealth/toolkit 4.10.0 (`toolkit-v4.10.0`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ### 2026-04-30
 
+#### @ourfuturehealth/toolkit 4.20.0 (`toolkit-v4.20.0`)
+
+##### Changed
+
+- Refreshed the toolkit `contents-list` spacing, marker treatment, and typography to match the current Figma component more closely
+- Rewrote the toolkit `contents-list` docs page to better explain usage, macro options, and the React parity surface
+- Expanded toolkit docs-site coverage for `contents-list` with `Current page in the middle` and `Contents list with all links` examples
+- Updated the toolkit `contents-list` README and macro options to match the current component behavior more accurately
+
+#### @ourfuturehealth/react-components 0.19.0 (`react-v0.19.0`)
+
+##### Added
+
+- First public React release of `ContentsList`
+
+##### Changed
+
+- Added Storybook docs, builder, and showcase coverage for the new React `ContentsList` component
+- Added unit and accessibility coverage for the React `ContentsList` component
+
 #### @ourfuturehealth/toolkit 4.19.0 (`toolkit-v4.19.0`)
 
 ##### Added

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,6 +8,7 @@ This guide provides detailed migration instructions for upgrading between versio
 
 | Version                                                 | Date          | Breaking Changes           | Migration Complexity                     |
 | ------------------------------------------------------- | ------------- | -------------------------- | ---------------------------------------- |
+| [v4.20.0 / React v0.19.0](#upgrading-to-v4200--react-v0190) | April 2026    | No breaking changes        | 🟢 Low - adopt the new React `ContentsList` where needed |
 | [v4.10.0 / React v0.9.0](#upgrading-to-v4100--react-v090) | April 2026    | React `spritePath` removal | 🟢 Low - Remove the deprecated prop and adopt canonical names for new usage |
 | [v4.9.0 / React v0.7.0](#upgrading-to-v490--react-v070) | April 2026    | Icon naming sync           | 🟡 Medium - Search/replace icon names    |
 | [v4.8.0 / React v0.6.0](#upgrading-to-v480--react-v060) | March 2026    | No breaking changes        | 🟢 Low - only relevant if you adopted the earlier TextInput prototype |
@@ -19,6 +20,47 @@ This guide provides detailed migration instructions for upgrading between versio
 | [v4.0.0](#upgrading-to-v400-monorepo-restructure)       | 2025          | Monorepo restructure       | 🔴 High - Installation & paths change    |
 
 ---
+
+## Upgrading to v4.20.0 / React v0.19.0
+
+**Planned:** April 2026
+**Affected packages:**
+
+- `@ourfuturehealth/toolkit` v4.20.0+
+- `@ourfuturehealth/react-components` v0.19.0+
+
+### Breaking Changes
+
+There are no breaking changes in this release.
+
+### Release Overview
+
+This release refreshes the toolkit `contents-list` component to the current Figma spacing, marker, and typography treatment, and introduces the first public React `ContentsList` component.
+
+- Toolkit consumers get clearer docs and example coverage for different current-page arrangements.
+- React consumers can now adopt `ContentsList` directly instead of building bespoke navigation lists.
+- Storybook and the toolkit docs page now teach the same pattern family more clearly.
+
+### Migration Steps
+
+1. If you use toolkit `contents-list`, recheck spacing and marker rendering against your current layouts.
+2. If you want React parity, adopt the new public `ContentsList` component.
+3. Re-run visual QA for pages that use contents lists, especially where the current page sits in the middle of the list.
+
+#### React example
+
+**New in `react-v0.19.0`:**
+
+```tsx
+import { ContentsList } from '@ourfuturehealth/react-components';
+
+const items = [
+  { text: 'What is AMD?', current: true },
+  { text: 'Symptoms', href: '/conditions/amd/symptoms' },
+];
+
+<ContentsList items={items} />;
+```
 
 ## Upgrading to v4.10.0 / React v0.9.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,6 +8,7 @@ This guide provides detailed migration instructions for upgrading between versio
 
 | Version                                                 | Date          | Breaking Changes           | Migration Complexity                     |
 | ------------------------------------------------------- | ------------- | -------------------------- | ---------------------------------------- |
+| [v4.20.0 / React v0.19.0](#upgrading-to-v4200--react-v0190) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React ContentsList if needed and use the refreshed toolkit contents-list APIs when relevant |
 | [v4.19.0 / React v0.18.0](#upgrading-to-v4190--react-v0180) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React Breadcrumb if needed and use the refreshed toolkit breadcrumb APIs when relevant |
 | [v4.18.0 / React v0.17.0](#upgrading-to-v4180--react-v0170) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React Table if needed and use the refreshed toolkit table APIs when relevant |
 | [v4.17.0 / React v0.16.0](#upgrading-to-v4170--react-v0160) | April 2026    | No breaking changes        | 🟢 Low - adopt the public React Image if needed and use the refreshed toolkit image APIs when relevant |
@@ -27,6 +28,49 @@ This guide provides detailed migration instructions for upgrading between versio
 | [v4.3.0 / React v0.2.0](#upgrading-to-v430--react-v020) | March 2026    | Button variant naming      | 🟡 Medium - Find/replace required        |
 | [v4.1.0](#upgrading-to-v410)                            | February 2026 | Spacing scale indices      | 🟡 Medium - Index updates required       |
 | [v4.0.0](#upgrading-to-v400-monorepo-restructure)       | 2025          | Monorepo restructure       | 🔴 High - Installation & paths change    |
+
+---
+
+## Upgrading to v4.20.0 / React v0.19.0
+
+**Released:** April 2026
+**Affected packages:**
+
+- `@ourfuturehealth/toolkit` v4.20.0+
+- `@ourfuturehealth/react-components` v0.19.0+
+
+### Breaking Changes
+
+None.
+
+### Release Overview
+
+This release refreshes the toolkit `contents-list` component to the current design-system treatment and introduces the first public React `ContentsList` component.
+
+- Toolkit consumers should review the refreshed contents-list spacing, marker treatment, and typography, especially where local overrides depend on the older styling.
+- Toolkit docs now show explicit default, current-in-middle, and all-links examples.
+- React consumers can now adopt the public `ContentsList` component when they need toolkit-parity navigation lists for small groups of related content pages.
+
+### Migration Steps
+
+1. Adopt the public React `ContentsList` component where you need toolkit-parity content navigation in React.
+2. Prefer the refreshed toolkit contents-list API, docs examples, and canonical usage when touching existing Nunjucks templates.
+3. Re-run visual QA if you have local contents-list overrides, especially around marker contrast, spacing, and current-item placement.
+
+#### React example
+
+**New in `react-v0.19.0`:**
+
+```tsx
+import { ContentsList } from '@ourfuturehealth/react-components';
+
+const items = [
+  { text: 'What is AMD?', current: true },
+  { text: 'Symptoms', href: '/conditions/amd/symptoms' },
+];
+
+<ContentsList items={items} />;
+```
 
 ---
 ## Upgrading to v4.19.0 / React v0.18.0

--- a/docs/consuming-react-components.md
+++ b/docs/consuming-react-components.md
@@ -57,37 +57,17 @@ Import components and styles in your React application:
 
 ```tsx
 import React from 'react';
-import { Breadcrumb, Button, Table, TextInput } from '@ourfuturehealth/react-components';
+import { Button, ContentsList, TextInput } from '@ourfuturehealth/react-components';
 import '@ourfuturehealth/react-components/styles/participant';
 
 function App() {
-  const breadcrumbItems = [
-    { text: 'Health A to Z', href: '/health-a-to-z' },
-    { text: 'Conditions', href: '/health-a-to-z/conditions' },
-  ];
-  const symptomsHead = [
-    { content: 'Symptom' },
-    { content: 'Self-care' },
-  ];
-  const symptomsRows = [
-    [
-      { content: 'Dry eyes' },
-      { content: 'Use artificial tears' },
-    ],
-    [
-      { content: 'Headache' },
-      { content: 'Rest and keep hydrated' },
-    ],
-  ];
-
   return (
     <div>
-      <Breadcrumb
-        items={breadcrumbItems}
-        current={{
-          text: 'Eczema',
-          href: '/health-a-to-z/conditions/eczema',
-        }}
+      <ContentsList
+        items={[
+          { text: 'What is AMD?', current: true },
+          { text: 'Symptoms', href: '/conditions/amd/symptoms' },
+        ]}
       />
       <TextInput
         id="name"
@@ -96,7 +76,6 @@ function App() {
         inputWidth={20}
         onChange={(e) => console.log(e.target.value)}
       />
-      <Table caption="Symptoms and self-care" head={symptomsHead} rows={symptomsRows} />
       <Button onClick={() => console.log('Clicked')}>Submit</Button>
     </div>
   );
@@ -170,6 +149,7 @@ The React components package currently provides the following components:
 - `Card` - Content presentation cards for summaries, status, and next steps
 - `CardCallout` - Feedback-style callout cards for informational, warning, success, and error messages
 - `CardDoDont` - Positive and negative recommendation lists
+- `ContentsList` - Navigation lists for small groups of related content pages
 - `Pagination` - Previous/next page navigation for a small related sequence
 
 For complete component documentation and live examples, run Storybook locally from this repository:

--- a/docs/consuming-react-components.md
+++ b/docs/consuming-react-components.md
@@ -57,12 +57,18 @@ Import components and styles in your React application:
 
 ```tsx
 import React from 'react';
-import { Button, TextInput } from '@ourfuturehealth/react-components';
+import { Button, ContentsList, TextInput } from '@ourfuturehealth/react-components';
 import '@ourfuturehealth/react-components/styles/participant';
 
 function App() {
   return (
     <div>
+      <ContentsList
+        items={[
+          { text: 'What is AMD?', current: true },
+          { text: 'Symptoms', href: '/conditions/amd/symptoms' },
+        ]}
+      />
       <TextInput
         id="name"
         label="Your name"
@@ -136,6 +142,7 @@ The React components package currently provides the following components:
 - `Card` - Content presentation cards for summaries, status, and next steps
 - `CardCallout` - Feedback-style callout cards for informational, warning, success, and error messages
 - `CardDoDont` - Positive and negative recommendation lists
+- `ContentsList` - Navigation lists for small groups of related content pages
 
 For complete component documentation and live examples, run Storybook locally from this repository:
 

--- a/docs/release-versioning-strategy.md
+++ b/docs/release-versioning-strategy.md
@@ -31,8 +31,8 @@ For consumer migration instructions, use [Upgrading Guide](../UPGRADING.md).
 
 | Package                             | Canonical tag pattern | Example tag      |
 | ----------------------------------- | --------------------- | ---------------- |
-| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.19.0` |
-| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.18.0`   |
+| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.20.0` |
+| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.19.0`   |
 
 The release workflow still accepts legacy toolkit tags in the `v*` format for backward compatibility, but new toolkit releases should use `toolkit-v*`.
 

--- a/docs/release-versioning-strategy.md
+++ b/docs/release-versioning-strategy.md
@@ -31,8 +31,8 @@ For consumer migration instructions, use [Upgrading Guide](../UPGRADING.md).
 
 | Package                             | Canonical tag pattern | Example tag      |
 | ----------------------------------- | --------------------- | ---------------- |
-| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.10.0` |
-| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.9.0`   |
+| `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.20.0` |
+| `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.19.0`   |
 
 The release workflow still accepts legacy toolkit tags in the `v*` format for backward compatibility, but new toolkit releases should use `toolkit-v*`.
 
@@ -60,7 +60,7 @@ Consumers must install the package release tarball:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/toolkit": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/toolkit-v4.10.0/ourfuturehealth-toolkit-4.10.0.tgz"
+    "@ourfuturehealth/toolkit": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/toolkit-v4.20.0/ourfuturehealth-toolkit-4.20.0.tgz"
   }
 }
 ```
@@ -70,7 +70,7 @@ React consumers follow the same contract:
 ```json
 {
   "dependencies": {
-    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.9.0/ourfuturehealth-react-components-0.9.0.tgz"
+    "@ourfuturehealth/react-components": "https://github.com/ourfuturehealth/design-system-toolkit/releases/download/react-v0.19.0/ourfuturehealth-react-components-0.19.0.tgz"
   }
 }
 ```
@@ -128,8 +128,10 @@ This table is a visual aid for pre-monorepo versus post-monorepo releases.
 | 19    | `react-v0.6.0`   | N/A             | `0.6.0`       | Monorepo       | Released               |
 | 20    | `toolkit-v4.9.0` | `4.9.0`         | N/A           | Monorepo       | Released               |
 | 21    | `react-v0.7.0`   | N/A             | `0.7.0`       | Monorepo       | Released               |
-| 22    | `toolkit-v4.10.0` | `4.10.0`       | N/A           | Monorepo       | Planned in this branch |
-| 23    | `react-v0.9.0`   | N/A             | `0.9.0`       | Monorepo       | Planned in this branch |
+| 22    | `toolkit-v4.10.0` | `4.10.0`       | N/A           | Monorepo       | Released               |
+| 23    | `react-v0.9.0`   | N/A             | `0.9.0`       | Monorepo       | Released               |
+| 24    | `toolkit-v4.20.0` | `4.20.0`       | N/A           | Monorepo       | Planned in this branch |
+| 25    | `react-v0.19.0`  | N/A             | `0.19.0`      | Monorepo       | Planned in this branch |
 
 ## References
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -161,11 +161,11 @@ function App() {
         ]}
       />
       <Button variant="contained">Click me</Button>
-      <Pagination
-        previousUrl="/section/treatments"
-        previousPage="Treatments"
-        nextUrl="/section/symptoms"
-        nextPage="Symptoms"
+      <ContentsList
+        items={[
+          { text: 'What is AMD?', current: true },
+          { text: 'Symptoms', href: '/conditions/amd/symptoms' },
+        ]}
       />
       <Icon name="Search" size={24} />
       <LinkAction href="/services/minor-injuries">Find a minor injuries unit</LinkAction>
@@ -296,6 +296,7 @@ The package also provides:
 - `Radios`
 - `TaskList`
 - `Icon`
+- `ContentsList`
 - `Pagination`
 - `SummaryList`
 - `Table`

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -48,6 +48,7 @@ import {
   CardDoDont,
   CharacterCount,
   Checkboxes,
+  ContentsList,
   DateInput,
   ErrorSummary,
   Fieldset,
@@ -89,6 +90,12 @@ function App() {
       />
       <Tag variant="brand">Beta</Tag>
       <Button variant="contained">Click me</Button>
+      <ContentsList
+        items={[
+          { text: 'What is AMD?', current: true },
+          { text: 'Symptoms', href: '/conditions/amd/symptoms' },
+        ]}
+      />
       <Icon name="Search" size={24} />
       <LinkAction href="/services/minor-injuries">Find a minor injuries unit</LinkAction>
       <LinkIcon href="/previous-step">Go back</LinkIcon>
@@ -195,6 +202,7 @@ The package also provides:
 - `Checkboxes`
 - `Radios`
 - `Icon`
+- `ContentsList`
 
 ### ErrorSummary
 

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/react-components",
-  "version": "0.9.0",
+  "version": "0.19.0",
   "type": "module",
   "description": "React component library for OFH Design System",
   "packageManager": "pnpm@10.29.2",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/react-components",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "type": "module",
   "description": "React component library for OFH Design System",
   "packageManager": "pnpm@10.29.2",

--- a/packages/react-components/src/components/ContentsList/ContentsList.stories.tsx
+++ b/packages/react-components/src/components/ContentsList/ContentsList.stories.tsx
@@ -1,0 +1,378 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ArgTypes, Source, Stories, Title } from '@storybook/addon-docs/blocks';
+import { ContentsList, type ContentsListItem, type ContentsListProps } from './ContentsList';
+
+type ContentsListCurrentItem =
+  | 'what-is-amd'
+  | 'symptoms'
+  | 'getting-diagnosed'
+  | 'treatments'
+  | 'living-with-amd';
+
+type ContentsListStoryArgs = ContentsListProps & {
+  showCurrent?: boolean;
+  currentItem?: ContentsListCurrentItem;
+};
+
+const baseItems: Array<{ id: ContentsListCurrentItem; text: string; href: string }> = [
+  {
+    id: 'what-is-amd',
+    text: 'What is AMD?',
+    href: '/conditions/amd',
+  },
+  {
+    id: 'symptoms',
+    text: 'Symptoms',
+    href: '/conditions/amd/symptoms',
+  },
+  {
+    id: 'getting-diagnosed',
+    text: 'Getting diagnosed',
+    href: '/conditions/amd/getting-diagnosed',
+  },
+  {
+    id: 'treatments',
+    text: 'Treatments',
+    href: '/conditions/amd/treatments',
+  },
+  {
+    id: 'living-with-amd',
+    text: 'Living with AMD',
+    href: '/conditions/amd/living-with-amd',
+  },
+];
+
+const currentItemLabels: Record<ContentsListCurrentItem, string> = {
+  'what-is-amd': 'What is AMD?',
+  symptoms: 'Symptoms',
+  'getting-diagnosed': 'Getting diagnosed',
+  treatments: 'Treatments',
+  'living-with-amd': 'Living with AMD',
+};
+
+const buildItems = ({
+  showCurrent = true,
+  currentItem = 'what-is-amd',
+}: Pick<ContentsListStoryArgs, 'showCurrent' | 'currentItem'>): ContentsListItem[] =>
+  baseItems.map((item) =>
+    showCurrent && item.id === currentItem
+      ? {
+          text: item.text,
+          current: true,
+        }
+      : {
+          text: item.text,
+          href: item.href,
+        },
+  );
+
+const usageExample = `import { ContentsList } from '@ourfuturehealth/react-components';
+
+const items = [
+  {
+    text: 'What is AMD?',
+    current: true,
+  },
+  {
+    text: 'Symptoms',
+    href: '/conditions/amd/symptoms',
+  },
+  {
+    text: 'Getting diagnosed',
+    href: '/conditions/amd/getting-diagnosed',
+  },
+];
+
+<ContentsList items={items} />;
+`;
+
+const itemsShapeExample = `type ContentsListItem = {
+  text: React.ReactNode;
+  href?: string;
+  current?: boolean;
+  anchorProps?: Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'children' | 'href'>;
+};
+`;
+
+const defaultSource = `import { ContentsList } from '@ourfuturehealth/react-components';
+
+const items = [
+  {
+    text: 'What is AMD?',
+    current: true,
+  },
+  {
+    text: 'Symptoms',
+    href: '/conditions/amd/symptoms',
+  },
+  {
+    text: 'Getting diagnosed',
+    href: '/conditions/amd/getting-diagnosed',
+  },
+  {
+    text: 'Treatments',
+    href: '/conditions/amd/treatments',
+  },
+  {
+    text: 'Living with AMD',
+    href: '/conditions/amd/living-with-amd',
+  },
+];
+
+<ContentsList items={items} />;
+`;
+
+const currentInMiddleSource = `import { ContentsList } from '@ourfuturehealth/react-components';
+
+const items = [
+  {
+    text: 'What is AMD?',
+    href: '/conditions/amd',
+  },
+  {
+    text: 'Symptoms',
+    href: '/conditions/amd/symptoms',
+  },
+  {
+    text: 'Getting diagnosed',
+    current: true,
+  },
+  {
+    text: 'Treatments',
+    href: '/conditions/amd/treatments',
+  },
+  {
+    text: 'Living with AMD',
+    href: '/conditions/amd/living-with-amd',
+  },
+];
+
+<ContentsList items={items} />;
+`;
+
+const allLinksSource = `import { ContentsList } from '@ourfuturehealth/react-components';
+
+const items = [
+  {
+    text: 'What is AMD?',
+    href: '/conditions/amd',
+  },
+  {
+    text: 'Symptoms',
+    href: '/conditions/amd/symptoms',
+  },
+  {
+    text: 'Getting diagnosed',
+    href: '/conditions/amd/getting-diagnosed',
+  },
+  {
+    text: 'Treatments',
+    href: '/conditions/amd/treatments',
+  },
+  {
+    text: 'Living with AMD',
+    href: '/conditions/amd/living-with-amd',
+  },
+];
+
+<ContentsList items={items} />;
+`;
+
+const renderContentsList = ({
+  showCurrent = true,
+  currentItem = 'what-is-amd',
+  items,
+  ...props
+}: ContentsListStoryArgs) => (
+  <ContentsList
+    {...props}
+    items={items ?? buildItems({ showCurrent, currentItem })}
+  />
+);
+
+const meta: Meta<ContentsListStoryArgs> = {
+  title: 'Components/Contents List',
+  component: ContentsList,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      page: () => (
+        <>
+          <Title />
+          <p>
+            Use ContentsList to show a short list of related pages near the top
+            of a guide or information hub. It matches the toolkit markup,
+            keeps the current page as text instead of a link, and uses the same
+            visually hidden heading and navigation label as the Nunjucks macro.
+          </p>
+
+          <h2>How to use the React component</h2>
+          <p>
+            Pass the list of pages through <code>items</code>. Mark the current
+            page item with <code>current: true</code> and omit its
+            <code>href</code>. Leave every item linked when you are using the
+            component as a related-pages list from a landing page.
+          </p>
+          <Source code={usageExample} language="tsx" />
+
+          <h2>Items shape</h2>
+          <p>
+            Each item needs visible text. Add <code>href</code> for linked
+            items, <code>current</code> for the current page item, and
+            <code>anchorProps</code> when you need extra link attributes.
+          </p>
+          <Source code={itemsShapeExample} language="tsx" />
+
+          <h2>Component props</h2>
+          <ArgTypes />
+
+          <h2>Storybook builder helpers</h2>
+          <p>
+            <code>showCurrent</code> and <code>currentItem</code> are
+            Storybook Builder helpers only. They make the interactive story
+            easier to use, but they are not real <code>ContentsList</code> props.
+          </p>
+
+          <h2>Examples</h2>
+          <Stories />
+        </>
+      ),
+    },
+  },
+  argTypes: {
+    items: {
+      control: false,
+      description:
+        'Contents list items rendered in order. Use `current: true` on the current page item.',
+      table: {
+        type: { summary: 'ContentsListItem[]' },
+      },
+    },
+    classes: {
+      control: false,
+      description:
+        'Toolkit-parity alias for extra root classes. Prefer `className` in React-first usage.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+    className: {
+      control: false,
+      description: 'Adds extra classes to the root `<nav>` element.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+    ref: {
+      control: false,
+      description: 'React ref for the root `<nav>` element.',
+      table: {
+        category: 'Advanced',
+      },
+    },
+    showCurrent: {
+      control: 'boolean',
+      description:
+        'Builder-only Storybook helper. Toggles whether one item is rendered as the current page.',
+      table: {
+        category: 'Builder story only',
+      },
+    },
+    currentItem: {
+      control: {
+        type: 'select',
+        labels: currentItemLabels,
+      },
+      options: Object.keys(currentItemLabels),
+      description:
+        'Builder-only Storybook helper. Chooses which item is rendered as the current page.',
+      if: {
+        arg: 'showCurrent',
+      },
+      table: {
+        category: 'Builder story only',
+        type: {
+          summary: 'ContentsListCurrentItem',
+        },
+      },
+    },
+  },
+  args: {
+    showCurrent: true,
+    currentItem: 'what-is-amd',
+  },
+};
+
+export default meta;
+type Story = StoryObj<ContentsListStoryArgs>;
+
+export const Default: Story = {
+  render: renderContentsList,
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      source: {
+        code: defaultSource,
+      },
+      description: {
+        story:
+          'A realistic contents list example with the current page shown as text at the top of the list.',
+      },
+    },
+  },
+};
+
+export const Builder: Story = {
+  render: renderContentsList,
+  parameters: {
+    controls: {
+      include: ['showCurrent', 'currentItem'],
+    },
+  },
+};
+
+export const CurrentInMiddle: Story = {
+  render: () => (
+    <ContentsList
+      items={buildItems({
+        showCurrent: true,
+        currentItem: 'getting-diagnosed',
+      })}
+    />
+  ),
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      source: {
+        code: currentInMiddleSource,
+      },
+      description: {
+        story:
+          'A fixed example showing that the current page item can appear anywhere in the list, not only at the start.',
+      },
+    },
+  },
+};
+
+export const AllLinks: Story = {
+  render: () => <ContentsList items={buildItems({ showCurrent: false })} />,
+  parameters: {
+    controls: {
+      disable: true,
+    },
+    docs: {
+      source: {
+        code: allLinksSource,
+      },
+      description: {
+        story:
+          'A fixed example for hub or landing pages where the contents list is a set of links and no current page item is shown.',
+      },
+    },
+  },
+};

--- a/packages/react-components/src/components/ContentsList/ContentsList.stories.tsx
+++ b/packages/react-components/src/components/ContentsList/ContentsList.stories.tsx
@@ -86,12 +86,19 @@ const items = [
 <ContentsList items={items} />;
 `;
 
-const itemsShapeExample = `type ContentsListItem = {
+const itemsShapeExample = `type ContentsListCurrentItem = {
   text: React.ReactNode;
-  href?: string;
-  current?: boolean;
+  current: true;
+};
+
+type ContentsListLinkedItem = {
+  text: React.ReactNode;
+  href: string;
+  current?: false;
   anchorProps?: Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'children' | 'href'>;
 };
+
+type ContentsListItem = ContentsListCurrentItem | ContentsListLinkedItem;
 `;
 
 const defaultSource = `import { ContentsList } from '@ourfuturehealth/react-components';

--- a/packages/react-components/src/components/ContentsList/ContentsList.test.tsx
+++ b/packages/react-components/src/components/ContentsList/ContentsList.test.tsx
@@ -52,6 +52,21 @@ describe('ContentsList', () => {
     expect(link).toHaveAttribute('data-track', 'contents-list-link');
   });
 
+  it('renders plain text when a non-current item is missing href at runtime', () => {
+    render(
+      <ContentsList
+        items={[
+          {
+            text: 'Symptoms',
+          } as ContentsListItem,
+        ]}
+      />,
+    );
+
+    expect(screen.queryByRole('link', { name: 'Symptoms' })).not.toBeInTheDocument();
+    expect(screen.getByText('Symptoms').tagName).toBe('SPAN');
+  });
+
   it('forwards refs and merges classes with className', () => {
     const ref = { current: null as HTMLElement | null };
 

--- a/packages/react-components/src/components/ContentsList/ContentsList.test.tsx
+++ b/packages/react-components/src/components/ContentsList/ContentsList.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { axe } from 'vitest-axe';
+import { ContentsList, type ContentsListItem } from './ContentsList';
+
+const defaultItems: ContentsListItem[] = [
+  {
+    text: 'What is AMD?',
+    current: true,
+  },
+  {
+    text: 'Symptoms',
+    href: '/conditions/amd/symptoms',
+  },
+  {
+    text: 'Getting diagnosed',
+    href: '/conditions/amd/getting-diagnosed',
+  },
+];
+
+describe('ContentsList', () => {
+  it('renders the contents list with a current item and linked items', () => {
+    render(<ContentsList items={defaultItems} />);
+
+    expect(screen.getByLabelText('Pages in this guide')).toBeInTheDocument();
+    expect(screen.getByText('Contents')).toHaveClass('ofh-u-visually-hidden');
+    expect(screen.getByText('What is AMD?').tagName).toBe('SPAN');
+    expect(screen.getByText('Symptoms').tagName).toBe('A');
+  });
+
+  it('forwards anchorProps to linked items', () => {
+    render(
+      <ContentsList
+        items={[
+          {
+            text: 'Symptoms',
+            href: '/conditions/amd/symptoms',
+            anchorProps: {
+              target: '_blank',
+              rel: 'noreferrer',
+              'data-track': 'contents-list-link',
+            },
+          },
+        ]}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: 'Symptoms' });
+
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer');
+    expect(link).toHaveAttribute('data-track', 'contents-list-link');
+  });
+
+  it('forwards refs and merges classes with className', () => {
+    const ref = { current: null as HTMLElement | null };
+
+    render(
+      <ContentsList
+        ref={ref}
+        items={defaultItems}
+        classes="app-contents-list"
+        className="qa-contents-list"
+      />,
+    );
+
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+    expect(ref.current).toHaveClass('ofh-contents-list');
+    expect(ref.current).toHaveClass('app-contents-list');
+    expect(ref.current).toHaveClass('qa-contents-list');
+  });
+
+  it('has no detectable accessibility violations', async () => {
+    const { container } = render(<ContentsList items={defaultItems} />);
+
+    const results = await axe(container);
+
+    expect(results.violations).toHaveLength(0);
+  });
+});

--- a/packages/react-components/src/components/ContentsList/ContentsList.tsx
+++ b/packages/react-components/src/components/ContentsList/ContentsList.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { joinClassNames } from '../_internal/joinClassNames';
+
+type ContentsListAnchorProps = Omit<
+  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  'children' | 'href'
+> & {
+  [key: `data-${string}`]: string | number | undefined;
+};
+
+export interface ContentsListItem {
+  /** Visible label for the contents list item. */
+  text: React.ReactNode;
+  /** Link destination for the item. Omit it when the item is the current page. */
+  href?: string;
+  /** Marks the item as the current page so it is rendered as text instead of a link. */
+  current?: boolean;
+  /** Extra anchor attributes for linked items, such as `target`, `rel`, or `data-*` hooks. */
+  anchorProps?: ContentsListAnchorProps;
+}
+
+export interface ContentsListProps
+  extends Omit<React.ComponentPropsWithoutRef<'nav'>, 'children' | 'ref'> {
+  /** Contents list items rendered in order. */
+  items: ContentsListItem[];
+  /** Toolkit-parity alias for adding extra classes to the root element. */
+  classes?: string;
+  /** React ref for the root `<nav>` element. */
+  ref?: React.Ref<HTMLElement>;
+}
+
+export const ContentsList = ({
+  items,
+  classes = '',
+  className = '',
+  ref,
+  ...props
+}: ContentsListProps) => {
+  const { 'aria-label': ariaLabel = 'Pages in this guide' } = props;
+
+  return (
+    <nav
+      {...props}
+      ref={ref}
+      aria-label={ariaLabel}
+      className={joinClassNames('ofh-contents-list', classes, className)}
+    >
+      <h2 className="ofh-u-visually-hidden">Contents</h2>
+      <ol className="ofh-contents-list__list">
+        {items.map((item, index) => {
+          const key = item.href ?? `${index}-${String(item.text)}`;
+
+          return item.current ? (
+            <li className="ofh-contents-list__item" aria-current="page" key={key}>
+              <span className="ofh-contents-list__current">{item.text}</span>
+            </li>
+          ) : (
+            <li className="ofh-contents-list__item" key={key}>
+              <a
+                {...item.anchorProps}
+                className={joinClassNames(
+                  'ofh-contents-list__link',
+                  item.anchorProps?.className,
+                )}
+                href={item.href}
+              >
+                {item.text}
+              </a>
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+};
+
+ContentsList.displayName = 'ContentsList';

--- a/packages/react-components/src/components/ContentsList/ContentsList.tsx
+++ b/packages/react-components/src/components/ContentsList/ContentsList.tsx
@@ -8,16 +8,25 @@ type ContentsListAnchorProps = Omit<
   [key: `data-${string}`]: string | number | undefined;
 };
 
-export interface ContentsListItem {
+export interface ContentsListCurrentItem {
   /** Visible label for the contents list item. */
   text: React.ReactNode;
-  /** Link destination for the item. Omit it when the item is the current page. */
-  href?: string;
   /** Marks the item as the current page so it is rendered as text instead of a link. */
-  current?: boolean;
+  current: true;
+}
+
+export interface ContentsListLinkedItem {
+  /** Visible label for the contents list item. */
+  text: React.ReactNode;
+  /** Link destination for linked items. */
+  href: string;
+  /** Linked items should leave this unset. */
+  current?: false;
   /** Extra anchor attributes for linked items, such as `target`, `rel`, or `data-*` hooks. */
   anchorProps?: ContentsListAnchorProps;
 }
+
+export type ContentsListItem = ContentsListCurrentItem | ContentsListLinkedItem;
 
 export interface ContentsListProps
   extends Omit<React.ComponentPropsWithoutRef<'nav'>, 'children' | 'ref'> {
@@ -36,11 +45,14 @@ export const ContentsList = ({
   ref,
   ...props
 }: ContentsListProps) => {
-  const { 'aria-label': ariaLabel = 'Pages in this guide' } = props;
+  const {
+    'aria-label': ariaLabel = 'Pages in this guide',
+    ...navProps
+  } = props;
 
   return (
     <nav
-      {...props}
+      {...navProps}
       ref={ref}
       aria-label={ariaLabel}
       className={joinClassNames('ofh-contents-list', classes, className)}
@@ -48,11 +60,15 @@ export const ContentsList = ({
       <h2 className="ofh-u-visually-hidden">Contents</h2>
       <ol className="ofh-contents-list__list">
         {items.map((item, index) => {
-          const key = item.href ?? `${index}-${String(item.text)}`;
+          const key = 'href' in item ? item.href : `${index}-${String(item.text)}`;
 
           return item.current ? (
             <li className="ofh-contents-list__item" aria-current="page" key={key}>
               <span className="ofh-contents-list__current">{item.text}</span>
+            </li>
+          ) : !item.href ? (
+            <li className="ofh-contents-list__item" key={key}>
+              <span>{item.text}</span>
             </li>
           ) : (
             <li className="ofh-contents-list__item" key={key}>

--- a/packages/react-components/src/components/ContentsList/index.ts
+++ b/packages/react-components/src/components/ContentsList/index.ts
@@ -1,0 +1,2 @@
+export { ContentsList } from './ContentsList';
+export type { ContentsListItem, ContentsListProps } from './ContentsList';

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -91,6 +91,12 @@ export type { CardCalloutProps } from './components/CardCallout';
 export { CardDoDont } from './components/CardDoDont';
 export type { CardDoDontItem, CardDoDontProps } from './components/CardDoDont';
 
+export { ContentsList } from './components/ContentsList';
+export type {
+  ContentsListItem,
+  ContentsListProps,
+} from './components/ContentsList';
+
 export { Pagination } from './components/Pagination';
 export type { PaginationProps } from './components/Pagination';
 

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -77,5 +77,11 @@ export type { CardCalloutProps } from './components/CardCallout';
 export { CardDoDont } from './components/CardDoDont';
 export type { CardDoDontItem, CardDoDontProps } from './components/CardDoDont';
 
+export { ContentsList } from './components/ContentsList';
+export type {
+  ContentsListItem,
+  ContentsListProps,
+} from './components/ContentsList';
+
 export { Tag } from './components/Tag';
 export type { TagProps, TagVariant } from './components/Tag';

--- a/packages/site/views/design-system/components/contents-list/all-links/index.njk
+++ b/packages/site/views/design-system/components/contents-list/all-links/index.njk
@@ -3,8 +3,8 @@
 {{ contentsList({
   items: [
     {
-      text: "What is AMD?",
-      current: true
+      href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/",
+      text: "What is AMD?"
     },
     {
       href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/symptoms/",

--- a/packages/site/views/design-system/components/contents-list/current-in-middle/index.njk
+++ b/packages/site/views/design-system/components/contents-list/current-in-middle/index.njk
@@ -3,16 +3,16 @@
 {{ contentsList({
   items: [
     {
-      text: "What is AMD?",
-      current: true
+      href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/",
+      text: "What is AMD?"
     },
     {
       href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/symptoms/",
       text: "Symptoms"
     },
     {
-      href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/getting-diagnosed/",
-      text: "Getting diagnosed"
+      text: "Getting diagnosed",
+      current: true
     },
     {
       href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/treatment/",

--- a/packages/site/views/design-system/components/contents-list/index.njk
+++ b/packages/site/views/design-system/components/contents-list/index.njk
@@ -3,7 +3,7 @@
 {% set subSection = "Components" %}
 {% set pageDescription = "Use contents lists to allow users to navigate between related pages, for example about a single condition." %}
 {% set theme = "Navigation" %}
-{% set dateUpdated = "February 2019" %}
+{% set dateUpdated = "April 2026" %}
 {% set backlog_issue_id = "25" %}
 
 {% extends "app-layout.njk" %}
@@ -14,17 +14,41 @@
 
 {% block bodyContent %}
 
+  <p>Use a contents list to help users move around a small group of related information pages, such as a condition guide or advice hub.</p>
+  <p>If you are working in React instead of Nunjucks, use the React <code>ContentsList</code> component in Storybook. This page is the toolkit/Nunjucks usage guide.</p>
+
+  <h2 id="default-contents-list">Default contents list</h2>
+  <p>Use a current page item when the contents list appears on one page in the guide and needs to show where the user is now.</p>
+
   {{ designExample({
     group: "components",
     item: "contents-list",
     type: "default"
   }) }}
 
-  <h2>When to use a contents list</h2>
+  <h2 id="current-page-in-the-middle">Current page in the middle</h2>
+  <p>The current page does not need to be the first item. Use the current-state styling on whichever item matches the page the user is viewing.</p>
+
+  {{ designExample({
+    group: "components",
+    item: "contents-list",
+    type: "current-in-middle"
+  }) }}
+
+  <h2 id="contents-list-with-all-links">Contents list with all links</h2>
+  <p>When you are linking to a group of related pages from a landing page or hub, you can show the list without a current page item.</p>
+
+  {{ designExample({
+    group: "components",
+    item: "contents-list",
+    type: "all-links"
+  }) }}
+
+  <h2 id="when-to-use-a-contents-list">When to use a contents list</h2>
   <p>Use a contents list at the top of the page to allow users to navigate around a small group of related pages (up to 8 pages), for example a group of pages about a specific condition. The example on this page is from the nhs.uk page about <a href="https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/">age-related macular degeneration</a>.</p>
   <p>If you're using a contents list, you should also use <a href="/design-system/components/pagination">pagination</a> at the bottom of the page. The 2 components make up the multi-page navigation pattern.</p>
 
-  <h2>When not to use a contents list</h2>
+  <h2 id="when-not-to-use-a-contents-list">When not to use a contents list</h2>
   <p>Do not use a contents list on pages which aren't grouped together or "related" as this is likely confuse users.</p>
   <p>Do not use a contents list in a transactional service or a form. We use other components instead, including:</p>
   <ul>
@@ -32,7 +56,16 @@
     <li><a href="/design-system/components/link-icon">link icon</a> to navigate back</li>
   </ul>
 
-  <h2>How to use a contents list</h2>
+  <h2 id="how-contents-lists-work">How contents lists work</h2>
+  <p>Use these options when configuring the contents list macro:</p>
+  <ul>
+    <li><code>items</code>: the list of pages shown in the contents list</li>
+    <li><code>text</code>: the visible label for each item</li>
+    <li><code>href</code>: the link destination for each non-current item</li>
+    <li><code>current</code>: marks the current page item so it is rendered as text instead of a link</li>
+    <li><code>classes</code>: extra classes added to the root contents list element</li>
+    <li><code>attributes</code>: extra HTML attributes added to the root contents list element</li>
+  </ul>
   <p>Use the contents list at the top of the page together with pagination at the bottom of each page.</p>
   <p>Keep links short and descriptive. Links that are too long (more than 2 lines) make it difficult for users to scan the list.</p>
   <p>Page titles must reflect the subject of the page (for example, "Treatment"), with the overall subject of the section as the sub-header (for example, "Age-related macular degeneration (AMD)"). This is so users are clear where they have navigated to.</p>

--- a/packages/site/views/design-system/components/contents-list/macro-options.json
+++ b/packages/site/views/design-system/components/contents-list/macro-options.json
@@ -4,39 +4,39 @@
       "name": "items",
       "type": "array",
       "required": true,
-      "description": "Array of content list items objects.",
+      "description": "Array of contents list item objects shown in order.",
       "params": [
-        {
-          "name": "href",
-          "type": "string",
-          "required": true,
-          "description": "href value to use within each content list item label."
-        },
         {
           "name": "text",
           "type": "string",
           "required": true,
-          "description": "Text to use within each content list item label."
+          "description": "Visible label for the contents list item."
+        },
+        {
+          "name": "href",
+          "type": "string",
+          "required": false,
+          "description": "Link destination for the item. Omit it when the item is the current page."
+        },
+        {
+          "name": "current",
+          "type": "boolean",
+          "required": false,
+          "description": "When true, renders the item as the current page instead of a link."
         }
       ]
-    },
-    {
-      "name": "current",
-      "type": "boolean",
-      "required": false,
-      "description": "Set the current active page."
     },
     {
       "name": "classes",
       "type": "string",
       "required": false,
-      "description": "Classes to add to the content list container."
+      "description": "Classes to add to the contents list container."
     },
     {
       "name": "attributes",
       "type": "object",
       "required": false,
-      "description": "HTML attributes (for example data attributes) to items in the content list."
+      "description": "HTML attributes (for example data attributes) to add to the root contents list element."
     }
   ]
 }

--- a/packages/site/views/examples/components/contents-list/index.njk
+++ b/packages/site/views/examples/components/contents-list/index.njk
@@ -13,9 +13,8 @@
         {{ contentsList({
           items: [
             {
-              href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/",
               text: "What is AMD?",
-              current: "true"
+              current: true
             },
             {
               href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/symptoms/",
@@ -24,13 +23,11 @@
             {
               href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/getting-diagnosed/",
               text: "Getting diagnosed"
-            }
-            ,
+            },
             {
               href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/treatment/",
               text: "Treatments"
-            }
-            ,
+            },
             {
               href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/living-with-amd/",
               text: "Living with AMD"

--- a/packages/toolkit/components/contents-list/README.md
+++ b/packages/toolkit/components/contents-list/README.md
@@ -57,9 +57,8 @@ Find out more about the contents list component and when to use it in the [desig
 {{ contentsList({
   items: [
     {
-      href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/",
       text: "What is AMD?",
-      current: "true"
+      current: true
     },
     {
       href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/symptoms/",
@@ -68,13 +67,11 @@ Find out more about the contents list component and when to use it in the [desig
     {
       href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/getting-diagnosed/",
       text: "Getting diagnosed"
-    }
-    ,
+    },
     {
       href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/treatment/",
       text: "Treatments"
-    }
-    ,
+    },
     {
       href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/living-with-amd/",
       text: "Living with AMD"
@@ -87,13 +84,13 @@ Find out more about the contents list component and when to use it in the [desig
 
 The contents list Nunjucks macro takes the following arguments:
 
-| Name              | Type    | Required | Description                                                                           |
-| ----------------- | ------- | -------- | ------------------------------------------------------------------------------------- |
-| **items**         | array   | Yes      | Array of items in the contents list.                                                  |
-| **items.[].href** | string  | Yes      | Href value of an item in the contents list.                                           |
-| **items.[].text** | string  | Yes      | Text value of an item in the contents llst.                                           |
-| **current**       | boolean | No       | Current active page in the contents list.                                             |
-| **classes**       | string  | No       | Optional additional classes content list container. Separate each class with a space. |
-| **attributes**    | object  | No       | Any extra HTML attributes (for example data attributes) to items in the list.         |
+| Name                  | Type    | Required | Description                                                                                   |
+| --------------------- | ------- | -------- | --------------------------------------------------------------------------------------------- |
+| **items**             | array   | Yes      | Array of items in the contents list.                                                          |
+| **items.[].text**     | string  | Yes      | Visible label for the contents list item.                                                     |
+| **items.[].href**     | string  | No       | Link destination for the item. Omit it when the item is the current page.                     |
+| **items.[].current**  | boolean | No       | When true, renders the item as the current page instead of a link.                            |
+| **classes**           | string  | No       | Optional additional classes for the contents list container. Separate each class with a space. |
+| **attributes**        | object  | No       | Extra HTML attributes (for example data attributes) for the root contents list element.       |
 
 If you are using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `html` can be a [security risk](https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting). Read more about this in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).

--- a/packages/toolkit/components/contents-list/_contents-list.scss
+++ b/packages/toolkit/components/contents-list/_contents-list.scss
@@ -8,23 +8,29 @@
  */
 
 .ofh-contents-list {
+  @include ofh-font('paragraph-md');
   @include ofh-responsive-margin(40, 'bottom');
 }
 
 .ofh-contents-list__list {
+  display: flex;
+  flex-direction: column;
+  gap: $ofh-size-8;
   list-style: none;
+  margin: 0;
   padding: 0;
 }
 
 .ofh-contents-list__item {
-  background: url("data:image/svg+xml,%3Csvg class='ofh-icon ofh-icon__emdash' xmlns='http://www.w3.org/2000/svg' fill='%23aeb7bd' width='19' height='1' aria-hidden='true'%3E%3Cpath d='M0 0h19v1H0z'%3E%3C/path%3E%3C/svg%3E")
-    left ofh-px-to-rem(12px) no-repeat;
-  padding: 0 0 0 $ofh-size-32;
-  position: relative;
+  align-items: center;
+  display: flex;
+  gap: $ofh-size-12;
 
-  @include mq($from: tablet) {
-    background: url("data:image/svg+xml,%3Csvg class='ofh-icon ofh-icon__emdash' xmlns='http://www.w3.org/2000/svg' fill='%23aeb7bd' width='16' height='1' aria-hidden='true'%3E%3Cpath d='M0 0h19v1H0z'%3E%3C/path%3E%3C/svg%3E")
-      left ofh-px-to-rem(14px) no-repeat;
+  &::before {
+    background-color: $ofh-color-border-input-default;
+    content: '';
+    flex: 0 0 ofh-px-to-rem(20px);
+    height: $ofh-stroke-weight-1;
   }
 }
 
@@ -33,5 +39,6 @@
 }
 
 .ofh-contents-list__current {
+  color: $ofh-color-foreground-primary;
   font-weight: $ofh-typography-weight-semibold;
 }

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/toolkit",
-  "version": "4.19.0",
+  "version": "4.20.0",
   "description": "Our Future Health design system toolkit contains the code you need to start building user interfaces for Our Future Health websites and services.",
   "repository": {
     "type": "git",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/toolkit",
-  "version": "4.10.0",
+  "version": "4.20.0",
   "description": "Our Future Health design system toolkit contains the code you need to start building user interfaces for Our Future Health websites and services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
This PR delivers **DSE-429 contents list refresh** across toolkit, React, the docs site, and Storybook.

It audits the existing toolkit contents list against the current Figma component, aligns the visual treatment more closely with the design, introduces the public React `ContentsList` component, and updates the docs site and Storybook to teach the component more clearly.

Ticket: [DSE-429](https://ourfuturehealth.atlassian.net/browse/DSE-429)

## Release scope
- `@ourfuturehealth/toolkit` -> `4.20.0`
- `@ourfuturehealth/react-components` -> `0.19.0`
- updates release metadata in `CHANGELOG.md`, `UPGRADING.md`, `docs/release-versioning-strategy.md`, `docs/consuming-react-components.md`, and `packages/react-components/README.md`

## Breaking Changes
- None.

## Key Changes
- refreshes the toolkit `contents-list` spacing, marker treatment, and typography to match the current Figma component more closely
- replaces the old light SVG dash marker with a token-driven 20px rule and adopts the Figma 8px item gap / 12px marker-to-text gap
- keeps the current item visually stronger while preserving the existing contents-list structure and accessibility semantics
- expands toolkit docs-site coverage with:
  - `Default contents list`
  - `Current page in the middle`
  - `Contents list with all links`
- rewrites the toolkit docs page, README, and macro options so the component is easier to understand and the macro API matches the actual behavior more closely
- adds the public React `ContentsList` component with a React-friendly `items` API, current-item support, and `anchorProps` passthrough for extra link attributes
- adds unit and accessibility coverage for the new React component
- updates Storybook so `ContentsList` follows the newer `Docs` / `Default` / `Builder` / showcase teaching pattern

## Validation
- `npm test`
- `pnpm lint`
- `pnpm --filter=@ourfuturehealth/react-components build:storybook`
- `pnpm --filter=site build:eleventy`
- `pnpm build`
- `pnpm docs:release-contract`
- `pnpm smoke:release-artifacts`
- manual QA against current/main and branch toolkit contents-list routes
- manual QA on the new React Storybook docs, Builder, and showcase stories

## Reviewer Focus
- toolkit contents lists should now feel closer to the current Figma treatment, especially typography, marker contrast, and spacing
- toolkit docs site and React Storybook should now teach the same contents-list pattern family
- the new React `ContentsList` API should feel straightforward to adopt while still covering toolkit parity
- release metadata should line up on `toolkit-v4.20.0` / `react-v0.19.0`


[DSE-429]: https://ourfuturehealth.atlassian.net/browse/DSE-429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ