### PR TITLE
PC-1418: Patch fast-uri vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
       "handlebars": "4.7.9",
       "lodash": "4.18.1",
       "lodash-es": "4.18.1",
-      "fast-uri": "3.1.5",
+      "fast-uri": "3.1.6",
       "js-cookie": "3.0.7",
       "esbuild@0.27.3": "0.28.1",
       "form-data": "^4.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ overrides:
   handlebars: 4.7.9
   lodash: 4.18.1
   lodash-es: 4.18.1
-  fast-uri: 3.1.5
+  fast-uri: 3.1.6
   js-cookie: 3.0.7
   esbuild@0.27.3: 0.28.1
   form-data: ^4.0.6
@@ -3239,8 +3239,8 @@ packages:
   fast-levenshtein@3.0.0:
     resolution: {integrity: sha512-hKKNajm46uNmTlhHSyZkmToAc56uZJwYq7yrciZjqOxnlfQwERDQJmHPUp7m1m9wx8vgOe8IaCKZ5Kv2k1DdCQ==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -8153,7 +8153,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -9117,7 +9117,7 @@ snapshots:
     dependencies:
       fastest-levenshtein: 1.0.16
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fastest-levenshtein@1.0.16: {}
 


### PR DESCRIPTION
## Description
Lockfile-only update does not seem to resolve this so bumping the override.

[GHSA-f65p-4m7j-42xc](https://github.com/fastify/fast-uri/security/advisories/GHSA-f65p-4m7j-42xc)

https://ourfuturehealth.atlassian.net/browse/PC-1418
https://ourfuturehealth.atlassian.net/browse/PC-1419
https://ourfuturehealth.atlassian.net/browse/PC-1420
https://ourfuturehealth.atlassian.net/browse/PC-1421