### PR TITLE
DS-394: update breakpoint values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ## Monorepo Package Releases (`toolkit-v*`, `react-v*`)
 
+### 2026-08-26
+
+#### @ourfuturehealth/toolkit 4.26.0 (`toolkit-v4.26.0`)
+
+##### Changed
+
+- Aligned named Sass desktop breakpoints with the approved design tokens: `desktop` now starts at `990px` and `large-desktop` at `1440px`
+
+#### @ourfuturehealth/react-components 0.25.0 (`react-v0.25.0`)
+
+##### Changed
+
+- Recompiled the participant and research theme styles with the updated toolkit desktop breakpoints
+
 ### 2026-08-19
 
 #### @ourfuturehealth/react-components 0.24.1 (`react-v0.24.1`)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -35,6 +35,29 @@ This guide provides detailed migration instructions for upgrading between versio
 
 ---
 
+## Upgrading to v4.26.0 / React v0.25.0
+
+**Affected packages:**
+
+- `@ourfuturehealth/toolkit` v4.26.0+
+- `@ourfuturehealth/react-components` v0.25.0+
+
+### Breaking Changes
+
+None. Public Sass names, mixins, CSS classes, token values, and React APIs are unchanged.
+
+### Release Overview
+
+This high-impact responsive behaviour change realigns named breakpoints to the approved design system: `desktop` now starts at `990px`, and `large-desktop` starts at `1440px`. React participant and research theme CSS includes the same toolkit Sass change.
+
+### Migration Steps
+
+1. Audit local Sass that uses the named `desktop` or `large-desktop` queries; those rules now activate later.
+2. Check responsive layouts at `640/641px`, `768/769px`, `989/990px`, and `1439/1440px`, including any local breakpoint overrides.
+3. Re-test pages that rely on responsive spacing, typography, iconography, headers, images, tables, or footers.
+
+---
+
 ## Upgrading to v4.24.0 / React v0.23.0
 
 **Released:** July 2026

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/react-components",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "type": "module",
   "description": "React component library for OFH Design System",
   "packageManager": "pnpm@10.29.2",

--- a/packages/toolkit/core/README.md
+++ b/packages/toolkit/core/README.md
@@ -238,8 +238,8 @@ Source Sans Pro from Google Fonts – <https://fonts.google.com/specimen/Source+
 ```
 mobile: 320px
 tablet: 641px
-desktop: 769px
-large-desktop: 990px
+desktop: 990px
+large-desktop: 1440px
 ```
 
 ### Media queries (using [sass-mq](https://github.com/sass-mq/sass-mq))

--- a/packages/toolkit/core/settings/_breakpoints.scss
+++ b/packages/toolkit/core/settings/_breakpoints.scss
@@ -24,7 +24,7 @@ $mq-responsive: true; // [1] //
 $mq-breakpoints: (
   mobile: 320px,
   tablet: 641px,
-  desktop: 769px,
-  large-desktop: 990px,
+  desktop: 990px,
+  large-desktop: 1440px,
 ) !default;
 $mq-static-breakpoint: desktop; // [2] //

--- a/packages/toolkit/core/settings/breakpoints.styles.test.js
+++ b/packages/toolkit/core/settings/breakpoints.styles.test.js
@@ -1,0 +1,52 @@
+/** @jest-environment node */
+
+const path = require('path');
+const sass = require('sass');
+
+const compileBreakpointCss = () =>
+  sass.compileString(
+    `
+      @import 'core/settings/breakpoints';
+      @import 'core/vendor/sass-mq';
+
+      .from-desktop {
+        @include mq($from: desktop) {
+          color: red;
+        }
+      }
+
+      .until-desktop {
+        @include mq($until: desktop) {
+          color: red;
+        }
+      }
+
+      .from-large-desktop {
+        @include mq($from: large-desktop) {
+          color: red;
+        }
+      }
+
+      .until-large-desktop {
+        @include mq($until: large-desktop) {
+          color: red;
+        }
+      }
+    `,
+    {
+      loadPaths: [path.resolve(__dirname, '../../')],
+      quietDeps: true,
+      silenceDeprecations: ['if-function', 'import'],
+    },
+  ).css;
+
+describe('breakpoint Sass output', () => {
+  it('compiles named desktop boundaries from the shared mq() mixin', () => {
+    const css = compileBreakpointCss();
+
+    expect(css).toContain('@media (min-width: 61.875em)');
+    expect(css).toContain('@media (max-width: 61.865em)');
+    expect(css).toContain('@media (min-width: 90em)');
+    expect(css).toContain('@media (max-width: 89.99em)');
+  });
+});

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/toolkit",
-  "version": "4.25.0",
+  "version": "4.26.0",
   "description": "Our Future Health design system toolkit contains the code you need to start building user interfaces for Our Future Health websites and services.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Updates the shared Sass breakpoint map to match the approved Figma `ofh/width/page` values:

- `desktop`: `769px` to `990px`
- `large-desktop`: `990px` to `1440px`

Breakpoint names and APIs stay the same. Toolkit, site docs, and both React theme bundles now compile named desktop rules at the new boundaries. The PR also adds a Sass regression test and updates public breakpoint and release guidance.

Jira: https://ourfuturehealth.atlassian.net/browse/DS-394

## Release scope

- Bumps `@ourfuturehealth/toolkit` from `4.25.0` to `4.26.0`.
- Bumps `@ourfuturehealth/react-components` from `0.24.1` to `0.25.0`, because it packages toolkit Sass in both theme styles.
- Adds changelog and upgrade guidance for responsive QA.
- No new dependency, iframe docs change, or public API rename.

## Validation

- `pnpm build`
- `pnpm lint`
- `pnpm test` (88 toolkit tests and 270 React tests)
- `pnpm docs:release-contract`
- `NPM_CONFIG_REGISTRY=https://registry.npmjs.org pnpm smoke:release-artifacts` for toolkit and React under Yarn, npm, and pnpm
- CSS artifact checks: toolkit and React emit `61.875em` for desktop; site emits `61.875em` and `90em`
- Browser QA at `640/641`, `768/769`, `989/990`, and `1439/1440` for docs, standalone examples, and representative React stories