### PR TITLE
DSE-440: prevent Header navigation prop leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ### 2026-07-14
 
+#### @ourfuturehealth/react-components 0.23.1 (`react-v0.23.1`)
+
+##### Fixed
+
+- Stopped Header direct desktop navigation links from forwarding the Header-only `current`, `external`, and `label` props to their anchor elements
+
 #### @ourfuturehealth/toolkit 4.24.0 (`toolkit-v4.24.0`)
 
 ##### Added

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/react-components",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "type": "module",
   "description": "React component library for OFH Design System",
   "packageManager": "pnpm@10.29.2",

--- a/packages/react-components/src/components/Header/Header.test.tsx
+++ b/packages/react-components/src/components/Header/Header.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'vitest-axe';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { Header } from './Header';
 
 const baseNavigation = [
@@ -127,6 +127,44 @@ describe('Header', () => {
     expect(container.querySelector('.ofh-header')).toHaveClass(
       'ofh-header--with-bottom-border',
     );
+  });
+
+  it('does not forward Header-only props from direct desktop navigation links', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      render(
+        <Header
+          brand={{
+            ariaLabel: 'Our Future Health home',
+            href: '/',
+          }}
+          navigation={[
+            {
+              current: true,
+              external: true,
+              href: '/about',
+              label: 'About',
+              openInNewWindow: true,
+              rel: 'nofollow',
+            },
+          ]}
+        />,
+      );
+
+      const link = screen.getByRole('link', { name: 'About' });
+
+      expect(link).toHaveAttribute('aria-current', 'page');
+      expect(link).toHaveClass('ofh-header__nav-link--current');
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'nofollow noopener noreferrer');
+      expect(link).not.toHaveAttribute('current');
+      expect(link).not.toHaveAttribute('external');
+      expect(link).not.toHaveAttribute('label');
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it('does not render the bottom border when disabled', () => {

--- a/packages/react-components/src/components/Header/Header.tsx
+++ b/packages/react-components/src/components/Header/Header.tsx
@@ -509,7 +509,7 @@ export const Header = ({
             <ul className="ofh-header__nav-list">
               {navigation.map((item, index) => {
                 if (!isNavGroup(item)) {
-                  const resolvedProps = resolveAnchorProps(item, item.href);
+                  const resolvedProps = resolveHeaderLinkProps(item);
 
                   return (
                     <li className="ofh-header__nav-item" key={`header-nav-${index}`}>


### PR DESCRIPTION
## Description

Fixes the desktop direct-primary-navigation route in `Header`. It now uses the same sanitising helper as the other Header link routes, so `current`, `external`, and `label` are not spread onto the anchor.

`current: true` still applies the active class and `aria-current="page"`. Existing `href`, `rel`, `target`, and `openInNewWindow` behaviour is unchanged.

## Release

- Bumps `@ourfuturehealth/react-components` from `0.23.0` to `0.23.1`.
- Adds the fix to `CHANGELOG.md` for `react-v0.23.1`.
- No `UPGRADING.md` entry is needed because this changes neither the public API nor the install contract.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm docs:release-contract`
- `./scripts/release/smoke-current-release-artifacts.sh react-components --managers yarn,npm,pnpm`
- `git diff --check origin/main...HEAD`

## Notes for review

- No visual or token changes. The regression test covers the rendered anchor, active semantics, and React development warnings.

[DSE-440](https://ourfuturehealth.atlassian.net/browse/DSE-440)

[DSE-440]: https://ourfuturehealth.atlassian.net/browse/DSE-440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ