### PR TITLE
fix(form-group): restore Figma spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ## Monorepo Package Releases (`toolkit-v*`, `react-v*`)
 
+### 2026-07-15
+
+#### @ourfuturehealth/toolkit 4.24.1 (`toolkit-v4.24.1`)
+
+##### Fixed
+
+- Restored the generic form-group responsive bottom margin to `16px` on mobile and tablet, and `24px` on desktop, matching the Figma spacing token
+
 ### 2026-07-14
 
 #### @ourfuturehealth/react-components 0.23.1 (`react-v0.23.1`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ## Monorepo Package Releases (`toolkit-v*`, `react-v*`)
 
-### 2026-07-15
+### 2026-07-16
 
 #### @ourfuturehealth/toolkit 4.24.1 (`toolkit-v4.24.1`)
 
 ##### Fixed
 
-- Restored the generic form-group responsive bottom margin to `16px` on mobile and tablet, and `24px` on desktop, matching the Figma spacing token
+- Restored generic form-group responsive bottom margins to the Figma spacing tokens: `16px` on mobile and tablet, and `24px` on desktop; form-group wrappers remain one token higher at `24px` on mobile and tablet, and `32px` on desktop
 
 ### 2026-07-14
 

--- a/packages/toolkit/core/objects/_form-group.scss
+++ b/packages/toolkit/core/objects/_form-group.scss
@@ -7,7 +7,7 @@
 }
 
 .ofh-form-group--wrapper {
-  @include ofh-responsive-margin(24, 'bottom');
+  @include ofh-responsive-margin(32, 'bottom');
 }
 
 .ofh-form-group--error {

--- a/packages/toolkit/core/objects/_form-group.scss
+++ b/packages/toolkit/core/objects/_form-group.scss
@@ -1,5 +1,5 @@
 .ofh-form-group {
-  @include ofh-responsive-margin(16, 'bottom');
+  @include ofh-responsive-margin(24, 'bottom');
 
   .ofh-form-group:last-of-type {
     margin-bottom: 0; // Remove margin from last item in nested groups

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/toolkit",
-  "version": "4.24.0",
+  "version": "4.24.1",
   "description": "Our Future Health design system toolkit contains the code you need to start building user interfaces for Our Future Health websites and services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Restores the responsive bottom margins for generic form groups and form-group wrappers to the Figma spacing tokens.

Standalone form groups use 16px on mobile and tablet, and 24px on desktop. Form-group wrappers remain one token higher at 24px on mobile and tablet, and 32px on desktop.

Form groups used directly inside a fieldset are unchanged. They already use the base responsive values and retain their final-child margin reset.

## Release scope

- @ourfuturehealth/toolkit patch release: 4.24.1 (toolkit-v4.24.1)
- No @ourfuturehealth/react-components release
- No migration guidance required because the public API and install contract are unchanged
- Refresh the changelog date during final pre-merge review if this does not merge on 16 July 2026

## Reviewer focus

Please compare standalone text inputs, selects, and autocomplete fields with the Fieldset reference in Figma. Check the gap before the next content block, particularly before actions and page-level content. Also check any legacy form-group wrapper usage to confirm it retains a clear step above a regular form group.

https://www.figma.com/design/nxk6i2mSprkAZmUNhjnkYY/OFH-design-system?node-id=14016-12983

## Validation

- pnpm --filter=@ourfuturehealth/toolkit run lint
- pnpm --filter=@ourfuturehealth/toolkit run test
- pnpm --filter=@ourfuturehealth/toolkit run build
- pnpm docs:release-contract
- pnpm smoke:release-artifacts, passed for the 4.24.1 toolkit tarball with Yarn, npm, and pnpm