### PR TITLE
ci: automate releases from main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,2 +1,7 @@
 ## Description
 
+## Release
+
+- [ ] No package release
+- [ ] Release toolkit
+- [ ] Release React components

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -26,6 +26,16 @@ on:
         required: false
         default: false
         type: boolean
+      send_slack_notification:
+        description: Send a Slack notification for this dry-run release.
+        required: false
+        default: false
+        type: boolean
+      force_failure_notification:
+        description: Fail the dry-run before publishing so the Slack failure notification path can be tested.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -132,6 +142,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Force dry-run failure notification
+        if: github.event_name == 'workflow_dispatch' && inputs.force_failure_notification
+        run: |
+          echo 'Forcing dry-run failure before release checks or publishing.'
+          exit 1
+
       - name: Run linting
         run: pnpm run lint
 
@@ -226,11 +242,14 @@ jobs:
     permissions:
       contents: read
       issues: write
+    outputs:
+      issue_url: ${{ steps.repair_issue.outputs.issue_url }}
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Create or update repair issue
+        id: repair_issue
         env:
           GH_TOKEN: ${{ github.token }}
           RESPONSIBLE_USER: ${{ needs.plan_auto_release.outputs.responsible_user }}
@@ -244,3 +263,34 @@ jobs:
           PUBLISH_RESULT: ${{ needs.publish_releases.result }}
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: node scripts/release/notify-auto-release-failure.mjs
+
+  notify_slack:
+    name: Notify Slack
+    needs:
+      - plan_auto_release
+      - run_release_checks
+      - publish_releases
+      - notify_failure
+    if: always() && github.event_name != 'pull_request' && (needs.plan_auto_release.outputs.has_releases == 'true' || needs.plan_auto_release.result == 'failure') && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.send_slack_notification))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Send Slack release notification
+        continue-on-error: true
+        env:
+          SLACK_RELEASE_WORKFLOW_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WORKFLOW_WEBHOOK_URL }}
+          RELEASE_STATUS: ${{ needs.publish_releases.result == 'success' && 'success' || 'failure' }}
+          FAILED_GATE: ${{ needs.plan_auto_release.result == 'failure' && 'planning' || needs.run_release_checks.result == 'failure' && 'checks' || needs.publish_releases.result == 'failure' && 'publishing' || 'none' }}
+          RESPONSIBLE_USER: ${{ needs.plan_auto_release.outputs.responsible_user }}
+          PR_NUMBER: ${{ needs.plan_auto_release.outputs.pr_number }}
+          PR_URL: ${{ needs.plan_auto_release.outputs.pr_url }}
+          PR_TITLE: ${{ needs.plan_auto_release.outputs.pr_title }}
+          RELEASE_SUMMARY: ${{ needs.plan_auto_release.outputs.summary }}
+          PACKAGES_JSON: ${{ needs.plan_auto_release.outputs.packages }}
+          REPAIR_ISSUE_URL: ${{ needs.notify_failure.outputs.issue_url }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash scripts/release/notify-auto-release-slack.sh

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,246 @@
+name: Automated release
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      release_scope:
+        description: Package release path to exercise with test tags and draft prereleases.
+        required: true
+        type: choice
+        options:
+          - toolkit
+          - react-components
+          - all
+      keep_test_releases:
+        description: Keep dry-run tags and draft prereleases for debugging.
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: automated-release-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate_pr_release_intent:
+    name: Validate PR release intent
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate release checkboxes and package versions
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node scripts/release/auto-release-plan.mjs validate-pr \
+            --base-sha "${{ github.event.pull_request.base.sha }}" \
+            --head-sha "${{ github.event.pull_request.head.sha }}" \
+            --event-path "${GITHUB_EVENT_PATH}"
+
+  plan_auto_release:
+    name: Plan automated release
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.plan_push.outputs.packages || steps.plan_test.outputs.packages }}
+      has_releases: ${{ steps.plan_push.outputs.has_releases || steps.plan_test.outputs.has_releases }}
+      responsible_user: ${{ steps.plan_push.outputs.responsible_user || steps.plan_test.outputs.responsible_user }}
+      pr_number: ${{ steps.plan_push.outputs.pr_number || steps.plan_test.outputs.pr_number }}
+      pr_url: ${{ steps.plan_push.outputs.pr_url || steps.plan_test.outputs.pr_url }}
+      pr_title: ${{ steps.plan_push.outputs.pr_title || steps.plan_test.outputs.pr_title }}
+      summary: ${{ steps.plan_push.outputs.summary || steps.plan_test.outputs.summary }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve merged pull request
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/auto-release"
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" > "${RUNNER_TEMP}/auto-release/pulls.json"
+
+          pr_number=$(jq -r '.[0].number // empty' "${RUNNER_TEMP}/auto-release/pulls.json")
+          if [[ -n "${pr_number}" ]]; then
+            gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" > "${RUNNER_TEMP}/auto-release/pull.json"
+          else
+            printf '{}\n' > "${RUNNER_TEMP}/auto-release/pull.json"
+          fi
+
+      - name: Plan main merge release
+        id: plan_push
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node scripts/release/auto-release-plan.mjs plan-push \
+            --base-sha "${{ github.event.before }}" \
+            --head-sha "${{ github.sha }}" \
+            --pr-json "${RUNNER_TEMP}/auto-release/pull.json" \
+            --github-output "${GITHUB_OUTPUT}"
+
+      - name: Plan dry-run release
+        id: plan_test
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          node scripts/release/auto-release-plan.mjs plan-test \
+            --scope "${{ inputs.release_scope }}" \
+            --run-id "${{ github.run_id }}-${{ github.run_attempt }}" \
+            --github-output "${GITHUB_OUTPUT}"
+
+  run_release_checks:
+    name: Run release checks
+    needs: plan_auto_release
+    if: needs.plan_auto_release.outputs.has_releases == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+
+      - name: Enable Corepack and pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.29.2 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run linting
+        run: pnpm run lint
+
+      - name: Install Playwright browser for tests
+        run: pnpm --filter=@ourfuturehealth/react-components exec playwright install --with-deps chromium
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Build all packages
+        run: pnpm build
+
+      - name: Validate release contract docs
+        run: pnpm docs:release-contract
+
+  publish_releases:
+    name: Publish releases
+    needs:
+      - plan_auto_release
+      - run_release_checks
+    if: needs.plan_auto_release.outputs.has_releases == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+
+      - name: Enable Corepack and pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.29.2 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure release tag author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Publish planned releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KEEP_TEST_RELEASES: ${{ github.event_name == 'workflow_dispatch' && inputs.keep_test_releases || 'false' }}
+          TARGET_SHA: ${{ github.sha }}
+        run: |
+          packages_file="${RUNNER_TEMP}/auto-release-packages.json"
+          cat > "${packages_file}" <<'JSON'
+          ${{ needs.plan_auto_release.outputs.packages }}
+          JSON
+
+          jq -c '.[]' "${packages_file}" | while read -r release_package; do
+            package_name=$(jq -r '.package' <<< "${release_package}")
+            tag=$(jq -r '.tag' <<< "${release_package}")
+            version=$(jq -r '.version' <<< "${release_package}")
+            is_test=$(jq -r '.test' <<< "${release_package}")
+
+            args=(
+              --package "${package_name}"
+              --tag "${tag}"
+              --target "${TARGET_SHA}"
+              --expected-version "${version}"
+              --stage-dir "${RUNNER_TEMP}/release-assets-${package_name}-${tag}"
+            )
+
+            if [[ "${is_test}" == "true" ]]; then
+              args+=(--test-release)
+
+              if [[ "${KEEP_TEST_RELEASES}" == "true" ]]; then
+                args+=(--keep-test-release)
+              fi
+            fi
+
+            bash scripts/release/publish-auto-release.sh "${args[@]}"
+          done
+
+  notify_failure:
+    name: Notify auto-release failure
+    needs:
+      - plan_auto_release
+      - run_release_checks
+      - publish_releases
+    if: always() && github.event_name == 'push' && (needs.plan_auto_release.result == 'failure' || needs.run_release_checks.result == 'failure' || needs.publish_releases.result == 'failure')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create or update repair issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RESPONSIBLE_USER: ${{ needs.plan_auto_release.outputs.responsible_user }}
+          PR_NUMBER: ${{ needs.plan_auto_release.outputs.pr_number }}
+          PR_URL: ${{ needs.plan_auto_release.outputs.pr_url }}
+          PR_TITLE: ${{ needs.plan_auto_release.outputs.pr_title }}
+          RELEASE_SUMMARY: ${{ needs.plan_auto_release.outputs.summary }}
+          PACKAGES_JSON: ${{ needs.plan_auto_release.outputs.packages }}
+          PLAN_RESULT: ${{ needs.plan_auto_release.result }}
+          CHECKS_RESULT: ${{ needs.run_release_checks.result }}
+          PUBLISH_RESULT: ${{ needs.publish_releases.result }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node scripts/release/notify-auto-release-failure.mjs

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - main
+      - feature/auto-release-from-main-ci
   workflow_dispatch:
     inputs:
       release_scope:
@@ -74,7 +75,7 @@ jobs:
           fetch-depth: 0
 
       - name: Resolve merged pull request
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -92,7 +93,7 @@ jobs:
 
       - name: Plan main merge release
         id: plan_push
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -104,10 +105,12 @@ jobs:
 
       - name: Plan dry-run release
         id: plan_test
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/feature/auto-release-from-main-ci')
+        env:
+          RELEASE_SCOPE: ${{ github.event_name == 'workflow_dispatch' && inputs.release_scope || 'all' }}
         run: |
           node scripts/release/auto-release-plan.mjs plan-test \
-            --scope "${{ inputs.release_scope }}" \
+            --scope "${RELEASE_SCOPE}" \
             --run-id "${{ github.run_id }}-${{ github.run_attempt }}" \
             --github-output "${GITHUB_OUTPUT}"
 
@@ -182,7 +185,7 @@ jobs:
       - name: Publish planned releases
         env:
           GH_TOKEN: ${{ github.token }}
-          KEEP_TEST_RELEASES: ${{ github.event_name == 'workflow_dispatch' && inputs.keep_test_releases || 'false' }}
+          KEEP_TEST_RELEASES: ${{ github.ref == 'refs/heads/feature/auto-release-from-main-ci' || (github.event_name == 'workflow_dispatch' && inputs.keep_test_releases) || 'false' }}
           TARGET_SHA: ${{ github.sha }}
         run: |
           packages_file="${RUNNER_TEMP}/auto-release-packages.json"
@@ -221,7 +224,7 @@ jobs:
       - plan_auto_release
       - run_release_checks
       - publish_releases
-    if: always() && github.event_name == 'push' && (needs.plan_auto_release.result == 'failure' || needs.run_release_checks.result == 'failure' || needs.publish_releases.result == 'failure')
+    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && (needs.plan_auto_release.result == 'failure' || needs.run_release_checks.result == 'failure' || needs.publish_releases.result == 'failure')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -11,7 +11,6 @@ on:
   push:
     branches:
       - main
-      - feature/auto-release-from-main-ci
   workflow_dispatch:
     inputs:
       release_scope:
@@ -75,7 +74,7 @@ jobs:
           fetch-depth: 0
 
       - name: Resolve merged pull request
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -93,7 +92,7 @@ jobs:
 
       - name: Plan main merge release
         id: plan_push
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -105,12 +104,10 @@ jobs:
 
       - name: Plan dry-run release
         id: plan_test
-        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/feature/auto-release-from-main-ci')
-        env:
-          RELEASE_SCOPE: ${{ github.event_name == 'workflow_dispatch' && inputs.release_scope || 'all' }}
+        if: github.event_name == 'workflow_dispatch'
         run: |
           node scripts/release/auto-release-plan.mjs plan-test \
-            --scope "${RELEASE_SCOPE}" \
+            --scope "${{ inputs.release_scope }}" \
             --run-id "${{ github.run_id }}-${{ github.run_attempt }}" \
             --github-output "${GITHUB_OUTPUT}"
 
@@ -185,7 +182,7 @@ jobs:
       - name: Publish planned releases
         env:
           GH_TOKEN: ${{ github.token }}
-          KEEP_TEST_RELEASES: ${{ github.ref == 'refs/heads/feature/auto-release-from-main-ci' || (github.event_name == 'workflow_dispatch' && inputs.keep_test_releases) || 'false' }}
+          KEEP_TEST_RELEASES: ${{ github.event_name == 'workflow_dispatch' && inputs.keep_test_releases || 'false' }}
           TARGET_SHA: ${{ github.sha }}
         run: |
           packages_file="${RUNNER_TEMP}/auto-release-packages.json"
@@ -224,7 +221,7 @@ jobs:
       - plan_auto_release
       - run_release_checks
       - publish_releases
-    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && (needs.plan_auto_release.result == 'failure' || needs.run_release_checks.result == 'failure' || needs.publish_releases.result == 'failure')
+    if: always() && github.event_name == 'push' && (needs.plan_auto_release.result == 'failure' || needs.run_release_checks.result == 'failure' || needs.publish_releases.result == 'failure')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-contract.yml
+++ b/.github/workflows/release-contract.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     paths:
       - '.github/workflows/release.yml'
+      - '.github/workflows/auto-release.yml'
       - '.github/workflows/release-contract.yml'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
       - 'README.md'
       - 'UPGRADING.md'
       - 'docs/**'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Create release
+name: Manual release fallback
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    name: Create release
+    name: Manual release fallback
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -105,21 +105,17 @@ For the background on tag naming and monorepo versioning, see [Release Versionin
 
 2. **Update [CHANGELOG.md](CHANGELOG.md)**: Document what's being released
 
-3. **Commit and push**:
+3. **Select release intent in the PR template**:
+   - choose `No package release` for changes that do not publish package artifacts
+   - choose `Release toolkit`, `Release React components`, or both when package versions are bumped
 
-   ```bash
-   git add packages/[package-name]/package.json CHANGELOG.md
-   git commit -m "chore([package]): bump version to X.X.X"
-   git push origin main
-   ```
-
-4. **Create and push tag**:
-   - Toolkit: `git tag -a toolkit-vX.X.X -m "Release toolkit vX.X.X" && git push origin toolkit-vX.X.X`
-   - React: `git tag -a react-vX.X.X -m "Release react vX.X.X" && git push origin react-vX.X.X`
+4. **Merge to `main`**: the automated release workflow creates the package tag, GitHub release, and release assets after checks pass
 
 5. **Verify**: Check [GitHub Releases](https://github.com/ourfuturehealth/design-system-toolkit/releases) and test installation
 
 6. **Announce**: Post in #design-system Slack channel
+
+Human-pushed release tags are still supported through the **Manual release fallback** workflow for recovery and exceptional cases.
 
 For detailed instructions, release types, and troubleshooting, see the [Release Process documentation](/docs/release-process.md).
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -67,23 +67,17 @@ Select:
 
 The automated PR check fails if a package version changes without the matching release checkbox, if a release checkbox is selected without a package version change, if the candidate tag already exists, or if [CHANGELOG.md](../CHANGELOG.md) does not mention the candidate tag.
 
-### 4. Merge to main
+### 4. Open and merge the pull request
 
-Toolkit example:
+Open a pull request into `main` with the package version, changelog, and migration documentation changes. Use the release checkboxes in the pull request body to declare whether the PR should release toolkit, React components, both packages, or no package artifacts.
 
-```bash
-git add packages/toolkit/package.json CHANGELOG.md UPGRADING.md
-git commit -m "chore(toolkit): bump version to 4.0.1"
-git push origin main
-```
+Before merging:
 
-React example:
+- confirm the release-intent PR check passes
+- confirm the normal pull request checks pass
+- confirm the candidate tag does not already exist
 
-```bash
-git add packages/react-components/package.json CHANGELOG.md UPGRADING.md
-git commit -m "chore(react-components): bump version to 0.5.1"
-git push origin main
-```
+Merge the pull request through the normal repository process. Do not push release commits directly to `main`, and do not create release tags locally for the normal release path.
 
 After the pull request is merged, the **Automated release** workflow runs on `main`. Maintainers do not create the release tag manually for the normal release path.
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -17,6 +17,7 @@ The design system distributes packages through **GitHub Releases**.
 - all tests pass locally: `pnpm test`
 - all linting passes locally: `pnpm lint`
 - changelog and migration docs are updated when required
+- the release section in the pull request template is filled in
 
 ## Release Steps
 
@@ -45,7 +46,28 @@ For the package you are releasing:
 - update [CHANGELOG.md](../CHANGELOG.md)
 - update [UPGRADING.md](../UPGRADING.md) if the release changes the public API or install contract
 
-### 3. Commit and tag
+### 3. Select release intent in the pull request
+
+Every pull request includes a release section:
+
+```md
+## Release
+
+- [ ] No package release
+- [ ] Release toolkit
+- [ ] Release React components
+```
+
+Select:
+
+- `No package release` when no package artifacts should be published
+- `Release toolkit` when `packages/toolkit/package.json` is bumped
+- `Release React components` when `packages/react-components/package.json` is bumped
+- both package release checkboxes when both package manifests are bumped
+
+The automated PR check fails if a package version changes without the matching release checkbox, if a release checkbox is selected without a package version change, if the candidate tag already exists, or if [CHANGELOG.md](../CHANGELOG.md) does not mention the candidate tag.
+
+### 4. Merge to main
 
 Toolkit example:
 
@@ -53,8 +75,6 @@ Toolkit example:
 git add packages/toolkit/package.json CHANGELOG.md UPGRADING.md
 git commit -m "chore(toolkit): bump version to 4.0.1"
 git push origin main
-git tag -a toolkit-v4.0.1 -m "Release toolkit v4.0.1"
-git push origin toolkit-v4.0.1
 ```
 
 React example:
@@ -63,22 +83,26 @@ React example:
 git add packages/react-components/package.json CHANGELOG.md UPGRADING.md
 git commit -m "chore(react-components): bump version to 0.5.1"
 git push origin main
-git tag -a react-v0.5.1 -m "Release react-components v0.5.1"
-git push origin react-v0.5.1
 ```
 
-### 4. GitHub Actions builds the release
+After the pull request is merged, the **Automated release** workflow runs on `main`. Maintainers do not create the release tag manually for the normal release path.
 
-When a release tag is pushed, [.github/workflows/release.yml](../.github/workflows/release.yml) automatically:
+### 5. GitHub Actions builds the release
+
+When a release-intent pull request is merged, [.github/workflows/auto-release.yml](../.github/workflows/auto-release.yml) automatically:
 
 1. installs dependencies with pnpm
 2. runs linting and tests
-3. validates the release-contract docs
-4. prepares the package release assets in a dedicated staging directory outside the package tree
-5. smoke-tests the tarball with Yarn 1, npm, and pnpm
-6. renders release notes with the tarball install URL
-7. creates or updates the GitHub release
-8. uploads release assets
+3. builds all packages
+4. validates the release-contract docs
+5. prepares the package release assets in a dedicated staging directory outside the package tree
+6. smoke-tests the tarball with Yarn 1, npm, and pnpm
+7. creates the annotated package tag
+8. renders release notes with the tarball install URL
+9. creates the GitHub release
+10. uploads and verifies release assets
+
+The automated workflow never overwrites existing tags, releases, or release assets.
 
 Toolkit releases upload:
 
@@ -89,7 +113,7 @@ React releases upload:
 
 - `ourfuturehealth-react-components-{version}.tgz`
 
-### 5. Verify the release
+### 6. Verify the release
 
 After the workflow completes:
 
@@ -120,9 +144,20 @@ React release note example:
 
 ## Testing Before Or After Release
 
+### Dry-run the automated release flow
+
+The **Automated release** workflow has a `workflow_dispatch` dry-run mode for safe end-to-end testing. It creates fake tags such as `auto-release-test-toolkit-v4.13.0-<run-id>`, creates draft prereleases, uploads real staged assets, verifies the assets, and cleans up the test tags and releases unless `keep_test_releases` is selected.
+
+Use this before changing release automation or when validating a repair:
+
+1. open the Actions tab
+2. run **Automated release** manually
+3. choose `toolkit`, `react-components`, or `all`
+4. leave `keep_test_releases` unchecked unless you need to inspect the test release
+
 ### How release-contract validation stays current
 
-`pnpm docs:release-contract` scans all tracked Markdown, shell, and workflow files in the repository rather than relying on a narrow hand-maintained file list.
+`pnpm docs:release-contract` scans all tracked Markdown, release JavaScript, shell, and workflow files in the repository rather than relying on a narrow hand-maintained file list.
 
 It validates that:
 
@@ -194,6 +229,38 @@ Common causes:
 - package build failures
 - smoke test failures for the tarball install contract
 - stale docs or release templates that still mention the old git-subdirectory syntax
+- release intent checkboxes that do not match package version changes
+- candidate tags or GitHub releases that already exist
+
+On `main` merge failures, the workflow creates or updates a GitHub issue labelled `auto-release` and assigns it to the merge owner when possible.
+
+### Manual release fallback
+
+The normal release path is automated from `main`. Human-pushed release tags are reserved for recovery and exceptional cases through the **Manual release fallback** workflow.
+
+Use the fallback only after confirming the automated path cannot be repaired through a normal follow-up pull request.
+
+Toolkit fallback:
+
+```bash
+git fetch origin main --tags
+git switch main
+git pull --ff-only origin main
+git tag -a toolkit-v4.0.1 -m "Release toolkit v4.0.1"
+git push origin toolkit-v4.0.1
+```
+
+React fallback:
+
+```bash
+git fetch origin main --tags
+git switch main
+git pull --ff-only origin main
+git tag -a react-v0.5.1 -m "Release react-components v0.5.1"
+git push origin react-v0.5.1
+```
+
+The fallback workflow also refuses version/tag mismatches, but it may update an existing GitHub release for a human-pushed tag. Do not use it to overwrite a stale tag. Delete the incorrect remote tag or release intentionally first when that is the repair path.
 
 ### Why release assets are staged outside the package tree
 
@@ -224,3 +291,4 @@ If you are testing unreleased code, build and pack the package locally instead o
 3. Keep `.zip` guidance limited to compiled-file toolkit consumers
 4. Test every release with Yarn 1, npm, and pnpm before or during the workflow
 5. Update migration docs whenever the public API or install path changes
+6. Use the automated release path by default; reserve manual tags for recovery

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -148,6 +148,41 @@ Use this before changing release automation or when validating a repair:
 2. run **Automated release** manually
 3. choose `toolkit`, `react-components`, or `all`
 4. leave `keep_test_releases` unchecked unless you need to inspect the test release
+5. select `send_slack_notification` only when testing the Slack notification path
+6. select `force_failure_notification` only when testing the Slack failure notification path
+
+### Slack release notifications
+
+The automated release workflow can send success and failure notifications to Slack through a Slack Workflow Builder webhook. GitHub issues remain the authoritative repair trail for failures; Slack is a non-blocking notification layer.
+
+To configure Slack notifications:
+
+1. create a Slack workflow that starts **From a webhook**
+2. add the flat text variables listed below to the webhook trigger
+3. add a Slack step that posts those variables to the release channel
+4. save the generated webhook URL as the repository secret `SLACK_RELEASE_WORKFLOW_WEBHOOK_URL`
+
+Slack workflow variables:
+
+| Variable | Description |
+| -------- | ----------- |
+| `status` | `success` or `failure` |
+| `environment` | `production` or `dry-run` |
+| `repository` | GitHub repository name |
+| `summary` | Planned release summary from the workflow |
+| `package_summary` | Package, version, and tag lines |
+| `candidate_tags` | Comma-separated candidate tags |
+| `release_urls` | GitHub release URLs for the tags |
+| `workflow_url` | GitHub Actions run URL |
+| `pull_request` | Pull request number, title, and URL when available |
+| `actor` | Merge owner or workflow actor |
+| `commit` | Short commit SHA |
+| `failed_gate` | `planning`, `checks`, `publishing`, or `none` |
+| `repair_issue_url` | GitHub repair issue URL for failed production auto-releases |
+
+The notification step uses `curl` and does not use a third-party GitHub Action. If `SLACK_RELEASE_WORKFLOW_WEBHOOK_URL` is not configured, the workflow skips Slack notification without failing the release.
+
+To test failure notifications safely, run the dry-run workflow with `send_slack_notification` and `force_failure_notification` selected. The workflow fails before release checks and before any tag or release is created, then posts a Slack failure message with `failed_gate` set to `checks`.
 
 ### How release-contract validation stays current
 

--- a/docs/release-versioning-strategy.md
+++ b/docs/release-versioning-strategy.md
@@ -26,6 +26,7 @@ For consumer migration instructions, use [Upgrading Guide](../UPGRADING.md).
 - Toolkit and React components are versioned independently
 - Consumers install packaged release artifacts, not git subdirectories
 - Canonical tag patterns are package-specific
+- Package tags are normally created by the automated release workflow after a release-intent pull request is merged to `main`
 
 ## Canonical Tag Patterns
 
@@ -34,7 +35,7 @@ For consumer migration instructions, use [Upgrading Guide](../UPGRADING.md).
 | `@ourfuturehealth/toolkit`          | `toolkit-v*`          | `toolkit-v4.13.0` |
 | `@ourfuturehealth/react-components` | `react-v*`            | `react-v0.12.0`   |
 
-The release workflow still accepts legacy toolkit tags in the `v*` format for backward compatibility, but new toolkit releases should use `toolkit-v*`.
+The manual release fallback workflow still accepts legacy toolkit tags in the `v*` format for backward compatibility, but new toolkit releases should use `toolkit-v*`.
 
 ## Release Artifact Contract
 
@@ -143,4 +144,5 @@ This table is a visual aid for pre-monorepo versus post-monorepo releases.
 - [Release Process](./release-process.md)
 - [Upgrading Guide](../UPGRADING.md)
 - [Changelog](../CHANGELOG.md)
-- [Release workflow](../.github/workflows/release.yml)
+- [Automated release workflow](../.github/workflows/auto-release.yml)
+- [Manual release fallback workflow](../.github/workflows/release.yml)

--- a/scripts/release/auto-release-plan.mjs
+++ b/scripts/release/auto-release-plan.mjs
@@ -1,0 +1,359 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+
+const packageConfigs = [
+  {
+    id: 'toolkit',
+    checkboxLabel: 'Release toolkit',
+    manifestPath: 'packages/toolkit/package.json',
+    tagPrefix: 'toolkit-v',
+  },
+  {
+    id: 'react-components',
+    checkboxLabel: 'Release React components',
+    manifestPath: 'packages/react-components/package.json',
+    tagPrefix: 'react-v',
+  },
+];
+
+const noReleaseLabel = 'No package release';
+
+function usage() {
+  console.error(`Usage:
+  auto-release-plan.mjs validate-pr --base-sha <sha> --head-sha <sha> --event-path <path>
+  auto-release-plan.mjs plan-push --base-sha <sha> --head-sha <sha> --pr-json <path> --github-output <path>
+  auto-release-plan.mjs plan-test --scope <toolkit|react-components|all> --run-id <id> --github-output <path>`);
+}
+
+function parseArgs(argv) {
+  const [command, ...tokens] = argv;
+  const args = { command };
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+
+    if (!token.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${token}`);
+    }
+
+    const key = token.slice(2);
+    const value = tokens[index + 1];
+
+    if (!value || value.startsWith('--')) {
+      throw new Error(`Missing value for --${key}`);
+    }
+
+    args[key] = value;
+    index += 1;
+  }
+
+  return args;
+}
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    ...options,
+  }).trim();
+}
+
+function commandSucceeds(command, args) {
+  try {
+    execFileSync(command, args, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readJsonAtRef(ref, filePath) {
+  return JSON.parse(run('git', ['show', `${ref}:${filePath}`]));
+}
+
+function readTextAtRef(ref, filePath) {
+  return run('git', ['show', `${ref}:${filePath}`]);
+}
+
+function readCurrentJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function readEventBody(eventPath) {
+  const event = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+  return event.pull_request?.body || '';
+}
+
+function parsePullRequest(prJsonPath) {
+  if (!prJsonPath || !fs.existsSync(prJsonPath)) {
+    return {};
+  }
+
+  const pr = JSON.parse(fs.readFileSync(prJsonPath, 'utf8'));
+  return pr && typeof pr === 'object' && !Array.isArray(pr) ? pr : {};
+}
+
+function normalizeCheckboxLabel(label) {
+  return label.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+function parseReleaseIntent(body) {
+  const selected = {
+    noRelease: false,
+    toolkit: false,
+    'react-components': false,
+  };
+  const seen = new Set();
+  const lines = body.split(/\r?\n/);
+
+  for (const line of lines) {
+    const match = line.match(/^\s*[-*]\s+\[([ xX])\]\s+(.+?)\s*$/);
+
+    if (!match) {
+      continue;
+    }
+
+    const isChecked = match[1].toLowerCase() === 'x';
+    const label = normalizeCheckboxLabel(match[2]);
+
+    if (label === normalizeCheckboxLabel(noReleaseLabel)) {
+      seen.add('noRelease');
+      selected.noRelease = isChecked;
+      continue;
+    }
+
+    for (const config of packageConfigs) {
+      if (label === normalizeCheckboxLabel(config.checkboxLabel)) {
+        seen.add(config.id);
+        selected[config.id] = isChecked;
+      }
+    }
+  }
+
+  return {
+    ...selected,
+    hasReleaseSection: seen.size > 0,
+  };
+}
+
+function readPackageStates(baseSha, headSha) {
+  return packageConfigs.map((config) => {
+    const basePackage = readJsonAtRef(baseSha, config.manifestPath);
+    const headPackage = readJsonAtRef(headSha, config.manifestPath);
+    const version = headPackage.version;
+    const previousVersion = basePackage.version;
+
+    return {
+      ...config,
+      version,
+      previousVersion,
+      changed: version !== previousVersion,
+      tag: `${config.tagPrefix}${version}`,
+    };
+  });
+}
+
+function remoteTagExists(tag) {
+  return commandSucceeds('git', ['ls-remote', '--exit-code', '--tags', 'origin', `refs/tags/${tag}`]);
+}
+
+function releaseExists(tag) {
+  const repo = process.env.GITHUB_REPOSITORY;
+
+  if (!repo) {
+    throw new Error('GITHUB_REPOSITORY is required for release existence checks.');
+  }
+
+  return commandSucceeds('gh', ['release', 'view', tag, '--repo', repo]);
+}
+
+function validateReleaseIntent({ baseSha, headSha, body, skipRemoteChecks = false }) {
+  const intent = parseReleaseIntent(body);
+  const packages = readPackageStates(baseSha, headSha);
+  const changelog = readTextAtRef(headSha, 'CHANGELOG.md');
+  const errors = [];
+  const selectedPackages = packages.filter((pkg) => intent[pkg.id]);
+  const changedPackages = packages.filter((pkg) => pkg.changed);
+
+  if (intent.noRelease && selectedPackages.length > 0) {
+    errors.push('Choose either "No package release" or specific package releases, not both.');
+  }
+
+  if (intent.noRelease && changedPackages.length > 0) {
+    errors.push(
+      `Package versions changed while "No package release" is selected: ${changedPackages
+        .map((pkg) => `${pkg.id} ${pkg.previousVersion} -> ${pkg.version}`)
+        .join(', ')}.`,
+    );
+  }
+
+  for (const pkg of changedPackages) {
+    if (!intent[pkg.id]) {
+      errors.push(
+        `${pkg.id} version changed from ${pkg.previousVersion} to ${pkg.version}, but "${pkg.checkboxLabel}" is not selected.`,
+      );
+    }
+  }
+
+  for (const pkg of selectedPackages) {
+    if (!pkg.changed) {
+      errors.push(`"${pkg.checkboxLabel}" is selected, but ${pkg.manifestPath} still has version ${pkg.version}.`);
+    }
+
+    if (!changelog.includes(pkg.tag)) {
+      errors.push(`CHANGELOG.md must include ${pkg.tag} before this package can be released.`);
+    }
+
+    if (!skipRemoteChecks) {
+      if (remoteTagExists(pkg.tag)) {
+        errors.push(`Remote tag ${pkg.tag} already exists. Auto-release will not overwrite existing tags.`);
+      }
+
+      if (releaseExists(pkg.tag)) {
+        errors.push(`GitHub release ${pkg.tag} already exists. Auto-release will not overwrite existing releases.`);
+      }
+    }
+  }
+
+  return {
+    errors,
+    packages: selectedPackages.map((pkg) => ({
+      package: pkg.id,
+      tag: pkg.tag,
+      version: pkg.version,
+      test: false,
+    })),
+    intent,
+    changedPackages,
+  };
+}
+
+function writeOutput(outputPath, key, value) {
+  if (!outputPath) {
+    return;
+  }
+
+  const serialized = typeof value === 'string' ? value : JSON.stringify(value);
+  const delimiter = `OFH_AUTO_RELEASE_${key}`;
+
+  fs.appendFileSync(outputPath, `${key}<<${delimiter}\n${serialized}\n${delimiter}\n`);
+}
+
+function printErrors(errors) {
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+}
+
+function validatePr(args) {
+  const body = readEventBody(args['event-path']);
+  const result = validateReleaseIntent({
+    baseSha: args['base-sha'],
+    headSha: args['head-sha'],
+    body,
+  });
+
+  if (result.errors.length > 0) {
+    console.error('Release intent validation failed:');
+    printErrors(result.errors);
+    process.exit(1);
+  }
+
+  if (result.packages.length === 0) {
+    process.stdout.write('Release intent validation passed. No package release requested.\n');
+    return;
+  }
+
+  process.stdout.write(`Release intent validation passed for ${result.packages.map((pkg) => pkg.tag).join(', ')}.\n`);
+}
+
+function planPush(args) {
+  const pr = parsePullRequest(args['pr-json']);
+  const body = pr.body || '';
+  const result = validateReleaseIntent({
+    baseSha: args['base-sha'],
+    headSha: args['head-sha'],
+    body,
+  });
+  const responsibleUser = pr.merged_by?.login || pr.user?.login || process.env.GITHUB_ACTOR || '';
+  const summary =
+    result.packages.length > 0
+      ? result.packages.map((pkg) => `${pkg.package}:${pkg.tag}`).join(', ')
+      : 'No package release requested.';
+
+  writeOutput(args['github-output'], 'packages', result.packages);
+  writeOutput(args['github-output'], 'has_releases', result.packages.length > 0 ? 'true' : 'false');
+  writeOutput(args['github-output'], 'responsible_user', responsibleUser);
+  writeOutput(args['github-output'], 'pr_number', pr.number ? String(pr.number) : '');
+  writeOutput(args['github-output'], 'pr_url', pr.html_url || '');
+  writeOutput(args['github-output'], 'pr_title', pr.title || '');
+  writeOutput(args['github-output'], 'summary', summary);
+
+  if (result.errors.length > 0) {
+    console.error('Auto-release planning failed:');
+    printErrors(result.errors);
+    process.exit(1);
+  }
+
+  process.stdout.write(`${summary}\n`);
+}
+
+function planTest(args) {
+  const scope = args.scope;
+  const runId = args['run-id'];
+  const selectedPackages =
+    scope === 'all'
+      ? packageConfigs
+      : packageConfigs.filter((config) => config.id === scope);
+
+  if (selectedPackages.length === 0) {
+    throw new Error(`Unsupported test release scope: ${scope}`);
+  }
+
+  const packages = selectedPackages.map((config) => {
+    const version = readCurrentJson(config.manifestPath).version;
+    const packageName = config.id === 'toolkit' ? 'toolkit' : 'react';
+    const tag = `auto-release-test-${packageName}-v${version}-${runId}`;
+
+    return {
+      package: config.id,
+      tag,
+      version,
+      test: true,
+    };
+  });
+
+  writeOutput(args['github-output'], 'packages', packages);
+  writeOutput(args['github-output'], 'has_releases', 'true');
+  writeOutput(args['github-output'], 'responsible_user', process.env.GITHUB_ACTOR || '');
+  writeOutput(args['github-output'], 'pr_number', '');
+  writeOutput(args['github-output'], 'pr_url', '');
+  writeOutput(args['github-output'], 'pr_title', 'Workflow dispatch dry run');
+  writeOutput(args['github-output'], 'summary', packages.map((pkg) => `${pkg.package}:${pkg.tag}`).join(', '));
+
+  process.stdout.write(`Dry-run release plan: ${packages.map((pkg) => pkg.tag).join(', ')}\n`);
+}
+
+try {
+  const args = parseArgs(process.argv.slice(2));
+
+  switch (args.command) {
+    case 'validate-pr':
+      validatePr(args);
+      break;
+    case 'plan-push':
+      planPush(args);
+      break;
+    case 'plan-test':
+      planTest(args);
+      break;
+    default:
+      usage();
+      process.exit(1);
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/scripts/release/notify-auto-release-failure.mjs
+++ b/scripts/release/notify-auto-release-failure.mjs
@@ -68,6 +68,15 @@ function writeTempBody(body) {
   return bodyPath;
 }
 
+function writeOutput(key, value) {
+  if (!process.env.GITHUB_OUTPUT) {
+    return;
+  }
+
+  const delimiter = `OFH_AUTO_RELEASE_${key}`;
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `${key}<<${delimiter}\n${value}\n${delimiter}\n`);
+}
+
 function createIssue(title, bodyPath, assignee) {
   const args = ['issue', 'create', '--title', title, '--body-file', bodyPath, '--label', 'auto-release'];
 
@@ -137,8 +146,11 @@ const existingIssue = findExistingIssue(title);
 
 if (existingIssue) {
   run('gh', ['issue', 'comment', String(existingIssue), '--body-file', bodyPath]);
+  const issueUrl = `https://github.com/${process.env.GITHUB_REPOSITORY}/issues/${existingIssue}`;
+  writeOutput('issue_url', issueUrl);
   process.stdout.write(`Updated existing auto-release repair issue #${existingIssue}.\n`);
 } else {
   const issueUrl = createIssue(title, bodyPath, responsibleUser);
+  writeOutput('issue_url', issueUrl);
   process.stdout.write(`Created auto-release repair issue: ${issueUrl}\n`);
 }

--- a/scripts/release/notify-auto-release-failure.mjs
+++ b/scripts/release/notify-auto-release-failure.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    ...options,
+  }).trim();
+}
+
+function commandSucceeds(command, args) {
+  try {
+    execFileSync(command, args, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function safeJsonParse(value, fallback) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return fallback;
+  }
+}
+
+function createOrUpdateLabel() {
+  commandSucceeds('gh', [
+    'label',
+    'create',
+    'auto-release',
+    '--color',
+    'B60205',
+    '--description',
+    'Automated release repair follow-up',
+    '--force',
+  ]);
+}
+
+function findExistingIssue(title) {
+  const raw = run('gh', [
+    'issue',
+    'list',
+    '--state',
+    'open',
+    '--label',
+    'auto-release',
+    '--json',
+    'number,title',
+    '--limit',
+    '100',
+  ]);
+  const issues = safeJsonParse(raw, []);
+  const existing = issues.find((issue) => issue.title === title);
+
+  return existing?.number;
+}
+
+function writeTempBody(body) {
+  const bodyPath = path.join(os.tmpdir(), `auto-release-failure-${Date.now()}.md`);
+  fs.writeFileSync(bodyPath, body);
+  return bodyPath;
+}
+
+function createIssue(title, bodyPath, assignee) {
+  const args = ['issue', 'create', '--title', title, '--body-file', bodyPath, '--label', 'auto-release'];
+
+  if (assignee) {
+    args.push('--assignee', assignee);
+  }
+
+  try {
+    return run('gh', args);
+  } catch (error) {
+    if (!assignee) {
+      throw error;
+    }
+
+    console.error(`Could not assign issue to ${assignee}; creating without assignee.`);
+    return run('gh', ['issue', 'create', '--title', title, '--body-file', bodyPath, '--label', 'auto-release']);
+  }
+}
+
+const shortSha = (process.env.GITHUB_SHA || '').slice(0, 7) || 'unknown';
+const title = `[auto-release] Repair release for ${shortSha}`;
+const responsibleUser = process.env.RESPONSIBLE_USER || process.env.GITHUB_ACTOR || '';
+const workflowUrl = process.env.WORKFLOW_URL || '';
+const packages = safeJsonParse(process.env.PACKAGES_JSON || '[]', []);
+const packageSummary =
+  packages.length > 0
+    ? packages.map((pkg) => `- ${pkg.package}: \`${pkg.tag}\``).join('\n')
+    : '- No candidate package metadata was available. Check the planning job logs.';
+const mention = responsibleUser ? `@${responsibleUser}` : 'the merge owner';
+const prLine = process.env.PR_URL
+  ? `[${process.env.PR_TITLE || `PR #${process.env.PR_NUMBER}`}](${process.env.PR_URL})`
+  : process.env.PR_NUMBER
+    ? `PR #${process.env.PR_NUMBER}`
+    : 'No associated PR was found.';
+
+const body = `Auto-release failed for ${mention}.
+
+## Context
+
+- Commit: \`${process.env.GITHUB_SHA || 'unknown'}\`
+- Workflow: ${workflowUrl || 'unknown'}
+- Pull request: ${prLine}
+- Planned release summary: ${process.env.RELEASE_SUMMARY || 'unknown'}
+
+## Candidate Releases
+
+${packageSummary}
+
+## Job Results
+
+- Planning: ${process.env.PLAN_RESULT || 'unknown'}
+- Checks: ${process.env.CHECKS_RESULT || 'unknown'}
+- Publishing: ${process.env.PUBLISH_RESULT || 'unknown'}
+
+## Repair Steps
+
+1. Open the failed workflow run and inspect the first failed job.
+2. Fix the failing check on a new PR into \`main\`.
+3. If a partial tag or release was created, delete the incorrect remote tag and GitHub release intentionally before retrying.
+4. Use the **Manual release fallback** workflow only when the automated path cannot be repaired by a normal follow-up PR.
+`;
+
+createOrUpdateLabel();
+
+const bodyPath = writeTempBody(body);
+const existingIssue = findExistingIssue(title);
+
+if (existingIssue) {
+  run('gh', ['issue', 'comment', String(existingIssue), '--body-file', bodyPath]);
+  process.stdout.write(`Updated existing auto-release repair issue #${existingIssue}.\n`);
+} else {
+  const issueUrl = createIssue(title, bodyPath, responsibleUser);
+  process.stdout.write(`Created auto-release repair issue: ${issueUrl}\n`);
+}

--- a/scripts/release/notify-auto-release-slack.sh
+++ b/scripts/release/notify-auto-release-slack.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+packages_json="${PACKAGES_JSON:-[]}"
+if ! jq -e . >/dev/null 2>&1 <<< "${packages_json}"; then
+  packages_json='[]'
+fi
+
+repository="${GITHUB_REPOSITORY:-${REPOSITORY:-unknown}}"
+commit_sha="${GITHUB_SHA:-${COMMIT_SHA:-unknown}}"
+short_sha="${commit_sha:0:7}"
+responsible_user="${RESPONSIBLE_USER:-${GITHUB_ACTOR:-unknown}}"
+
+package_summary=$(jq -r '
+  if type == "array" and length > 0 then
+    map("\(.package) \(.version) -> \(.tag)") | join("\n")
+  else
+    "No candidate packages"
+  end
+' <<< "${packages_json}")
+
+candidate_tags=$(jq -r '
+  if type == "array" and length > 0 then
+    map(.tag) | join(", ")
+  else
+    "none"
+  end
+' <<< "${packages_json}")
+
+release_urls=$(jq -r --arg repository "${repository}" '
+  if type == "array" and length > 0 then
+    map("https://github.com/\($repository)/releases/tag/\(.tag)") | join("\n")
+  else
+    ""
+  end
+' <<< "${packages_json}")
+
+release_environment=$(jq -r '
+  if type == "array" and length > 0 and ([.[].test] | all) then
+    "dry-run"
+  else
+    "production"
+  end
+' <<< "${packages_json}")
+
+pull_request='No associated pull request'
+if [[ -n "${PR_URL:-}" ]]; then
+  pull_request="#${PR_NUMBER:-unknown} ${PR_TITLE:-unknown} ${PR_URL}"
+elif [[ -n "${PR_NUMBER:-}" ]]; then
+  pull_request="#${PR_NUMBER} ${PR_TITLE:-unknown}"
+fi
+
+payload=$(jq -n \
+  --arg status "${RELEASE_STATUS:-unknown}" \
+  --arg environment "${release_environment}" \
+  --arg repository "${repository}" \
+  --arg summary "${RELEASE_SUMMARY:-unknown}" \
+  --arg package_summary "${package_summary}" \
+  --arg candidate_tags "${candidate_tags}" \
+  --arg release_urls "${release_urls}" \
+  --arg workflow_url "${WORKFLOW_URL:-unknown}" \
+  --arg pull_request "${pull_request}" \
+  --arg actor "${responsible_user}" \
+  --arg commit "${short_sha}" \
+  --arg failed_gate "${FAILED_GATE:-none}" \
+  --arg repair_issue_url "${REPAIR_ISSUE_URL:-}" \
+  '{
+    status: $status,
+    environment: $environment,
+    repository: $repository,
+    summary: $summary,
+    package_summary: $package_summary,
+    candidate_tags: $candidate_tags,
+    release_urls: $release_urls,
+    workflow_url: $workflow_url,
+    pull_request: $pull_request,
+    actor: $actor,
+    commit: $commit,
+    failed_gate: $failed_gate,
+    repair_issue_url: $repair_issue_url
+  }')
+
+if [[ "${SLACK_RELEASE_NOTIFY_DRY_RUN:-false}" == 'true' ]]; then
+  printf '%s\n' "${payload}"
+  exit 0
+fi
+
+if [[ -z "${SLACK_RELEASE_WORKFLOW_WEBHOOK_URL:-}" ]]; then
+  echo 'SLACK_RELEASE_WORKFLOW_WEBHOOK_URL is not configured; skipping Slack release notification.'
+  exit 0
+fi
+
+curl \
+  --fail \
+  --silent \
+  --show-error \
+  --request POST \
+  --header 'Content-Type: application/json' \
+  --data "${payload}" \
+  "${SLACK_RELEASE_WORKFLOW_WEBHOOK_URL}"
+
+echo 'Slack release notification sent.'

--- a/scripts/release/publish-auto-release.sh
+++ b/scripts/release/publish-auto-release.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF' >&2
+Usage: publish-auto-release.sh --package <toolkit|react-components> --tag <tag> --target <sha> --expected-version <version> [--stage-dir <dir>] [--test-release] [--keep-test-release]
+EOF
+}
+
+current_step='initializing auto-release publishing'
+package=''
+tag=''
+target=''
+expected_version=''
+stage_dir=''
+test_release=false
+keep_test_release=false
+tag_created=false
+
+on_error() {
+  printf 'Auto-release publishing failed while %s.\n' "${current_step}" >&2
+}
+
+is_safe_test_tag() {
+  [[ "${tag}" == auto-release-test-* ]]
+}
+
+cleanup_test_release() {
+  if [[ "${test_release}" != true || "${keep_test_release}" == true ]]; then
+    return
+  fi
+
+  if ! is_safe_test_tag; then
+    printf 'Refusing to clean up non-test tag: %s\n' "${tag}" >&2
+    return
+  fi
+
+  printf 'Cleaning up dry-run release %s\n' "${tag}"
+  gh release delete "${tag}" --repo "${GITHUB_REPOSITORY}" --yes --cleanup-tag >/dev/null 2>&1 || true
+
+  if [[ "${tag_created}" == true ]]; then
+    git push origin ":refs/tags/${tag}" >/dev/null 2>&1 || true
+  fi
+}
+
+trap on_error ERR
+trap cleanup_test_release EXIT
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --package)
+      package="$2"
+      shift 2
+      ;;
+    --tag)
+      tag="$2"
+      shift 2
+      ;;
+    --target)
+      target="$2"
+      shift 2
+      ;;
+    --expected-version)
+      expected_version="$2"
+      shift 2
+      ;;
+    --stage-dir)
+      stage_dir="$2"
+      shift 2
+      ;;
+    --test-release)
+      test_release=true
+      shift
+      ;;
+    --keep-test-release)
+      keep_test_release=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${package}" || -z "${tag}" || -z "${target}" || -z "${expected_version}" ]]; then
+  usage
+  exit 1
+fi
+
+case "${package}" in
+  toolkit|react-components)
+    ;;
+  *)
+    echo "Unsupported package: ${package}" >&2
+    exit 1
+    ;;
+esac
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+cd "${repo_root}"
+
+if [[ "${test_release}" == true && "${keep_test_release}" != true && ! "${tag}" == auto-release-test-* ]]; then
+  echo "Dry-run releases must use an auto-release-test-* tag." >&2
+  exit 1
+fi
+
+if [[ -z "${stage_dir}" ]]; then
+  stage_dir=$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/ofh-auto-release.${package}.XXXXXX")
+fi
+
+mkdir -p "${stage_dir}"
+metadata_file=$(mktemp)
+notes_path=$(mktemp)
+
+current_step="checking whether ${tag} already exists"
+if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+  echo "Remote tag ${tag} already exists. Auto-release will not overwrite existing tags." >&2
+  exit 1
+fi
+
+if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+  echo "GitHub release ${tag} already exists. Auto-release will not overwrite existing releases." >&2
+  exit 1
+fi
+
+current_step="preparing ${package} release assets"
+"${repo_root}/scripts/release/prepare-release-artifacts.sh" \
+  "${package}" \
+  --stage-dir "${stage_dir}" \
+  --metadata-file "${metadata_file}"
+# shellcheck disable=SC1090
+source "${metadata_file}"
+
+if [[ "${VERSION}" != "${expected_version}" ]]; then
+  echo "Expected ${package} version ${expected_version}, but prepared ${VERSION}." >&2
+  exit 1
+fi
+
+current_step="smoke testing ${package} release tarball"
+"${repo_root}/scripts/release/smoke-package-tarball.sh" \
+  --package-dir "${PACKAGE_DIR}" \
+  --tarball "${TARBALL_PATH}" \
+  --managers 'yarn,npm,pnpm'
+
+current_step="rendering ${package} release notes"
+if [[ "${package}" == 'toolkit' ]]; then
+  "${repo_root}/scripts/release/render-release-notes.sh" \
+    --package "${package}" \
+    --tag "${tag}" \
+    --version "${VERSION}" \
+    --tarball "${TARBALL_NAME}" \
+    --zip "${ZIP_NAME}" > "${notes_path}"
+else
+  "${repo_root}/scripts/release/render-release-notes.sh" \
+    --package "${package}" \
+    --tag "${tag}" \
+    --version "${VERSION}" \
+    --tarball "${TARBALL_NAME}" > "${notes_path}"
+fi
+
+current_step="creating annotated tag ${tag}"
+git tag -a "${tag}" "${target}" -m "Release ${package} v${VERSION}"
+git push origin "refs/tags/${tag}"
+tag_created=true
+
+current_step="creating GitHub release ${tag}"
+release_flags=()
+if [[ "${test_release}" == true ]]; then
+  release_flags+=(--draft --prerelease)
+fi
+
+gh release create "${tag}" \
+  --repo "${GITHUB_REPOSITORY}" \
+  --target "${target}" \
+  --title "${tag}" \
+  --notes-file "${notes_path}" \
+  --verify-tag \
+  "${release_flags[@]}"
+
+current_step="uploading GitHub release assets for ${tag}"
+if [[ "${package}" == 'toolkit' ]]; then
+  gh release upload "${tag}" "${ZIP_PATH}" "${TARBALL_PATH}" --repo "${GITHUB_REPOSITORY}"
+  expected_assets=("${ZIP_NAME}" "${TARBALL_NAME}")
+else
+  gh release upload "${tag}" "${TARBALL_PATH}" --repo "${GITHUB_REPOSITORY}"
+  expected_assets=("${TARBALL_NAME}")
+fi
+
+current_step="verifying GitHub release assets for ${tag}"
+asset_names=$(gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" --json assets --jq '.assets[].name')
+for asset in "${expected_assets[@]}"; do
+  if ! grep -Fxq "${asset}" <<< "${asset_names}"; then
+    echo "Missing expected release asset ${asset} on ${tag}." >&2
+    exit 1
+  fi
+done
+
+printf 'Published %s release %s with assets:\n' "${package}" "${tag}"
+printf '  %s\n' "${expected_assets[@]}"

--- a/scripts/release/validate-release-docs.sh
+++ b/scripts/release/validate-release-docs.sh
@@ -56,8 +56,8 @@ else
 fi
 
 # This validator protects the published consumer install contract.
-# It intentionally scans tracked Markdown, workflow, and shell files so new docs
-# are picked up automatically without maintaining a brittle file allowlist.
+# It intentionally scans tracked Markdown, release JavaScript, workflow, and shell files
+# so new docs and release automation are picked up automatically without maintaining a brittle file allowlist.
 # If consumer-facing release docs move to a new file type, update this script and
 # docs/release-process.md together.
 tracked_text_files=()
@@ -65,9 +65,9 @@ while IFS= read -r path; do
   if [[ -n "${path}" && "${path}" != 'CHANGELOG.md' ]]; then
     tracked_text_files+=("${path}")
   fi
-done < <(git ls-files -- '*.md' '*.sh' '*.yml' '*.yaml')
+done < <(git ls-files -- '*.md' '*.mjs' '*.sh' '*.yml' '*.yaml')
 
-print_success "Collected ${#tracked_text_files[@]} tracked Markdown, shell, and workflow files"
+print_success "Collected ${#tracked_text_files[@]} tracked Markdown, release script, shell, and workflow files"
 
 broken_git_subdir_pattern=':pack''ages/'
 stale_pre_monorepo_version='v3.4.''3'


### PR DESCRIPTION
## Description

Automates the release tagging step that currently happens manually after a PR is merged to `main`.

Today, after release checks pass, a maintainer still has to pull latest `main`, create the correct package tag locally, and push it so the release artifacts are published. This PR moves that into GitHub Actions while keeping the existing tag-triggered release workflow as a manual fallback.

## What changed

- Adds a new **Automated release** workflow.
- Adds PR-time validation for release intent.
- Uses PR-template checkboxes as the release source of truth:
  - `No package release`
  - `Release toolkit`
  - `Release React components`
- On merge to `main`, derives release tags from package versions:
  - `toolkit-v{version}`
  - `react-v{version}`
- Requires the candidate tag to be mentioned in `CHANGELOG.md`.
- Runs lint, tests, build, release-contract docs, asset preparation, and tarball smoke tests before publishing.
- Creates annotated tags, GitHub releases, and release assets only after all release gates pass.
- Refuses to overwrite existing tags or releases.
- Creates a GitHub repair issue if an auto-release fails.
- Renames the existing tag-triggered workflow to **Manual release fallback**.

## Why

This removes a fragile manual release step while keeping release intent explicit in the PR. The workflow should only publish when a maintainer has deliberately selected a package release checkbox and bumped the matching package version.

## Review focus

Please check:

- whether the PR checkbox release intent is clear enough for maintainers
- whether the validation rules catch the right mistakes before merge
- whether the auto-release workflow has the right gates before creating tags/releases
- whether the duplicate tag/release behavior is appropriately conservative
- whether the manual fallback path is documented clearly enough

## Testing done

- PR validation workflow passed on this PR with `No package release`.
- Branch dry-run of the automated release workflow completed successfully.
- Dry-run created fake toolkit and React release tags, draft prereleases, and uploaded/verifed release assets.
- Confirmed production workflow is back to `push` on `main` only.
- Ran local validation:
  - `node --check` for new release scripts
  - `bash -n` for release shell scripts
  - workflow YAML parsing
  - `pnpm exec eslint scripts/release/*.mjs --max-warnings 0`
  - `pnpm docs:release-contract`
  - `pnpm lint`
  - `pnpm build`
  - `npm test`

## Release

- [x] No package release
- [ ] Release toolkit
- [ ] Release React components
