### PR TITLE
DSE-442: fix(header): preserve visited mobile link colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ### 2026-07-16
 
+#### @ourfuturehealth/react-components 0.23.2 (`react-v0.23.2`)
+
+##### Fixed
+
+- Kept selected mobile Header navigation links dark when they have been visited, including focused visited links and selected sub-navigation links
+
+#### @ourfuturehealth/toolkit 4.24.2 (`toolkit-v4.24.2`)
+
+##### Fixed
+
+- Kept selected mobile Header navigation links dark when they have been visited, including focused visited links and selected sub-navigation links
+
 #### @ourfuturehealth/toolkit 4.24.1 (`toolkit-v4.24.1`)
 
 ##### Fixed

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/react-components",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "type": "module",
   "description": "React component library for OFH Design System",
   "packageManager": "pnpm@10.29.2",

--- a/packages/toolkit/components/header/_header.scss
+++ b/packages/toolkit/components/header/_header.scss
@@ -559,6 +559,13 @@
 }
 
 .ofh-header__mobile-link--current {
+  @include ofh-header-link-no-visited-state(
+    $ofh-color-foreground-primary,
+    $ofh-color-foreground-primary,
+    null,
+    $ofh-color-foreground-primary
+  );
+
   background-color: $ofh-color-background-primary;
   border-left: $ofh-stroke-weight-4 solid var(--ofh-header-list-item-selected-border);
   color: $ofh-color-foreground-primary;
@@ -630,6 +637,13 @@
 }
 
 .ofh-header__mobile-subnav-link--current {
+  @include ofh-header-link-no-visited-state(
+    $ofh-color-foreground-primary,
+    $ofh-color-foreground-primary,
+    null,
+    $ofh-color-foreground-primary
+  );
+
   background-color: $ofh-color-background-primary;
   border-left: $ofh-stroke-weight-4 solid var(--ofh-header-list-item-selected-border);
   color: $ofh-color-foreground-primary;

--- a/packages/toolkit/components/header/header.styles.test.js
+++ b/packages/toolkit/components/header/header.styles.test.js
@@ -6,11 +6,10 @@ const sass = require('sass');
 const compileToolkitCss = () => {
   const entrypoint = path.resolve(__dirname, '../../ofh.scss');
 
-  return sass.renderSync({
-    file: entrypoint,
+  return sass.compile(entrypoint, {
     quietDeps: true,
-    silenceDeprecations: ['if-function', 'import', 'legacy-js-api'],
-  }).css.toString();
+    silenceDeprecations: ['if-function', 'import'],
+  }).css;
 };
 
 describe('Header compiled CSS', () => {

--- a/packages/toolkit/components/header/header.styles.test.js
+++ b/packages/toolkit/components/header/header.styles.test.js
@@ -1,0 +1,50 @@
+/** @jest-environment node */
+
+const path = require('path');
+const sass = require('sass');
+
+const compileToolkitCss = () => {
+  const entrypoint = path.resolve(__dirname, '../../ofh.scss');
+
+  return sass.renderSync({
+    file: entrypoint,
+    quietDeps: true,
+    silenceDeprecations: ['if-function', 'import', 'legacy-js-api'],
+  }).css.toString();
+};
+
+describe('Header compiled CSS', () => {
+  let css;
+
+  beforeAll(() => {
+    css = compileToolkitCss();
+  });
+
+  it.each([
+    ['ofh-header__mobile-link', 'ofh-header__mobile-link--current'],
+    ['ofh-header__mobile-subnav-link', 'ofh-header__mobile-subnav-link--current'],
+  ])('keeps .%s dark when it is visited or focused after visiting', (
+    linkClass,
+    currentLinkClass,
+  ) => {
+    const baseVisitedRule = `.${linkClass}:visited`;
+    const currentVisitedRule = `.${currentLinkClass}:visited`;
+    const currentFocusVisitedRule = `.${currentLinkClass}:focus:visited`;
+    const baseVisitedIndex = css.indexOf(baseVisitedRule);
+    const currentVisitedIndex = css.indexOf(currentVisitedRule);
+    const currentFocusVisitedIndex = css.indexOf(currentFocusVisitedRule);
+
+    expect(baseVisitedIndex).toBeGreaterThanOrEqual(0);
+    expect(css.slice(baseVisitedIndex, css.indexOf('}', baseVisitedIndex))).toContain(
+      'color: var(--ofh-header-list-item-color);',
+    );
+    expect(currentVisitedIndex).toBeGreaterThan(baseVisitedIndex);
+    expect(
+      css.slice(currentVisitedIndex, css.indexOf('}', currentVisitedIndex)),
+    ).toContain('color: #1b1b1b;');
+    expect(currentFocusVisitedIndex).toBeGreaterThan(currentVisitedIndex);
+    expect(
+      css.slice(currentFocusVisitedIndex, css.indexOf('}', currentFocusVisitedIndex)),
+    ).toContain('color: #1b1b1b;');
+  });
+});

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/toolkit",
-  "version": "4.24.1",
+  "version": "4.24.2",
   "description": "Our Future Health design system toolkit contains the code you need to start building user interfaces for Our Future Health websites and services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Fixes the dark Header theme where a selected mobile link could become white on its white background after it had been visited.

## Changes

- Keep selected mobile direct and sub-navigation links on the primary foreground colour in visited and focus-visited states.
- Add compiled CSS regression coverage for the cascade and source order.
- Prepare patch releases for @ourfuturehealth/toolkit 4.24.2 and @ourfuturehealth/react-components 0.23.2.

## Validation

- pnpm lint
- pnpm test
- pnpm --filter=@ourfuturehealth/toolkit run build
- pnpm --filter=@ourfuturehealth/react-components run build:storybook
- Manual mobile verification in Participant Hub with the packed React package.

Jira: https://ourfuturehealth.atlassian.net/browse/DSE-442