### PR TITLE
DSE-343: add Light Hero theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ## Monorepo Package Releases (`toolkit-v*`, `react-v*`)
 
+### 2026-07-14
+
+#### @ourfuturehealth/toolkit 4.24.0 (`toolkit-v4.24.0`)
+
+##### Added
+
+- Added the `light` Hero theme, with the Light Header's yellow surface, dark text and links, brand Tile Pattern decoration, and free/boxed docs examples
+
+##### Changed
+
+- Aligned boxed Hero media overlap to `32px` at tablet and larger breakpoints, matching the current Figma component
+
+#### @ourfuturehealth/react-components 0.23.0 (`react-v0.23.0`)
+
+##### Added
+
+- Added the public React Hero `light` theme, including TypeScript support, Storybook examples, and unit coverage
+
 ### 2026-07-13
 
 #### @ourfuturehealth/toolkit 4.23.0 (`toolkit-v4.23.0`)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,6 +8,7 @@ This guide provides detailed migration instructions for upgrading between versio
 
 | Version                                                 | Date          | Breaking Changes           | Migration Complexity                     |
 | ------------------------------------------------------- | ------------- | -------------------------- | ---------------------------------------- |
+| [v4.24.0 / React v0.23.0](#upgrading-to-v4240--react-v0230) | July 2026     | No breaking changes        | 🟢 Low - use the Light Hero theme where it pairs with a Light Header |
 | [v4.23.0 / React v0.22.0](#upgrading-to-v4230--react-v0220) | July 2026     | Hero macro API update      | 🟡 Medium - update old Hero `text` / `imageURL` usages before adopting the new Hero |
 | [v4.22.0 / React v0.21.0](#upgrading-to-v4220--react-v0210) | June 2026     | No breaking changes        | 🟢 Low - adopt the new public Header surfaces where needed |
 | [v4.21.0 / React v0.20.0](#upgrading-to-v4210--react-v0200) | April 2026    | No breaking changes        | 🟢 Low - adopt the new public Search surfaces where needed |
@@ -31,6 +32,47 @@ This guide provides detailed migration instructions for upgrading between versio
 | [v4.3.0 / React v0.2.0](#upgrading-to-v430--react-v020) | March 2026    | Button variant naming      | 🟡 Medium - Find/replace required        |
 | [v4.1.0](#upgrading-to-v410)                            | February 2026 | Spacing scale indices      | 🟡 Medium - Index updates required       |
 | [v4.0.0](#upgrading-to-v400-monorepo-restructure)       | 2025          | Monorepo restructure       | 🔴 High - Installation & paths change    |
+
+---
+
+## Upgrading to v4.24.0 / React v0.23.0
+
+**Released:** July 2026
+**Affected packages:**
+
+- `@ourfuturehealth/toolkit` v4.24.0+
+- `@ourfuturehealth/react-components` v0.23.0+
+
+### Breaking Changes
+
+None.
+
+### Release Overview
+
+This release adds the `light` Hero theme in toolkit and React. It is intended for pages that use the Light Header and has a yellow surface, dark content, standard link states, and brand Tile Pattern decoration.
+
+Boxed Heroes with media now use a `32px` content overlap at tablet and desktop widths, matching the current Figma component.
+
+### Migration Steps
+
+1. Existing Hero usage does not need to change.
+2. Use `theme: "light"` when a Hero should pair with the Light Header.
+3. Recheck boxed Heroes with media at tablet and desktop widths if their layout relied on the previous `64px` desktop overlap.
+
+#### Toolkit example
+
+```njk
+{{ hero({
+  "theme": "light",
+  "heading": "Take part in health research"
+}) }}
+```
+
+#### React example
+
+```tsx
+<Hero theme="light" heading="Take part in health research" />
+```
 
 ---
 

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/react-components",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "type": "module",
   "description": "React component library for OFH Design System",
   "packageManager": "pnpm@10.29.2",

--- a/packages/react-components/src/components/Hero/Hero.stories.tsx
+++ b/packages/react-components/src/components/Hero/Hero.stories.tsx
@@ -303,7 +303,7 @@ const meta: Meta<HeroStoryArgs> = {
   argTypes: {
     theme: {
       control: 'radio',
-      options: ['brand', 'dark'],
+      options: ['brand', 'dark', 'light'],
       description: 'Hero colour theme.',
     },
     variant: {
@@ -430,6 +430,20 @@ export const AllActionsFreeDark: Story = {
   },
 };
 
+export const AllActionsFreeLight: Story = {
+  name: 'All actions - Free - Light',
+  args: {
+    ...allActionsContent,
+    theme: 'light',
+    image: portraitImages[0],
+    showButton: undefined,
+    showTextLink: undefined,
+  },
+  parameters: {
+    ...disabledControls,
+  },
+};
+
 export const AllActionsBoxedBrand: Story = {
   name: 'All actions - Boxed - Brand',
   args: {
@@ -451,6 +465,21 @@ export const AllActionsBoxedDark: Story = {
     theme: 'dark',
     variant: 'boxed',
     image: portraitImages[0],
+    showButton: undefined,
+    showTextLink: undefined,
+  },
+  parameters: {
+    ...disabledControls,
+  },
+};
+
+export const AllActionsBoxedLight: Story = {
+  name: 'All actions - Boxed - Light',
+  args: {
+    ...allActionsContent,
+    theme: 'light',
+    variant: 'boxed',
+    image: portraitImages[1],
     showButton: undefined,
     showTextLink: undefined,
   },

--- a/packages/react-components/src/components/Hero/Hero.test.tsx
+++ b/packages/react-components/src/components/Hero/Hero.test.tsx
@@ -73,6 +73,25 @@ describe('Hero', () => {
     expect(document.querySelector('.ofh-hero__media-column')).toBeNull();
   });
 
+  it('supports light heroes with brand tile decoration', () => {
+    render(
+      <Hero
+        theme="light"
+        variant="boxed"
+        heading="Light hero"
+      />,
+    );
+
+    expect(document.querySelector('.ofh-hero')).toHaveClass(
+      'ofh-hero--light',
+      'ofh-hero--boxed',
+    );
+    expect(document.querySelectorAll('.ofh-hero__decoration')).toHaveLength(3);
+    expect(document.querySelector('.ofh-tile-pattern')).toHaveClass(
+      'ofh-tile-pattern--color-brand',
+    );
+  });
+
   it('treats decorative images as decorative and allows root override', () => {
     const ref = createRef<HTMLElement>();
 

--- a/packages/react-components/src/components/Hero/Hero.tsx
+++ b/packages/react-components/src/components/Hero/Hero.tsx
@@ -4,7 +4,7 @@ import { getHeadingTag, joinClasses, type HeadingLevel } from '../../internal/of
 import { Button } from '../Button';
 import { TilePattern, type TilePatternColor, type TilePatternTile } from '../TilePattern';
 
-type HeroTheme = 'brand' | 'dark';
+type HeroTheme = 'brand' | 'dark' | 'light';
 type HeroVariant = 'free' | 'boxed';
 type HeroAs = 'section' | 'div';
 

--- a/packages/site/tests/fixtures/hero/light.njk
+++ b/packages/site/tests/fixtures/hero/light.njk
@@ -1,0 +1,7 @@
+{% from 'hero/macro.njk' import hero %}
+
+{{ hero({
+  "theme": "light",
+  "variant": "boxed",
+  "heading": "Take part in health research"
+}) }}

--- a/packages/site/views/design-system/components/hero/all-actions-boxed-light/index.njk
+++ b/packages/site/views/design-system/components/hero/all-actions-boxed-light/index.njk
@@ -1,0 +1,20 @@
+{% from 'hero/macro.njk' import hero %}
+
+{{ hero({
+  "theme": "light",
+  "variant": "boxed",
+  "heading": "Take part in health research that helps everyone",
+  "description": "Join Our Future Health to help researchers discover better ways to prevent, detect and treat disease.",
+  "secondaryAction": {
+    "text": "Find out what taking part involves",
+    "href": "/get-started"
+  },
+  "primaryAction": {
+    "text": "Start now",
+    "href": "/get-started"
+  },
+  "image": {
+    "src": "/assets/examples/hero/ofh-portrait-02.jpg",
+    "alt": "Portrait of a person"
+  }
+}) }}

--- a/packages/site/views/design-system/components/hero/all-actions-free-light/index.njk
+++ b/packages/site/views/design-system/components/hero/all-actions-free-light/index.njk
@@ -1,0 +1,19 @@
+{% from 'hero/macro.njk' import hero %}
+
+{{ hero({
+  "theme": "light",
+  "heading": "Take part in health research that helps everyone",
+  "description": "Join Our Future Health to help researchers discover better ways to prevent, detect and treat disease.",
+  "secondaryAction": {
+    "text": "Find out what taking part involves",
+    "href": "/get-started"
+  },
+  "primaryAction": {
+    "text": "Start now",
+    "href": "/get-started"
+  },
+  "image": {
+    "src": "/assets/examples/hero/ofh-portrait-01.jpg",
+    "alt": "Portrait of a person"
+  }
+}) }}

--- a/packages/site/views/design-system/components/hero/index.njk
+++ b/packages/site/views/design-system/components/hero/index.njk
@@ -22,7 +22,7 @@
   <p>Do not use Hero more than once on the same page.</p>
 
   <h2>How to use Hero</h2>
-  <p>Use the <code>brand</code> theme by default and switch to <code>dark</code> when the page needs the darker colour mode. Use the <code>free</code> variant for an open split layout or <code>boxed</code> when the content needs white containment.</p>
+  <p>Use the <code>brand</code> theme by default, <code>dark</code> when the page needs the darker colour mode, or <code>light</code> to pair with the Light Header. Use the <code>free</code> variant for an open split layout or <code>boxed</code> when the content needs white containment.</p>
   <p>Hero supports at most 1 primary button and 1 secondary text link. The button is the primary call to action. The text link is the lower-emphasis secondary action.</p>
   <p>If you use media, provide meaningful alt text when the image carries information. If the image is decorative, set it as decorative so assistive technology ignores it.</p>
   <p>Hero defaults to a <code>section</code> root. Use the root override only when the page structure already provides the surrounding landmark or section semantics.</p>
@@ -43,6 +43,13 @@
     type: "all-actions-free-dark"
   }) }}
 
+  <h3>All actions - Free - Light</h3>
+  {{ designExample({
+    group: "components",
+    item: "hero",
+    type: "all-actions-free-light"
+  }) }}
+
   <h3>All actions - Boxed - Brand</h3>
   {{ designExample({
     group: "components",
@@ -55,6 +62,13 @@
     group: "components",
     item: "hero",
     type: "all-actions-boxed-dark"
+  }) }}
+
+  <h3>All actions - Boxed - Light</h3>
+  {{ designExample({
+    group: "components",
+    item: "hero",
+    type: "all-actions-boxed-light"
   }) }}
 
   <h3>Single action Text Link - Free - Brand</h3>

--- a/packages/site/views/design-system/components/hero/macro-options.json
+++ b/packages/site/views/design-system/components/hero/macro-options.json
@@ -4,7 +4,7 @@
       "name": "theme",
       "type": "string",
       "required": false,
-      "description": "Hero colour theme. Use brand or dark. Defaults to brand."
+      "description": "Hero colour theme. Use brand, dark, or light. Defaults to brand."
     },
     {
       "name": "variant",

--- a/packages/toolkit/components/hero/README.md
+++ b/packages/toolkit/components/hero/README.md
@@ -10,8 +10,10 @@ Use Hero for the single primary introduction at the top of a page when users nee
 
 - [Hero all-actions free brand example](/design-example/components/hero/all-actions-free-brand/layout-default/)
 - [Hero all-actions free dark example](/design-example/components/hero/all-actions-free-dark/layout-default/)
+- [Hero all-actions free light example](/design-example/components/hero/all-actions-free-light/layout-default/)
 - [Hero all-actions boxed brand example](/design-example/components/hero/all-actions-boxed-brand/layout-default/)
 - [Hero all-actions boxed dark example](/design-example/components/hero/all-actions-boxed-dark/layout-default/)
+- [Hero all-actions boxed light example](/design-example/components/hero/all-actions-boxed-light/layout-default/)
 - [Hero single text-link free brand example](/design-example/components/hero/single-text-link-free-brand/layout-default/)
 - [Hero single button free brand example](/design-example/components/hero/single-button-free-brand/layout-default/)
 - [Hero no-actions free brand example](/design-example/components/hero/no-actions-free-brand/layout-default/)
@@ -84,7 +86,7 @@ Use Hero for the single primary introduction at the top of a page when users nee
 
 | Name | Type | Required | Description |
 | ---- | ---- | ---- | ---- |
-| `theme` | string | No | Hero colour theme. Use `brand` or `dark`. Defaults to `brand`. |
+| `theme` | string | No | Hero colour theme. Use `brand`, `dark`, or `light`. Defaults to `brand`. |
 | `variant` | string | No | Hero containment variant. Use `free` or `boxed`. Defaults to `free`. |
 | `heading` / `headingHtml` | string | Yes | Plain text or trusted HTML heading content. |
 | `headingLevel` | number | No | Semantic heading level from `1` to `6`. Defaults to `1`. |

--- a/packages/toolkit/components/hero/_hero.scss
+++ b/packages/toolkit/components/hero/_hero.scss
@@ -148,12 +148,6 @@
   }
 }
 
-@include mq($from: desktop) {
-  .ofh-hero {
-    --ofh-hero-boxed-overlap: #{$ofh-size-64};
-  }
-}
-
 .ofh-hero__content {
   @include ofh-responsive-gap-y(32);
 

--- a/packages/toolkit/components/hero/_hero.scss
+++ b/packages/toolkit/components/hero/_hero.scss
@@ -29,6 +29,14 @@
   --ofh-hero-link-visited: #{$ofh-color-foreground-link-visited};
 }
 
+.ofh-hero--light {
+  --ofh-hero-background: #{$ofh-color-background-secondary-yellow};
+  --ofh-hero-text: #{$ofh-color-foreground-primary};
+  --ofh-hero-link: #{$ofh-color-foreground-link-default};
+  --ofh-hero-link-hover: #{$ofh-color-foreground-link-hover};
+  --ofh-hero-link-visited: #{$ofh-color-foreground-link-visited};
+}
+
 .ofh-hero--dark {
   --ofh-hero-background: #{$ofh-color-background-brand-blue-navy-2};
   --ofh-hero-text: #{$ofh-color-foreground-primary-inverted};

--- a/packages/toolkit/components/hero/hero.test.js
+++ b/packages/toolkit/components/hero/hero.test.js
@@ -91,6 +91,18 @@ describe('Our Future Health hero macro', () => {
     expect(secondaryLink.getAttribute('data-track')).toBe('hero-secondary');
   });
 
+  it('renders the light theme with brand tile decoration', () => {
+    const { decorations, root, tilePatterns } = renderFixture(
+      'tests/fixtures/hero/light.njk',
+    );
+
+    expect(root.classList.contains('ofh-hero--light')).toBe(true);
+    expect(root.classList.contains('ofh-hero--boxed')).toBe(true);
+    expect(decorations).toHaveLength(3);
+    expect(tilePatterns).toHaveLength(3);
+    expect(tilePatterns[0].classList.contains('ofh-tile-pattern--color-brand')).toBe(true);
+  });
+
   it('falls back to safe defaults and supports text-only trusted HTML content', () => {
     const {
       contentColumn,

--- a/packages/toolkit/components/hero/template.njk
+++ b/packages/toolkit/components/hero/template.njk
@@ -29,7 +29,7 @@
   [{ "type": 13, "color": "transparent" }, 1, 5, 3, { "type": 18, "color": "transparent" }, 19]
 ] %}
 
-{% if theme != 'dark' %}
+{% if theme not in ['dark', 'light'] %}
   {% set theme = 'brand' %}
 {% endif %}
 

--- a/packages/toolkit/components/hero/template.njk
+++ b/packages/toolkit/components/hero/template.njk
@@ -29,7 +29,7 @@
   [{ "type": 13, "color": "transparent" }, 1, 5, 3, { "type": 18, "color": "transparent" }, 19]
 ] %}
 
-{% if theme not in ['dark', 'light'] %}
+{% if theme not in ['brand', 'dark', 'light'] %}
   {% set theme = 'brand' %}
 {% endif %}
 

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/toolkit",
-  "version": "4.23.0",
+  "version": "4.24.0",
   "description": "Our Future Health design system toolkit contains the code you need to start building user interfaces for Our Future Health websites and services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Adds `light` as a public Hero theme across the toolkit macro, React component, docs site, and Storybook.

Use Light Hero with the Light Header. It uses the secondary-yellow surface, dark text, standard link states, brand Tile Pattern decoration, and the white boxed panel. Free and boxed layouts, media, actions, and responsive tokens retain their existing behaviour. Boxed Hero media overlap is now 32px at tablet and above.

This includes:

- toolkit and React support for `theme: "light"`
- free and boxed Light Hero examples in the docs site and Storybook
- toolkit and React test coverage for Light theme rendering and decoration
- updated Hero API guidance and macro options
- minor release preparation for toolkit 4.24.0 and React 0.23.0

## Validation

- `pnpm test`
- `pnpm lint`
- toolkit build
- React Storybook build
- site build
- `pnpm docs:release-contract`
- `git diff --check`

## Notes for review

- Figma comparison completed. Light Hero spacing, typography, tokens, and decoration match the responsive component design.
- Boxed Hero media overlap is 32px at tablet and above, matching Figma.
- `CHANGELOG.md` and `UPGRADING.md` include the release notes and adoption guidance.

[DSE-343](https://ourfuturehealth.atlassian.net/browse/DSE-343)

[DSE-343]: https://ourfuturehealth.atlassian.net/browse/DSE-343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ