### PR TITLE
PC-000: support Next client imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ## Monorepo Package Releases (`toolkit-v*`, `react-v*`)
 
+### 2026-08-19
+
+#### @ourfuturehealth/react-components 0.24.1 (`react-v0.24.1`)
+
+##### Fixed
+
+- Made the React package safe to import directly in Next.js App Router by preserving its Client Component boundary and keeping React's JSX runtime external in the published ESM bundle
+- Corrected the CommonJS output extension so Node recognises the package's `require` entrypoint under its ESM package configuration
+
 ### 2026-08-17
 
 #### @ourfuturehealth/toolkit 4.25.0 (`toolkit-v4.25.0`)

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -4,14 +4,14 @@
   "type": "module",
   "description": "React component library for OFH Design System",
   "packageManager": "pnpm@10.29.2",
-  "main": "dist/index.cjs.js",
+  "main": "dist/index.cjs",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.esm.js",
-      "require": "./dist/index.cjs.js"
+      "require": "./dist/index.cjs"
     },
     "./styles": "./dist/ofh-design-system-react.css",
     "./styles/participant": "./dist/ofh-design-system-react.css",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/react-components",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "type": "module",
   "description": "React component library for OFH Design System",
   "packageManager": "pnpm@10.29.2",

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -1,3 +1,5 @@
+"use client";
+
 // Main library entry point
 // Components will be exported from here
 

--- a/packages/react-components/vite.config.ts
+++ b/packages/react-components/vite.config.ts
@@ -26,11 +26,12 @@ export default defineConfig(() => {
         entry: resolve(__dirname, 'src/index.ts'),
         name: 'OFHDesignSystemReact',
         formats: ['es', 'cjs'],
-        fileName: (format) => `index.${format === 'es' ? 'esm' : 'cjs'}.js`,
+        fileName: (format) => `index.${format === 'es' ? 'esm.js' : 'cjs'}`,
       },
       rollupOptions: {
-        external: ['react', 'react-dom'],
+        external: [/^react(?:\/|$)/, /^react-dom(?:\/|$)/],
         output: {
+          banner: '"use client";\n',
           globals: {
             react: 'React',
             'react-dom': 'ReactDOM',

--- a/scripts/release/smoke-package-tarball.sh
+++ b/scripts/release/smoke-package-tarball.sh
@@ -265,6 +265,8 @@ NODE
       ;;
   esac
 
+  react_artifact_check "${install_dir}"
+
   (
     cd "${install_dir}"
     node - <<'NODE'
@@ -296,6 +298,30 @@ NODE
   )
 }
 
+react_artifact_check() {
+  local install_dir=$1
+
+  (
+    cd "${install_dir}"
+    node - <<'NODE'
+const fs = require('fs');
+const path = require('path');
+
+const packageEntry = require.resolve('@ourfuturehealth/react-components');
+const esmEntry = path.join(path.dirname(packageEntry), 'index.esm.js');
+const source = fs.readFileSync(esmEntry, 'utf8');
+
+if (!/^['"]use client['"];/u.test(source)) {
+  throw new Error('Expected the ESM entrypoint to preserve the use client directive');
+}
+
+if (!/from ['"]react\/jsx-(?:dev-)?runtime['"]/.test(source)) {
+  throw new Error('Expected the ESM entrypoint to reference an external React JSX runtime');
+}
+NODE
+  )
+}
+
 IFS=',' read -r -a manager_list <<< "${managers}"
 
 for manager in "${manager_list[@]}"; do
@@ -310,7 +336,7 @@ for manager in "${manager_list[@]}"; do
     @ourfuturehealth/react-components)
       print_step "Installing react-components tarball and peer dependencies with ${manager}"
       smoke_react "${manager}"
-      print_success "React tarball passed export and component rendering checks with ${manager}"
+      print_success "React tarball passed artifact, export, and component rendering checks with ${manager}"
       ;;
   esac
 done


### PR DESCRIPTION
## Description

Marks the React package entrypoint as a client boundary and preserves that directive in the published ESM bundle. React subpath imports, including `react/jsx-runtime`, remain external so Next.js uses the consuming app's React runtime.

This fixes the Next.js App Router local-development crash when an app imports `@ourfuturehealth/react-components` directly. It also corrects the CommonJS output filename to use the `.cjs` extension under the package's ESM configuration.

## Release scope

- Bumps `@ourfuturehealth/react-components` from `0.24.0` to `0.24.1` and adds the changelog entry.
- No `@ourfuturehealth/toolkit` release.
- No migration guidance is needed. Consumer imports are unchanged.

## Validation

- `pnpm lint`
- `pnpm --filter=@ourfuturehealth/react-components run test` (270 tests)
- `pnpm --filter=@ourfuturehealth/react-components run build`
- `pnpm --filter=@ourfuturehealth/react-components run build:storybook`
- `pnpm docs:release-contract`
- `NPM_CONFIG_REGISTRY=https://registry.npmjs.org pnpm smoke:release-artifacts react-components`
- Fresh Next.js `16.2.11` and React `19.2.4` local-development test with the packed `0.24.1` tarball. A direct root import served successfully without a wrapper.