### PR TITLE
chore(release): prepare Header fixes for release

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         env:
@@ -26,6 +28,12 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+
+      - name: Validate package release metadata
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: ./scripts/release/validate-package-release-metadata.sh "$BASE_SHA" "$HEAD_SHA"
 
       - name: Run linting
         run: pnpm run lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 
 ## Monorepo Package Releases (`toolkit-v*`, `react-v*`)
 
+### 2026-09-07
+
+#### @ourfuturehealth/toolkit 4.25.1 (`toolkit-v4.25.1`)
+
+##### Fixed
+
+- Marked the current account page in the mobile Header menu and placed account links after the primary navigation
+- Updated the Welsh NHS partner logo assets used at mobile sizes
+
+#### @ourfuturehealth/react-components 0.24.2 (`react-v0.24.2`)
+
+##### Fixed
+
+- Marked the current account page in the mobile Header menu and placed account links after the primary navigation
+
 ### 2026-08-19
 
 #### @ourfuturehealth/react-components 0.24.1 (`react-v0.24.1`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We are following [Semantic Versioning](https://semver.org/spec/v2.0.0.html), as 
 ##### Fixed
 
 - Marked the current account page in the mobile Header menu and placed account links after the primary navigation
+- Updated the Welsh NHS partner logo assets used at mobile sizes
 
 ### 2026-08-19
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -18,6 +18,10 @@ The design system distributes packages through **GitHub Releases**.
 - all linting passes locally: `pnpm lint`
 - changelog and migration docs are updated when required
 
+Pull requests that change published toolkit or React package source/assets must
+also bump the affected package version and add its changelog entry. The pull
+request workflow validates this before merge.
+
 ## Release Steps
 
 ### 1. Decide what to release

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/react-components",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "type": "module",
   "description": "React component library for OFH Design System",
   "packageManager": "pnpm@10.29.2",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ourfuturehealth/toolkit",
-  "version": "4.25.0",
+  "version": "4.25.1",
   "description": "Our Future Health design system toolkit contains the code you need to start building user interfaces for Our Future Health websites and services.",
   "repository": {
     "type": "git",

--- a/scripts/release/validate-package-release-metadata.sh
+++ b/scripts/release/validate-package-release-metadata.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF' >&2
+Usage: validate-package-release-metadata.sh <base-ref> <head-ref>
+EOF
+}
+
+if [[ $# -ne 2 ]]; then
+  usage
+  exit 1
+fi
+
+base_ref=$1
+head_ref=$2
+
+git rev-parse --verify "${base_ref}^{commit}" >/dev/null
+git rev-parse --verify "${head_ref}^{commit}" >/dev/null
+
+toolkit_changed=false
+react_changed=false
+
+is_non_release_file() {
+  local path=$1
+
+  case "$path" in
+    *.test.js|*.spec.js|*.test.ts|*.test.tsx|*.spec.ts|*.spec.tsx|*.stories.tsx|*/README.md)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+while IFS= read -r path; do
+  [[ -n "$path" ]] || continue
+  is_non_release_file "$path" && continue
+
+  case "$path" in
+    packages/toolkit/components/*|packages/toolkit/core/*|packages/toolkit/common/*|packages/toolkit/common.js|packages/toolkit/assets/*|packages/toolkit/ofh*.js|packages/toolkit/ofh*.scss|packages/toolkit/polyfills.js|packages/toolkit/gulpfile.js)
+      toolkit_changed=true
+      ;;
+    packages/react-components/src/*|packages/react-components/scripts/*|packages/react-components/vite.config.*|packages/react-components/tsconfig*.json)
+      react_changed=true
+      ;;
+  esac
+done < <(git diff --name-only --diff-filter=ACMR "$base_ref" "$head_ref")
+
+version_for() {
+  local ref=$1
+  local manifest=$2
+
+  git show "${ref}:${manifest}" | node -e \
+    "let input=''; process.stdin.on('data', chunk => input += chunk); process.stdin.on('end', () => process.stdout.write(JSON.parse(input).version));"
+}
+
+validate_package() {
+  local package_label=$1
+  local manifest=$2
+  local tag_prefix=$3
+
+  local base_version
+  local head_version
+  local changelog_heading
+
+  base_version=$(version_for "$base_ref" "$manifest")
+  head_version=$(version_for "$head_ref" "$manifest")
+
+  if [[ "$base_version" == "$head_version" ]]; then
+    echo "${package_label}: source changed, but version remains ${head_version}." >&2
+    return 1
+  fi
+
+  changelog_heading="#### ${package_label} ${head_version} (\`${tag_prefix}${head_version}\`)"
+  if ! git show "${head_ref}:CHANGELOG.md" | grep -F "${changelog_heading}" >/dev/null; then
+    echo "${package_label}: missing changelog heading for ${head_version}." >&2
+    return 1
+  fi
+
+  printf '%s: %s -> %s with matching changelog entry\n' "${package_label}" "${base_version}" "${head_version}"
+}
+
+validation_failed=false
+
+if [[ "$toolkit_changed" == true ]]; then
+  validate_package '@ourfuturehealth/toolkit' 'packages/toolkit/package.json' 'toolkit-v' || validation_failed=true
+fi
+
+if [[ "$react_changed" == true ]]; then
+  validate_package '@ourfuturehealth/react-components' 'packages/react-components/package.json' 'react-v' || validation_failed=true
+fi
+
+if [[ "$validation_failed" == true ]]; then
+  exit 1
+fi
+
+if [[ "$toolkit_changed" == true || "$react_changed" == true ]]; then
+  echo 'Package release metadata validation passed.'
+else
+  echo 'No published package source or asset changes require release metadata.'
+fi

--- a/scripts/release/validate-package-release-metadata.sh
+++ b/scripts/release/validate-package-release-metadata.sh
@@ -46,7 +46,7 @@ while IFS= read -r path; do
       react_changed=true
       ;;
   esac
-done < <(git diff --name-only --diff-filter=ACMR "$base_ref" "$head_ref")
+done < <(git diff --name-only --diff-filter=ACMRD "$base_ref" "$head_ref")
 
 version_for() {
   local ref=$1


### PR DESCRIPTION
## Description

Adds the missing release metadata and validation for the Header fixes merged in #268.

- Bumps `@ourfuturehealth/toolkit` from `4.25.0` to `4.25.1`.
- Bumps `@ourfuturehealth/react-components` from `0.24.1` to `0.24.2`.
- Adds changelog entries for the current account-page state, mobile navigation order, and Welsh NHS partner-logo updates in both packages.
- Adds pull-request validation for published package changes that do not include a version and changelog update.
- Documents the release artifact expectations.

## Release scope

- `@ourfuturehealth/toolkit@4.25.1`: `toolkit-v4.25.1`, tarball, and ZIP artifacts.
- `@ourfuturehealth/react-components@0.24.2`: `react-v0.24.2` and tarball artifact.
- Release artifacts are generated by the release workflow and are not committed to this PR.
- Jira: [PC-000](https://ourfuturehealth.atlassian.net/browse/PC-000)

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm --filter=@ourfuturehealth/react-components run build:storybook`
- `pnpm docs:release-contract`
- `NPM_CONFIG_REGISTRY=https://registry.npmjs.org pnpm smoke:release-artifacts`
- `./scripts/release/validate-package-release-metadata.sh origin/main^ HEAD`
- `git diff --check`