### PR TITLE
PC-621: Cloudsmith setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,16 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
+registries:
+  cloudsmith-npm:
+    type: npm-registry
+    url: https://npm.pkg.ofh.org.uk/npm/
+    token: ${{ secrets.CLOUDSMITH_NPM_RO_TOKEN }}
+    replaces-base: true
 updates:
-  - package-ecosystem: "" # See documentation for possible values
+  - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    registries:
+      - cloudsmith-npm

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,13 +6,15 @@ jobs:
   build:
     name: Pull request
     runs-on: ubuntu-latest
+    # env:
+    #   CLOUDSMITH_NPM_REGISTRY_TOKEN: ${{ secrets.CLOUDSMITH_NPM_RO_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: "22.x"
 
       - name: Enable Corepack and pnpm
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,8 +21,11 @@ jobs:
           corepack enable
           corepack prepare pnpm@10.29.2 --activate
 
+      - name: Debug
+        run: pnpm config list
+
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --reporter=verbose
 
       - name: Run linting
         run: pnpm run lint

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,15 +6,18 @@ jobs:
   build:
     name: Pull request
     runs-on: ubuntu-latest
-    env:
-      CLOUDSMITH_NPM_REGISTRY_TOKEN: ${{ secrets.CLOUDSMITH_NPM_RO_TOKEN }}
+    # env:
+    #   CLOUDSMITH_NPM_REGISTRY_TOKEN: ${{ secrets.CLOUDSMITH_NPM_RO_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.CLOUDSMITH_NPM_RO_TOKEN }}
         with:
           node-version: "22.x"
+          registry-url: //${{ vars.CLOUDSMITH_NPM_URL }}/npm/
 
       - name: Enable Corepack and pnpm
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,8 +6,8 @@ jobs:
   build:
     name: Pull request
     runs-on: ubuntu-latest
-    # env:
-    #   CLOUDSMITH_NPM_REGISTRY_TOKEN: ${{ secrets.CLOUDSMITH_NPM_RO_TOKEN }}
+    env:
+      CLOUDSMITH_NPM_REGISTRY_TOKEN: ${{ secrets.CLOUDSMITH_NPM_RO_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,11 +24,8 @@ jobs:
           corepack enable
           corepack prepare pnpm@10.29.2 --activate
 
-      - name: Debug
-        run: pnpm config list
-
       - name: Install dependencies
-        run: pnpm install --reporter=ndjson
+        run: pnpm install
 
       - name: Run linting
         run: pnpm run lint

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,7 +17,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.CLOUDSMITH_NPM_RO_TOKEN }}
         with:
           node-version: "22.x"
-          registry-url: //${{ vars.CLOUDSMITH_NPM_URL }}/npm/
+          registry-url: http://npm.pkg.ofh.org.uk/npm/
 
       - name: Enable Corepack and pnpm
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,8 +6,8 @@ jobs:
   build:
     name: Pull request
     runs-on: ubuntu-latest
-    # env:
-    #   CLOUDSMITH_NPM_REGISTRY_TOKEN: ${{ secrets.CLOUDSMITH_NPM_RO_TOKEN }}
+    env:
+      CLOUDSMITH_NPM_REGISTRY_TOKEN: ${{ secrets.CLOUDSMITH_NPM_RO_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -17,7 +17,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.CLOUDSMITH_NPM_RO_TOKEN }}
         with:
           node-version: "22.x"
-          registry-url: http://npm.pkg.ofh.org.uk/npm/
+          registry-url: ${{ vars.CLOUDSMITH_NPM_URL }}
 
       - name: Enable Corepack and pnpm
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,7 +25,7 @@ jobs:
         run: pnpm config list
 
       - name: Install dependencies
-        run: pnpm install --reporter=verbose
+        run: pnpm install --reporter=ndjson
 
       - name: Run linting
         run: pnpm run lint

--- a/.github/workflows/release-contract.yml
+++ b/.github/workflows/release-contract.yml
@@ -3,31 +3,33 @@ name: Release contract
 on:
   pull_request:
     paths:
-      - '.github/workflows/release.yml'
-      - '.github/workflows/release-contract.yml'
-      - 'README.md'
-      - 'UPGRADING.md'
-      - 'docs/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'packages/toolkit/gulpfile.js'
-      - 'packages/toolkit/package.json'
-      - 'packages/react-components/package.json'
-      - 'packages/react-components/README.md'
-      - 'packages/react-components/scripts/**'
-      - 'scripts/release/**'
+      - ".github/workflows/release.yml"
+      - ".github/workflows/release-contract.yml"
+      - "README.md"
+      - "UPGRADING.md"
+      - "docs/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "packages/toolkit/gulpfile.js"
+      - "packages/toolkit/package.json"
+      - "packages/react-components/package.json"
+      - "packages/react-components/README.md"
+      - "packages/react-components/scripts/**"
+      - "scripts/release/**"
 
 jobs:
   validate:
     name: Validate release contract
     runs-on: ubuntu-latest
+    env:
+      CLOUDSMITH_NPM_REGISTRY_TOKEN: ${{ secrets.CLOUDSMITH_NPM_RO_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: "22.x"
 
       - name: Enable Corepack and pnpm
         run: |

--- a/.github/workflows/release-contract.yml
+++ b/.github/workflows/release-contract.yml
@@ -21,8 +21,8 @@ jobs:
   validate:
     name: Validate release contract
     runs-on: ubuntu-latest
-    env:
-      CLOUDSMITH_NPM_REGISTRY_TOKEN: ${{ secrets.CLOUDSMITH_NPM_RO_TOKEN }}
+    # env:
+    #   CLOUDSMITH_NPM_REGISTRY_TOKEN: ${{ secrets.CLOUDSMITH_NPM_RO_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -38,6 +38,9 @@ jobs:
         run: |
           corepack enable
           corepack prepare pnpm@10.29.2 --activate
+
+      - name: Debug
+        run: pnpm config list
 
       - name: Install dependencies for release-contract checks
         run: pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/release-contract.yml
+++ b/.github/workflows/release-contract.yml
@@ -21,8 +21,8 @@ jobs:
   validate:
     name: Validate release contract
     runs-on: ubuntu-latest
-    # env:
-    #   CLOUDSMITH_NPM_REGISTRY_TOKEN: ${{ secrets.CLOUDSMITH_NPM_RO_TOKEN }}
+    env:
+      CLOUDSMITH_NPM_REGISTRY_TOKEN: ${{ secrets.CLOUDSMITH_NPM_RO_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-contract.yml
+++ b/.github/workflows/release-contract.yml
@@ -28,8 +28,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.CLOUDSMITH_NPM_RO_TOKEN }}
         with:
           node-version: "22.x"
+          registry-url: ${{ vars.CLOUDSMITH_NPM_URL }}
 
       - name: Enable Corepack and pnpm
         run: |

--- a/.github/workflows/release-contract.yml
+++ b/.github/workflows/release-contract.yml
@@ -39,9 +39,6 @@ jobs:
           corepack enable
           corepack prepare pnpm@10.29.2 --activate
 
-      - name: Debug
-        run: pnpm config list
-
       - name: Install dependencies for release-contract checks
         run: pnpm install --frozen-lockfile --ignore-scripts
 
@@ -49,4 +46,6 @@ jobs:
         run: pnpm docs:release-contract
 
       - name: Prepare and smoke test current release artifacts
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org # use default npm registry instead of cloudsmith to simulate package consumer
         run: pnpm smoke:release-artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,16 @@ name: Create release
 on:
   push:
     tags:
-      - 'v*' # Toolkit releases (backward compatible)
-      - 'toolkit-v*' # Toolkit releases (new pattern)
-      - 'react-v*' # React components releases
+      - "v*" # Toolkit releases (backward compatible)
+      - "toolkit-v*" # Toolkit releases (new pattern)
+      - "react-v*" # React components releases
 
 jobs:
   build:
     name: Create release
     runs-on: ubuntu-latest
+    env:
+      CLOUDSMITH_NPM_REGISTRY_TOKEN: ${{ secrets.CLOUDSMITH_NPM_RO_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -19,7 +21,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: "22.x"
 
       - name: Enable Corepack and pnpm
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,8 @@ jobs:
           fi
 
       - name: Smoke test release tarball
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org # use default npm registry instead of cloudsmith to simulate package consumer
         run: |
           ./scripts/release/smoke-package-tarball.sh \
             --package-dir "${{ github.workspace }}/${{ steps.package_info.outputs.PACKAGE_DIR }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,11 @@ jobs:
           persist-credentials: false
 
       - uses: actions/setup-node@v4
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.CLOUDSMITH_NPM_RO_TOKEN }}
         with:
           node-version: "22.x"
+          registry-url: ${{ vars.CLOUDSMITH_NPM_URL }}
 
       - name: Enable Corepack and pnpm
         run: |

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=http://npm.pkg.ofh.org.uk/npm/
+//npm.pkg.ofh.org.uk/npm/:_authToken=${CLOUDSMITH_NPM_REGISTRY_TOKEN}

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ nvm use
 nvm install
 ```
 
+## NPM Registry Configuration
+
+- **Public packages**: All packages from the public npm registry are fetched from the Cloudsmith registry. Authentication is provided via the `CLOUDSMITH_NPM_REGISTRY_TOKEN` environment variable. See [doc for instructions](https://ourfuturehealth.atlassian.net/wiki/x/FQDAtg). The relevant settings are in the `.npmrc` file.
+
 ## Quick Start
 
 ```bash

--- a/scripts/release/.yarnrc
+++ b/scripts/release/.yarnrc
@@ -1,2 +1,0 @@
-registry "http://npm.pkg.ofh.org.uk/npm/"
-"//npm.pkg.ofh.org.uk/npm/:_authToken" "${CLOUDSMITH_NPM_REGISTRY_TOKEN}"

--- a/scripts/release/.yarnrc
+++ b/scripts/release/.yarnrc
@@ -1,0 +1,2 @@
+registry "http://npm.pkg.ofh.org.uk/npm/"
+"//npm.pkg.ofh.org.uk/npm/:_authToken" "${CLOUDSMITH_NPM_REGISTRY_TOKEN}"


### PR DESCRIPTION
## Description

Adds setup to pull public npm packages via Cloudsmith.

[PC-621](https://ourfuturehealth.atlassian.net/browse/PC-621)

### Testing

1. Pull down the branch and run `pnpm store prune && pnpm install --force` to trigger a fresh install ignoring cache. You should see this fail with authentication errors if you don't already have the personal Cloudsmith token configured. Otherwise, misconfigure your token to see installation fail with 401 authentication errors.
2. If you don't already have one, generate a personal token via https://app.cloudsmith.com/settings/api-keys
3. Set it as a local env var `CLOUDSMITH_NPM_REGISTRY_TOKEN`. You can use this [doc](https://ourfuturehealth.atlassian.net/wiki/spaces/PP/pages/1763934215/Authentication+to+Github+Packages#How-to-set-this-environment-variable-locally%3F) as a reference.

3. Run `pnpm store prune && pnpm install --force` again and see installation succeed

[PC-621]: https://ourfuturehealth.atlassian.net/browse/PC-621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ