### PR TITLE
Migrate Snyk scans to OAuth

### DIFF
--- a/.github/scripts/snyk-scans.sh
+++ b/.github/scripts/snyk-scans.sh
@@ -5,7 +5,6 @@ TOKEN="$1"
 PROJECT_NAME="$2"
 BRANCH="$3"
 VERBOSITY="$4"
-SNYK_TOKEN="$5"
 
 HOST="https://ourfuturehealth.kondukto.io"
 
@@ -27,18 +26,6 @@ run_snyk_scans() {
   local tool="$1"
   local branch_name="$BRANCH"
   local output_file="${tool}_results.json"
-
-  if [[ -z "${SNYK_TOKEN:-}" ]]; then
-    log_error "⚠️ Scan $tool skipped: No SNYK_TOKEN provided! Please set 'SNYK_TOKEN' in the GitHub Action inputs."
-  fi
-
-  export SNYK_TOKEN="$SNYK_TOKEN"
-  export SNYK_API="https://app.eu.snyk.io/api"
-
-  # Authenticate with Snyk
-  if ! $GITHUB_WORKSPACE/snyk auth "$SNYK_TOKEN"; then
-    log_error "⚠️ Scan ($tool) skipped: Snyk authentication failed! Ensure the SNYK_TOKEN is valid."
-  fi
 
   debug "Running $tool scan on branch: $branch_name"
 

--- a/.github/workflows/kondukto.yml
+++ b/.github/workflows/kondukto.yml
@@ -22,6 +22,16 @@ jobs:
         curl -L -o $GITHUB_WORKSPACE/snyk https://github.com/snyk/cli/releases/latest/download/snyk-linux
         chmod +x $GITHUB_WORKSPACE/snyk
 
+    - name: Configure and authenticate Snyk (OAuth)
+      env:
+        SNYK_CLIENT_ID: ${{ secrets.SNYK_CLIENT_ID }}
+        SNYK_CLIENT_SECRET: ${{ secrets.SNYK_CLIENT_SECRET }}
+      run: |
+        "$GITHUB_WORKSPACE/snyk" config environment SNYK-EU-01
+        "$GITHUB_WORKSPACE/snyk" auth --auth-type=oauth \
+          --client-id="$SNYK_CLIENT_ID" \
+          --client-secret="$SNYK_CLIENT_SECRET"
+
     - name: Install KDT CLI
       run: |
         curl -sSL https://cli.kondukto.io | sh
@@ -37,8 +47,7 @@ jobs:
           "$TOKEN" \
           "$PROJECT_NAME" \
           "main" \
-          "$VERBOSITY" \
-          "${{ secrets.SNYK_TOKEN }}"
+          "$VERBOSITY"
 
     - name: List available scanners
       run: kdt list scanners --host ${{ secrets.KONDUKTO_HOST }} --token ${{ secrets.KONDUKTO_TOKEN }}


### PR DESCRIPTION
## Description

Migrates Kondukto Snyk authentication from the long-lived API token to the OAuth credentials supplied by Security. The workflow configures the CLI for the EU tenant before scans and removes the token argument from the scan helper.

## Release scope

CI only. The workflow now requires `SNYK_CLIENT_ID` and `SNYK_CLIENT_SECRET` repository secrets. `SNYK_TOKEN` is no longer used.

## Validation

- Workflow and shell checks pass for the changed OAuth flow.
- Existing actionlint findings for `actions/checkout@v3` and unrelated shell quoting remain outside this change.
- `pnpm lint` could not run because this checkout has no installed dependencies.
- Manually dispatch the workflow after adding the OAuth secrets; confirm SCA, SAST, and the following Kondukto scanners complete.